### PR TITLE
ci: automate TestFlight beta releases

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,211 @@
+name: TestFlight Beta
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      marketing_version:
+        description: "Optional MARKETING_VERSION override, for example 1.1"
+        required: false
+        type: string
+      build_number:
+        description: "Optional CURRENT_PROJECT_VERSION override. Leave blank for an auto-generated build number."
+        required: false
+        type: string
+      summary:
+        description: "Short release summary for the generated changelog."
+        required: false
+        type: string
+      what_to_test:
+        description: "Extra TestFlight What to Test notes."
+        required: false
+        type: string
+
+concurrency:
+  group: testflight-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  testflight:
+    name: Build, Upload, And Annotate TestFlight
+    runs-on: macos-latest
+    timeout-minutes: 90
+
+    env:
+      ASC_BUNDLE_ID: com.offscript.app
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_KEY_TYPE: team
+      ASC_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+      TEST_DESTINATION: platform=iOS Simulator,OS=latest,name=iPhone 17 Pro
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Select active Xcode
+        run: |
+          set -euo pipefail
+          echo "DEVELOPER_DIR=$(xcode-select -p)" >> "$GITHUB_ENV"
+          xcodebuild -version
+
+      - name: Install App Store Connect script dependencies
+        run: python3 -m pip install --user PyJWT requests
+
+      - name: Validate required TestFlight secrets
+        run: |
+          set -euo pipefail
+          test -n "${ASC_KEY_ID}" || { echo "Missing secret ASC_KEY_ID"; exit 1; }
+          test -n "${ASC_ISSUER_ID}" || { echo "Missing secret ASC_ISSUER_ID. CI xcodebuild upload requires a team API key issuer ID."; exit 1; }
+          test -n "${ASC_KEY_P8_BASE64:-}" || { echo "Missing secret ASC_KEY_P8_BASE64"; exit 1; }
+        env:
+          ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
+
+      - name: Materialize App Store Connect API key
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s' "$ASC_KEY_P8_BASE64" | base64 --decode > "$ASC_KEY_PATH"
+          test -s "$ASC_KEY_PATH"
+        env:
+          ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
+
+      - name: Compute release metadata
+        id: metadata
+        run: |
+          set -euo pipefail
+          INPUT_VERSION="${{ github.event.inputs.marketing_version || '' }}"
+          INPUT_BUILD="${{ github.event.inputs.build_number || '' }}"
+
+          if [[ -n "$INPUT_VERSION" ]]; then
+            MARKETING_VERSION="$INPUT_VERSION"
+          else
+            MARKETING_VERSION="$(xcodebuild -project OffScript.xcodeproj -scheme OffScript -configuration Release -showBuildSettings | awk -F '= ' '/MARKETING_VERSION = / { print $2; exit }')"
+          fi
+
+          if [[ -n "$INPUT_BUILD" ]]; then
+            BUILD_NUMBER="$INPUT_BUILD"
+          else
+            BUILD_NUMBER="$(date -u +%Y%m%d)${GITHUB_RUN_NUMBER}${GITHUB_RUN_ATTEMPT}"
+          fi
+
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            REVISION_RANGE="${{ github.event.before }}..${{ github.sha }}"
+          else
+            REVISION_RANGE="$(git describe --tags --abbrev=0 2>/dev/null || echo HEAD~20)..${{ github.sha }}"
+          fi
+
+          {
+            echo "marketing_version=$MARKETING_VERSION"
+            echo "build_number=$BUILD_NUMBER"
+            echo "revision_range=$REVISION_RANGE"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "MARKETING_VERSION=$MARKETING_VERSION" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
+          echo "REVISION_RANGE=$REVISION_RANGE" >> "$GITHUB_ENV"
+
+      - name: Resolve simulator destination
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import json
+          import subprocess
+
+          preferred = [
+              "iPhone 17 Pro",
+              "iPhone 16 Pro",
+              "iPhone 15 Pro",
+              "iPhone 17",
+              "iPhone 16",
+              "iPhone 15",
+          ]
+          data = json.loads(subprocess.check_output(["xcrun", "simctl", "list", "devices", "available", "-j"]))
+          names = []
+          for runtime, devices in data.get("devices", {}).items():
+              if "iOS" not in runtime:
+                  continue
+              for device in devices:
+                  name = device.get("name", "")
+                  if device.get("isAvailable") and name.startswith("iPhone") and name not in names:
+                      names.append(name)
+
+          for name in preferred:
+              if name in names:
+                  print(f"TEST_DESTINATION=platform=iOS Simulator,OS=latest,name={name}")
+                  break
+          else:
+              if not names:
+                  raise SystemExit("No available iPhone simulator found")
+              print(f"TEST_DESTINATION=platform=iOS Simulator,OS=latest,name={names[0]}")
+          PY
+
+      - name: Generate changelog and What to Test notes
+        run: |
+          set -euo pipefail
+          scripts/generate_testflight_notes.py \
+            --range "$REVISION_RANGE" \
+            --version "$MARKETING_VERSION" \
+            --build "$BUILD_NUMBER" \
+            --summary "${{ github.event.inputs.summary || '' }}" \
+            --what-to-test "${{ github.event.inputs.what_to_test || '' }}" \
+            --output-dir build/TestFlight/notes
+
+          {
+            echo "## TestFlight Beta ${MARKETING_VERSION} (${BUILD_NUMBER})"
+            echo
+            cat build/TestFlight/notes/WHAT_TO_TEST.md
+            echo
+            echo "## Changelog"
+            sed -n '1,80p' build/TestFlight/notes/CHANGELOG.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate TestFlight export policy
+        run: scripts/upload_testflight.sh --validate-only
+
+      - name: Run tests
+        run: |
+          set -euo pipefail
+          xcodebuild test \
+            -project OffScript.xcodeproj \
+            -scheme OffScript \
+            -destination "$TEST_DESTINATION" \
+            -resultBundlePath build/TestFlight/TestResults.xcresult
+
+      - name: Upload to TestFlight
+        run: scripts/upload_testflight.sh
+
+      - name: Wait for processing and publish TestFlight notes
+        run: |
+          set -euo pipefail
+          scripts/app_store_connect.py wait-build \
+            --build "$BUILD_NUMBER" \
+            --require-valid \
+            --timeout 2400 \
+            --poll 30 \
+            --id-file build/TestFlight/notes/build-id.txt
+
+          scripts/app_store_connect.py set-beta-notes \
+            --build-id "$(cat build/TestFlight/notes/build-id.txt)" \
+            --notes-file build/TestFlight/notes/testflight-notes.txt \
+            --locale en-US
+
+          scripts/app_store_connect.py sync-latest --apply
+          scripts/app_store_connect.py status --limit 5 > build/TestFlight/notes/app-store-connect-status.txt
+
+      - name: Upload release artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: testflight-${{ steps.metadata.outputs.marketing_version }}-${{ steps.metadata.outputs.build_number }}
+          path: |
+            build/TestFlight/notes
+            build/TestFlight/TestResults.xcresult
+          if-no-files-found: warn

--- a/Config/AppStoreConnect.env.example
+++ b/Config/AppStoreConnect.env.example
@@ -1,0 +1,13 @@
+# Copy to .env.appstoreconnect, Config/.env.appstoreconnect, or
+# Config/AppStoreConnect.local.env.
+# Do not commit private keys or local env files.
+
+ASC_KEY_TYPE=team
+ASC_KEY_ID=XXXXXXXXXX
+ASC_ISSUER_ID=00000000-0000-0000-0000-000000000000
+ASC_KEY_PATH=/Users/zachgonser/Downloads/AuthKey_XXXXXXXXXX.p8
+ASC_BUNDLE_ID=com.offscript.app
+
+# GitHub Actions TestFlight uploads require a team API key because xcodebuild
+# requires an issuer ID for API-key signing/upload authentication.
+# Store the .p8 contents in GitHub as ASC_KEY_P8_BASE64, not as this local path.

--- a/Config/TestFlightUploadOptions.plist
+++ b/Config/TestFlightUploadOptions.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>destination</key>
+	<string>upload</string>
+	<key>manageAppVersionAndBuildNumber</key>
+	<true/>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>teamID</key>
+	<string>363TRR79UG</string>
+	<key>uploadSymbols</key>
+	<true/>
+</dict>
+</plist>

--- a/docs/TESTFLIGHT.md
+++ b/docs/TESTFLIGHT.md
@@ -1,0 +1,78 @@
+# TestFlight Release Policy
+
+## Internal And External Sync
+
+OffScript uses the same uploaded build for internal and external TestFlight whenever a build is intended for beta testing. Do not upload beta candidates as `TestFlight Internal Only`; those builds cannot be added to external tester groups later.
+
+Internal-only builds are allowed only for throwaway signing/debug checks. If a build may go to external testers, upload it with `Config/TestFlightUploadOptions.plist`.
+
+## Upload A Beta Candidate
+
+1. Bump `MARKETING_VERSION` only when the user-facing beta version changes.
+2. Bump `CURRENT_PROJECT_VERSION` for every App Store Connect upload.
+3. Run `scripts/upload_testflight.sh`.
+4. In App Store Connect, add the same processed build to the internal group and the external group.
+5. Before inviting testers, verify both groups show the same version and build number.
+
+The upload script refuses options files that include `testFlightInternalTestingOnly = true`.
+
+## Automated Main Branch Uploads
+
+Pushes to `main` run `.github/workflows/testflight.yml`.
+
+The workflow:
+
+1. Computes a unique build number from the UTC date, GitHub run number, and run attempt.
+2. Generates `CHANGELOG.md`, `WHAT_TO_TEST.md`, and `testflight-notes.txt` under `build/TestFlight/notes`.
+3. Runs the iOS test suite on an available iPhone simulator.
+4. Archives and uploads the Release build with `scripts/upload_testflight.sh`.
+5. Waits for App Store Connect processing, writes the generated notes into TestFlight's build localization, and syncs the latest eligible build to all beta groups.
+6. Uploads the changelog, What to Test notes, TestFlight notes, App Store Connect status snapshot, and test result bundle as GitHub Actions artifacts.
+
+Manual runs are available from GitHub Actions via **TestFlight Beta**. Use the manual inputs when a build needs custom release wording:
+
+- `marketing_version`: override `MARKETING_VERSION`.
+- `build_number`: override `CURRENT_PROJECT_VERSION`.
+- `summary`: short changelog summary.
+- `what_to_test`: extra tester instructions appended to generated What to Test notes.
+
+## GitHub Secrets
+
+Required repository secrets:
+
+- `ASC_KEY_ID`: App Store Connect API key ID.
+- `ASC_ISSUER_ID`: App Store Connect issuer ID.
+- `ASC_KEY_P8_BASE64`: base64-encoded contents of the `.p8` private key.
+
+The GitHub workflow expects a **team** App Store Connect API key because `xcodebuild -allowProvisioningUpdates` requires `-authenticationKeyPath`, `-authenticationKeyID`, and `-authenticationKeyIssuerID` for CI signing/upload authentication. Individual API keys can still be used by `scripts/app_store_connect.py` for local status checks, but they do not satisfy the CI `xcodebuild` issuer-ID requirement.
+
+Create the base64 secret locally with:
+
+```bash
+base64 -i /path/to/AuthKey_XXXXXXXXXX.p8 | pbcopy
+```
+
+## App Store Connect API Status Checks
+
+Use `scripts/app_store_connect.py status` to inspect the App Store Connect app record, beta groups, recent builds, and beta build states.
+
+Local credentials live in `.env.appstoreconnect` or `Config/AppStoreConnect.local.env`; both are ignored by git. Team API keys require `ASC_ISSUER_ID`. Individual API keys should set `ASC_KEY_TYPE=individual` and do not use an issuer ID.
+
+Useful checks:
+
+```bash
+scripts/app_store_connect.py doctor
+scripts/app_store_connect.py status --limit 8
+scripts/app_store_connect.py sync-latest
+scripts/app_store_connect.py wait-build --build 2026042501 --require-valid
+scripts/app_store_connect.py set-beta-notes --build 2026042501 --notes-file build/TestFlight/notes/testflight-notes.txt
+```
+
+`sync-latest` is dry-run by default. Use `scripts/app_store_connect.py sync-latest --apply` only when the latest eligible build is missing beta-group access and should be made available to all beta groups.
+
+## Current App Store Connect Convention
+
+- Bundle ID: `com.offscript.app`
+- Team ID: `363TRR79UG`
+- App Store name: `Offscript: A Podcast App`
+- Home screen display name: `OffScript`

--- a/scripts/app_store_connect.py
+++ b/scripts/app_store_connect.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import jwt
+import requests
+
+BASE_URL = "https://api.appstoreconnect.apple.com"
+DEFAULT_ENV_FILES = (
+    Path(".env.appstoreconnect"),
+    Path("Config/.env.appstoreconnect"),
+    Path("Config/AppStoreConnect.local.env"),
+)
+
+
+class ASCError(RuntimeError):
+    pass
+
+
+def load_env_file(path: Path) -> None:
+    if not path.exists():
+        return
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def load_default_env() -> None:
+    for path in DEFAULT_ENV_FILES:
+        load_env_file(path)
+
+
+def infer_key_id(key_path: Path) -> str | None:
+    match = re.search(r"AuthKey_([A-Z0-9]+)\.p8$", key_path.name)
+    return match.group(1) if match else None
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise ASCError(f"Missing {name}")
+    return value
+
+
+def make_token(scope: list[str] | None = None) -> str:
+    key_path = Path(required_env("ASC_KEY_PATH")).expanduser()
+    if not key_path.exists():
+        raise ASCError(f"Missing private key file: {key_path}")
+
+    key_id = os.environ.get("ASC_KEY_ID") or infer_key_id(key_path)
+    if not key_id:
+        raise ASCError("Missing ASC_KEY_ID and could not infer it from ASC_KEY_PATH")
+
+    key_type = os.environ.get("ASC_KEY_TYPE", "individual").lower()
+    now = int(time.time())
+    payload: dict[str, Any] = {
+        "iat": now,
+        "exp": now + 20 * 60,
+        "aud": "appstoreconnect-v1",
+    }
+
+    if scope:
+        payload["scope"] = scope
+
+    if key_type == "team":
+        payload["iss"] = required_env("ASC_ISSUER_ID")
+    elif key_type == "individual":
+        payload["sub"] = "user"
+    else:
+        raise ASCError("ASC_KEY_TYPE must be either individual or team")
+
+    private_key = key_path.read_text(encoding="utf-8")
+    token = jwt.encode(
+        payload,
+        private_key,
+        algorithm="ES256",
+        headers={"kid": key_id, "typ": "JWT"},
+    )
+    return token if isinstance(token, str) else token.decode("utf-8")
+
+
+class ASCClient:
+    def __init__(self) -> None:
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {make_token()}",
+                "Accept": "application/json",
+            }
+        )
+
+    def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        response = self.session.request(method, f"{BASE_URL}{path}", timeout=30, **kwargs)
+        if response.status_code == 204:
+            return {"data": []}
+
+        try:
+            body = response.json()
+        except ValueError:
+            body = {"raw": response.text}
+
+        if response.status_code >= 400:
+            message = json.dumps(body, indent=2)
+            if response.status_code == 401 and os.environ.get("ASC_KEY_TYPE", "individual").lower() == "individual":
+                message += "\nIf this is a team key, set ASC_KEY_TYPE=team and ASC_ISSUER_ID."
+            raise ASCError(f"{method} {path} failed with HTTP {response.status_code}:\n{message}")
+
+        return body
+
+
+def attrs(resource: dict[str, Any]) -> dict[str, Any]:
+    return resource.get("attributes") or {}
+
+
+def find_app(client: ASCClient, bundle_id: str) -> dict[str, Any]:
+    response = client.request(
+        "GET",
+        "/v1/apps",
+        params={
+            "filter[bundleId]": bundle_id,
+            "fields[apps]": "name,bundleId,sku,primaryLocale",
+            "limit": 1,
+        },
+    )
+    apps = response.get("data", [])
+    if not apps:
+        raise ASCError(f"No App Store Connect app found for bundle ID {bundle_id}")
+    return apps[0]
+
+
+def app_builds(client: ASCClient, app_id: str, limit: int) -> list[dict[str, Any]]:
+    response = client.request(
+        "GET",
+        f"/v1/apps/{app_id}/builds",
+        params={
+            "limit": limit,
+            "fields[builds]": "version,uploadedDate,expirationDate,expired,minOsVersion,processingState,buildAudienceType,usesNonExemptEncryption",
+        },
+    )
+    builds = response.get("data", [])
+    return sorted(builds, key=lambda build: attrs(build).get("uploadedDate") or "", reverse=True)
+
+
+def all_app_builds(client: ASCClient, app_id: str) -> list[dict[str, Any]]:
+    response = client.request(
+        "GET",
+        f"/v1/apps/{app_id}/builds",
+        params={
+            "limit": 200,
+            "fields[builds]": "version,uploadedDate,processingState,buildAudienceType",
+        },
+    )
+    builds = response.get("data", [])
+    return sorted(builds, key=lambda build: attrs(build).get("uploadedDate") or "", reverse=True)
+
+
+def beta_groups(client: ASCClient, app_id: str) -> list[dict[str, Any]]:
+    response = client.request(
+        "GET",
+        f"/v1/apps/{app_id}/betaGroups",
+        params={
+            "limit": 200,
+            "fields[betaGroups]": "name,isInternalGroup,hasAccessToAllBuilds,publicLinkEnabled,feedbackEnabled",
+        },
+    )
+    return response.get("data", [])
+
+
+def beta_group_builds(client: ASCClient, group_id: str) -> list[dict[str, Any]]:
+    response = client.request(
+        "GET",
+        f"/v1/betaGroups/{group_id}/builds",
+        params={
+            "limit": 200,
+            "fields[builds]": "version,uploadedDate,processingState,buildAudienceType",
+        },
+    )
+    return response.get("data", [])
+
+
+def beta_group_assignment_map(client: ASCClient, groups: list[dict[str, Any]]) -> dict[str, list[str]]:
+    assignments: dict[str, list[str]] = {}
+    for group in groups:
+        group_attrs = attrs(group)
+        kind = "internal" if group_attrs.get("isInternalGroup") else "external"
+        label = f"{group_attrs.get('name')}:{kind}"
+        for build in beta_group_builds(client, group["id"]):
+            assignments.setdefault(build["id"], []).append(label)
+    return assignments
+
+
+def build_beta_detail(client: ASCClient, build_id: str) -> dict[str, Any] | None:
+    try:
+        response = client.request(
+            "GET",
+            f"/v1/builds/{build_id}/buildBetaDetail",
+            params={"fields[buildBetaDetails]": "autoNotifyEnabled,internalBuildState,externalBuildState"},
+        )
+    except ASCError:
+        return None
+    return response.get("data")
+
+
+def print_app(app: dict[str, Any]) -> None:
+    app_attrs = attrs(app)
+    print(f"App: {app_attrs.get('name')} ({app_attrs.get('bundleId')})")
+    print(f"App Store Connect ID: {app.get('id')}")
+
+
+def print_groups(groups: list[dict[str, Any]]) -> None:
+    if not groups:
+        print("Beta groups: none")
+        return
+
+    print("Beta groups:")
+    for group in groups:
+        group_attrs = attrs(group)
+        kind = "internal" if group_attrs.get("isInternalGroup") else "external"
+        public_link = "public-link" if group_attrs.get("publicLinkEnabled") else "no-public-link"
+        print(f"- {group_attrs.get('name')} [{kind}, {public_link}] id={group.get('id')}")
+
+
+def print_builds(
+    client: ASCClient,
+    builds: list[dict[str, Any]],
+    group_assignments: dict[str, list[str]] | None = None,
+) -> None:
+    if not builds:
+        print("Builds: none")
+        return
+
+    print("Builds:")
+    for build in builds:
+        build_attrs = attrs(build)
+        line = (
+            f"- {build_attrs.get('version')} "
+            f"state={build_attrs.get('processingState')} "
+            f"audience={build_attrs.get('buildAudienceType')} "
+            f"uploaded={build_attrs.get('uploadedDate')} "
+            f"id={build.get('id')}"
+        )
+        print(line)
+
+        detail = build_beta_detail(client, build["id"])
+        if detail:
+            detail_attrs = attrs(detail)
+            print(
+                "  beta: "
+                f"internal={detail_attrs.get('internalBuildState')} "
+                f"external={detail_attrs.get('externalBuildState')} "
+                f"autoNotify={detail_attrs.get('autoNotifyEnabled')}"
+            )
+
+        if group_assignments is not None:
+            labels = group_assignments.get(build["id"], [])
+            if labels:
+                print(f"  groups: {', '.join(labels)}")
+            else:
+                print("  groups: none")
+
+
+def xcode_build_setting(name: str) -> str:
+    command = [
+        "xcodebuild",
+        "-project",
+        "OffScript.xcodeproj",
+        "-scheme",
+        "OffScript",
+        "-configuration",
+        "Release",
+        "-showBuildSettings",
+    ]
+    env = os.environ.copy()
+    env.setdefault("DEVELOPER_DIR", "/Applications/Xcode.app/Contents/Developer")
+    result = subprocess.run(command, check=True, capture_output=True, text=True, env=env)
+    pattern = re.compile(rf"^\s*{re.escape(name)}\s*=\s*(.+?)\s*$")
+    for line in result.stdout.splitlines():
+        match = pattern.match(line)
+        if match:
+            return match.group(1)
+    raise ASCError(f"Could not read Xcode build setting {name}")
+
+
+def project_version_and_build() -> tuple[str, str]:
+    return xcode_build_setting("MARKETING_VERSION"), xcode_build_setting("CURRENT_PROJECT_VERSION")
+
+
+def build_exists(builds: list[dict[str, Any]], version: str, build_number: str) -> bool:
+    return any(attrs(build).get("version") == build_number for build in builds if attrs(build).get("version"))
+
+
+def latest_build(builds: list[dict[str, Any]]) -> dict[str, Any] | None:
+    return builds[0] if builds else None
+
+
+def latest_eligible_build(builds: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for build in builds:
+        build_attrs = attrs(build)
+        if build_attrs.get("processingState") == "VALID" and build_attrs.get("buildAudienceType") == "APP_STORE_ELIGIBLE":
+            return build
+    return None
+
+
+def find_build_by_number(builds: list[dict[str, Any]], build_number: str) -> dict[str, Any] | None:
+    for build in builds:
+        if attrs(build).get("version") == build_number:
+            return build
+    return None
+
+
+def add_build_to_beta_groups(client: ASCClient, build_id: str, group_ids: list[str]) -> None:
+    if not group_ids:
+        return
+
+    client.request(
+        "POST",
+        f"/v1/builds/{build_id}/relationships/betaGroups",
+        json={"data": [{"type": "betaGroups", "id": group_id} for group_id in group_ids]},
+    )
+
+
+def beta_build_localizations(client: ASCClient, build_id: str) -> list[dict[str, Any]]:
+    response = client.request(
+        "GET",
+        f"/v1/builds/{build_id}/betaBuildLocalizations",
+        params={
+            "limit": 200,
+            "fields[betaBuildLocalizations]": "whatsNew,locale,build",
+        },
+    )
+    return response.get("data", [])
+
+
+def upsert_beta_build_localization(client: ASCClient, build_id: str, locale: str, whats_new: str) -> dict[str, Any]:
+    existing = next(
+        (item for item in beta_build_localizations(client, build_id) if attrs(item).get("locale") == locale),
+        None,
+    )
+
+    if existing:
+        return client.request(
+            "PATCH",
+            f"/v1/betaBuildLocalizations/{existing['id']}",
+            json={
+                "data": {
+                    "type": "betaBuildLocalizations",
+                    "id": existing["id"],
+                    "attributes": {"whatsNew": whats_new},
+                }
+            },
+        )
+
+    return client.request(
+        "POST",
+        "/v1/betaBuildLocalizations",
+        json={
+            "data": {
+                "type": "betaBuildLocalizations",
+                "attributes": {
+                    "locale": locale,
+                    "whatsNew": whats_new,
+                },
+                "relationships": {
+                    "build": {
+                        "data": {
+                            "type": "builds",
+                            "id": build_id,
+                        }
+                    }
+                },
+            }
+        },
+    )
+
+
+def command_doctor(args: argparse.Namespace) -> None:
+    client = ASCClient()
+    bundle_id = args.bundle_id or required_env("ASC_BUNDLE_ID")
+    app = find_app(client, bundle_id)
+    groups = beta_groups(client, app["id"])
+    builds = all_app_builds(client, app["id"])
+    latest = latest_build(builds)
+    project_version, project_build = project_version_and_build()
+
+    print_app(app)
+    print(f"Project release build: {project_version} ({project_build})")
+
+    if build_exists(builds, project_version, project_build):
+        print(f"WARNING: build number {project_build} already exists in App Store Connect for this app.")
+        print("         Bump CURRENT_PROJECT_VERSION before uploading again.")
+    else:
+        print("OK: project build number has not been uploaded yet.")
+
+    internal_groups = [group for group in groups if attrs(group).get("isInternalGroup")]
+    external_groups = [group for group in groups if not attrs(group).get("isInternalGroup")]
+    print(f"Beta groups: {len(internal_groups)} internal, {len(external_groups)} external")
+
+    if not external_groups:
+        print("WARNING: no external beta group exists.")
+
+    if not latest:
+        print("WARNING: no TestFlight builds found.")
+        return
+
+    latest_attrs = attrs(latest)
+    latest_detail = build_beta_detail(client, latest["id"])
+    print(
+        "Latest uploaded build: "
+        f"{latest_attrs.get('version')} "
+        f"state={latest_attrs.get('processingState')} "
+        f"audience={latest_attrs.get('buildAudienceType')} "
+        f"uploaded={latest_attrs.get('uploadedDate')}"
+    )
+
+    if latest_detail:
+        detail_attrs = attrs(latest_detail)
+        print(
+            "Latest beta state: "
+            f"internal={detail_attrs.get('internalBuildState')} "
+            f"external={detail_attrs.get('externalBuildState')}"
+        )
+
+    assignments = beta_group_assignment_map(client, groups)
+    latest_groups = assignments.get(latest["id"], [])
+    print(f"Latest groups: {', '.join(latest_groups) if latest_groups else 'none'}")
+
+    has_internal_latest = any(label.endswith(":internal") for label in latest_groups)
+    has_external_latest = any(label.endswith(":external") for label in latest_groups)
+    if has_internal_latest and has_external_latest:
+        print("OK: latest build is assigned to both internal and external groups.")
+    else:
+        print("WARNING: latest build is not assigned to both internal and external groups.")
+
+
+def command_sync_latest(args: argparse.Namespace) -> None:
+    client = ASCClient()
+    bundle_id = args.bundle_id or required_env("ASC_BUNDLE_ID")
+    app = find_app(client, bundle_id)
+    groups = beta_groups(client, app["id"])
+    builds = all_app_builds(client, app["id"])
+    build = latest_eligible_build(builds)
+    if not build:
+        raise ASCError("No valid App Store eligible build found")
+
+    build_attrs = attrs(build)
+    assignments = beta_group_assignment_map(client, groups)
+    assigned_group_labels = set(assignments.get(build["id"], []))
+    missing_groups = []
+    for group in groups:
+        group_attrs = attrs(group)
+        kind = "internal" if group_attrs.get("isInternalGroup") else "external"
+        label = f"{group_attrs.get('name')}:{kind}"
+        if label not in assigned_group_labels:
+            missing_groups.append(group)
+
+    print_app(app)
+    print(f"Latest eligible build: {build_attrs.get('version')} id={build.get('id')}")
+    if not missing_groups:
+        print("OK: latest eligible build already has access to every beta group.")
+        return
+
+    print("Missing beta group access:")
+    for group in missing_groups:
+        group_attrs = attrs(group)
+        kind = "internal" if group_attrs.get("isInternalGroup") else "external"
+        print(f"- {group_attrs.get('name')} [{kind}] id={group.get('id')}")
+
+    if not args.apply:
+        print("Dry run only. Re-run with --apply to add build access to these groups.")
+        return
+
+    add_build_to_beta_groups(client, build["id"], [group["id"] for group in missing_groups])
+    print("Applied: latest eligible build now has access to the missing beta groups.")
+
+
+def command_apps(args: argparse.Namespace) -> None:
+    client = ASCClient()
+    bundle_id = args.bundle_id or required_env("ASC_BUNDLE_ID")
+    print_app(find_app(client, bundle_id))
+
+
+def command_status(args: argparse.Namespace) -> None:
+    client = ASCClient()
+    bundle_id = args.bundle_id or required_env("ASC_BUNDLE_ID")
+    app = find_app(client, bundle_id)
+    print_app(app)
+    print()
+    groups = beta_groups(client, app["id"])
+    print_groups(groups)
+    print()
+    print_builds(client, app_builds(client, app["id"], args.limit), beta_group_assignment_map(client, groups))
+
+
+def command_builds(args: argparse.Namespace) -> None:
+    client = ASCClient()
+    bundle_id = args.bundle_id or required_env("ASC_BUNDLE_ID")
+    app = find_app(client, bundle_id)
+    group_assignments = None
+    if args.groups:
+        group_assignments = beta_group_assignment_map(client, beta_groups(client, app["id"]))
+    print_builds(client, app_builds(client, app["id"], args.limit), group_assignments)
+
+
+def command_exists(args: argparse.Namespace) -> None:
+    client = ASCClient()
+    bundle_id = args.bundle_id or required_env("ASC_BUNDLE_ID")
+    app = find_app(client, bundle_id)
+    version = args.version
+    build_number = args.build
+    if not version or not build_number:
+        version, build_number = project_version_and_build()
+
+    if build_exists(all_app_builds(client, app["id"]), version, build_number):
+        print(f"exists: {bundle_id} {version} ({build_number})")
+        raise ASCError("Build number already uploaded")
+
+    print(f"available: {bundle_id} {version} ({build_number})")
+
+
+def command_wait_build(args: argparse.Namespace) -> None:
+    client = ASCClient()
+    bundle_id = args.bundle_id or required_env("ASC_BUNDLE_ID")
+    app = find_app(client, bundle_id)
+    deadline = time.time() + args.timeout
+
+    while True:
+        build = find_build_by_number(all_app_builds(client, app["id"]), args.build)
+        if build:
+            build_attrs = attrs(build)
+            state = build_attrs.get("processingState")
+            audience = build_attrs.get("buildAudienceType")
+            print(f"build id={build['id']} number={build_attrs.get('version')} state={state} audience={audience}")
+            if not args.require_valid or state == "VALID":
+                if args.id_file:
+                    args.id_file.parent.mkdir(parents=True, exist_ok=True)
+                    args.id_file.write_text(build["id"], encoding="utf-8")
+                return
+            if state == "FAILED":
+                raise ASCError(f"Build {args.build} processing failed")
+
+        if time.time() >= deadline:
+            raise ASCError(f"Timed out waiting for build {args.build}")
+        time.sleep(args.poll)
+
+
+def command_set_beta_notes(args: argparse.Namespace) -> None:
+    client = ASCClient()
+    bundle_id = args.bundle_id or required_env("ASC_BUNDLE_ID")
+    app = find_app(client, bundle_id)
+    notes = args.notes_file.read_text(encoding="utf-8").strip()
+    if not notes:
+        raise ASCError(f"Notes file is empty: {args.notes_file}")
+
+    build_id = args.build_id
+    if not build_id:
+        if not args.build:
+            raise ASCError("Pass --build-id or --build")
+        build = find_build_by_number(all_app_builds(client, app["id"]), args.build)
+        if not build:
+            raise ASCError(f"Build not found: {args.build}")
+        build_id = build["id"]
+
+    upsert_beta_build_localization(client, build_id, args.locale, notes[:4000])
+    print(f"Updated TestFlight notes for build id={build_id} locale={args.locale}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read App Store Connect status for OffScript.")
+    parser.add_argument("--env", type=Path, help="Optional env file to load before defaults.")
+    parser.add_argument("--bundle-id", help="Bundle ID to inspect. Defaults to ASC_BUNDLE_ID.")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    apps_parser = subparsers.add_parser("app", help="Show the App Store Connect app record.")
+    apps_parser.set_defaults(func=command_apps)
+
+    builds_parser = subparsers.add_parser("builds", help="List recent builds.")
+    builds_parser.add_argument("--limit", type=int, default=10)
+    builds_parser.add_argument("--groups", action="store_true", help="Include beta group assignment for each build.")
+    builds_parser.set_defaults(func=command_builds)
+
+    status_parser = subparsers.add_parser("status", help="Show app, beta groups, recent builds, and beta states.")
+    status_parser.add_argument("--limit", type=int, default=10)
+    status_parser.set_defaults(func=command_status)
+
+    doctor_parser = subparsers.add_parser("doctor", help="Check release pipeline health before uploading.")
+    doctor_parser.set_defaults(func=command_doctor)
+
+    sync_parser = subparsers.add_parser("sync-latest", help="Ensure the latest eligible build has beta group access.")
+    sync_parser.add_argument("--apply", action="store_true", help="Actually add missing beta group access.")
+    sync_parser.set_defaults(func=command_sync_latest)
+
+    exists_parser = subparsers.add_parser("build-exists", help="Fail if a version/build is already uploaded.")
+    exists_parser.add_argument("--version")
+    exists_parser.add_argument("--build")
+    exists_parser.set_defaults(func=command_exists)
+
+    wait_parser = subparsers.add_parser("wait-build", help="Wait for an uploaded build to appear and optionally become VALID.")
+    wait_parser.add_argument("--build", required=True, help="CFBundleVersion / App Store Connect build number.")
+    wait_parser.add_argument("--timeout", type=int, default=1800)
+    wait_parser.add_argument("--poll", type=int, default=30)
+    wait_parser.add_argument("--require-valid", action="store_true")
+    wait_parser.add_argument("--id-file", type=Path)
+    wait_parser.set_defaults(func=command_wait_build)
+
+    notes_parser = subparsers.add_parser("set-beta-notes", help="Create or update TestFlight What to Test notes.")
+    notes_parser.add_argument("--build-id")
+    notes_parser.add_argument("--build", help="CFBundleVersion / App Store Connect build number.")
+    notes_parser.add_argument("--notes-file", type=Path, required=True)
+    notes_parser.add_argument("--locale", default="en-US")
+    notes_parser.set_defaults(func=command_set_beta_notes)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.env:
+        load_env_file(args.env)
+    load_default_env()
+
+    try:
+        args.func(args)
+    except ASCError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_testflight_notes.py
+++ b/scripts/generate_testflight_notes.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+DEFAULT_OUTPUT_DIR = Path("build/TestFlight/notes")
+
+
+def run_git(args: list[str]) -> str:
+    result = subprocess.run(["git", *args], check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def safe_git(args: list[str]) -> str:
+    try:
+        return run_git(args)
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def commit_subjects(revision_range: str, limit: int) -> list[str]:
+    if revision_range:
+        output = safe_git(["log", "--no-merges", f"--max-count={limit}", "--pretty=format:%s", revision_range])
+        if output:
+            return [line.strip() for line in output.splitlines() if line.strip()]
+
+    output = safe_git(["log", "--no-merges", f"--max-count={limit}", "--pretty=format:%s"])
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def changed_files(revision_range: str) -> list[str]:
+    output = safe_git(["diff", "--name-only", revision_range]) if revision_range else ""
+    if not output:
+        output = safe_git(["show", "--pretty=", "--name-only", "HEAD"])
+    return sorted({line.strip() for line in output.splitlines() if line.strip()})
+
+
+def bullets(items: list[str], fallback: str, limit: int | None = None) -> list[str]:
+    selected = items[:limit] if limit else items
+    if not selected:
+        return [f"- {fallback}"]
+    return [f"- {item}" for item in selected]
+
+
+def categorized_test_prompts(files: list[str]) -> list[str]:
+    prompts: list[str] = []
+    joined = "\n".join(files).lower()
+
+    if any(token in joined for token in ["queue", "playback", "player", "download", "podcastservices"]):
+        prompts.append("Queue several episodes, use Play Next/Add to End, and confirm playback advances in the expected order.")
+    if any(token in joined for token in ["library", "episode", "cardcomponents"]):
+        prompts.append("Open Library and a show detail page; verify episode rows, filters, search, and batch actions behave correctly.")
+    if any(token in joined for token in ["recommendation", "home", "search", "onboarding", "import", "taste"]):
+        prompts.append("Complete onboarding/import, then confirm Home recommendations explain why each episode is surfaced.")
+    if any(token in joined for token in ["download", "offline"]):
+        prompts.append("Download an episode, relaunch, and confirm offline status and playback from the downloaded file.")
+    if any(token in joined for token in ["settings", "telemetry", "sync"]):
+        prompts.append("Open Settings diagnostics and confirm sync/feed-build events are visible after import or playback activity.")
+    if any(token in joined for token in ["theme", "assets", "appicon", "design", "view"]):
+        prompts.append("Check the main tabs on a small iPhone simulator for clipping, overlap, readable text, and usable tap targets.")
+
+    prompts.append("Run a smoke pass through Home, Library, Queue, Search, mini-player, and full player.")
+    return list(dict.fromkeys(prompts))
+
+
+def truncate(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    suffix = "\n\nMore detail is available in the GitHub release-notes artifact."
+    return text[: max(0, max_chars - len(suffix))].rstrip() + suffix
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.rstrip() + "\n", encoding="utf-8")
+
+
+def build_notes(args: argparse.Namespace) -> tuple[str, str, str]:
+    commits = commit_subjects(args.revision_range, args.commit_limit)
+    files = changed_files(args.revision_range)
+    test_prompts = categorized_test_prompts(files)
+
+    title = f"OffScript beta {args.version} ({args.build})" if args.version and args.build else "OffScript beta"
+    summary = args.summary.strip() or "Automated beta candidate from the latest main branch changes."
+    custom_what_to_test = args.what_to_test.strip()
+
+    changelog = "\n".join(
+        [
+            f"# {title}",
+            "",
+            "## Summary",
+            summary,
+            "",
+            "## Changes",
+            *bullets(commits, "Latest main branch changes.", args.commit_limit),
+            "",
+            "## Changed Files",
+            *bullets(files, "No changed files detected.", 60),
+        ]
+    )
+
+    what_to_test_sections = [
+        f"# What To Test: {title}",
+        "",
+        "## Primary Pass",
+        *bullets(test_prompts, "Run the core app smoke flow."),
+    ]
+    if custom_what_to_test:
+        what_to_test_sections.extend(["", "## Release-Specific Notes", custom_what_to_test])
+    what_to_test = "\n".join(what_to_test_sections)
+
+    testflight_parts = [
+        title,
+        "",
+        "What changed:",
+        *bullets(commits, "Latest main branch changes.", 8),
+        "",
+        "What to test:",
+        *bullets(test_prompts, "Run the core app smoke flow.", 8),
+    ]
+    if custom_what_to_test:
+        testflight_parts.extend(["", "Release-specific focus:", textwrap.shorten(custom_what_to_test, width=700, placeholder="...")])
+    testflight = truncate("\n".join(testflight_parts), args.max_testflight_chars)
+
+    return changelog, what_to_test, testflight
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate TestFlight changelog and tester notes.")
+    parser.add_argument("--range", dest="revision_range", default="", help="Git revision range, e.g. before..sha")
+    parser.add_argument("--version", default="")
+    parser.add_argument("--build", default="")
+    parser.add_argument("--summary", default="")
+    parser.add_argument("--what-to-test", default="")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--commit-limit", type=int, default=18)
+    parser.add_argument("--max-testflight-chars", type=int, default=3800)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    changelog, what_to_test, testflight = build_notes(args)
+
+    write(args.output_dir / "CHANGELOG.md", changelog)
+    write(args.output_dir / "WHAT_TO_TEST.md", what_to_test)
+    write(args.output_dir / "testflight-notes.txt", testflight)
+
+    print(f"Wrote {args.output_dir / 'CHANGELOG.md'}")
+    print(f"Wrote {args.output_dir / 'WHAT_TO_TEST.md'}")
+    print(f"Wrote {args.output_dir / 'testflight-notes.txt'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/upload_testflight.sh
+++ b/scripts/upload_testflight.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_PATH="$ROOT_DIR/OffScript.xcodeproj"
+SCHEME="OffScript"
+CONFIGURATION="Release"
+ARCHIVE_PATH="$ROOT_DIR/build/TestFlight/OffScript.xcarchive"
+EXPORT_PATH="$ROOT_DIR/build/TestFlight/Upload"
+EXPORT_OPTIONS="${EXPORT_OPTIONS:-$ROOT_DIR/Config/TestFlightUploadOptions.plist}"
+PLIST_BUDDY="/usr/libexec/PlistBuddy"
+VALIDATE_ONLY="false"
+ASC_SCRIPT="$ROOT_DIR/scripts/app_store_connect.py"
+BUILD_NUMBER="${BUILD_NUMBER:-}"
+MARKETING_VERSION="${MARKETING_VERSION:-}"
+ENV_FILES=(
+	"$ROOT_DIR/.env.appstoreconnect"
+	"$ROOT_DIR/Config/.env.appstoreconnect"
+	"$ROOT_DIR/Config/AppStoreConnect.local.env"
+)
+
+if [[ "${1:-}" == "--validate-only" ]]; then
+	VALIDATE_ONLY="true"
+fi
+
+fail() {
+	echo "error: $*" >&2
+	exit 1
+}
+
+load_env_files() {
+	local env_file
+	for env_file in "${ENV_FILES[@]}"; do
+		if [[ -f "$env_file" ]]; then
+			set -a
+			# shellcheck disable=SC1090
+			source "$env_file"
+			set +a
+		fi
+	done
+}
+
+plist_value() {
+	"$PLIST_BUDDY" -c "Print :$1" "$2" 2>/dev/null || true
+}
+
+require_external_capable_options() {
+	[[ -f "$EXPORT_OPTIONS" ]] || fail "missing export options: $EXPORT_OPTIONS"
+
+	local destination method internal_only
+	destination="$(plist_value destination "$EXPORT_OPTIONS")"
+	method="$(plist_value method "$EXPORT_OPTIONS")"
+	internal_only="$(plist_value testFlightInternalTestingOnly "$EXPORT_OPTIONS")"
+
+	[[ "$destination" == "upload" ]] || fail "export options must use destination=upload"
+	[[ "$method" == "app-store-connect" ]] || fail "export options must use method=app-store-connect"
+	[[ "$internal_only" != "true" && "$internal_only" != "YES" ]] || fail "refusing internal-only TestFlight upload options"
+}
+
+archive_metadata() {
+	local archive_info="$ARCHIVE_PATH/Info.plist"
+	[[ -f "$archive_info" ]] || fail "archive metadata not found: $archive_info"
+
+	local version build bundle_id team
+	version="$(plist_value ApplicationProperties:CFBundleShortVersionString "$archive_info")"
+	build="$(plist_value ApplicationProperties:CFBundleVersion "$archive_info")"
+	bundle_id="$(plist_value ApplicationProperties:CFBundleIdentifier "$archive_info")"
+	team="$(plist_value ApplicationProperties:Team "$archive_info")"
+
+	echo "Archive: $bundle_id $version ($build), team $team"
+}
+
+check_build_number_available() {
+	if [[ -n "${ASC_KEY_PATH:-}" ]]; then
+		local args=(build-exists)
+		[[ -z "$MARKETING_VERSION" ]] || args+=(--version "$MARKETING_VERSION")
+		[[ -z "$BUILD_NUMBER" ]] || args+=(--build "$BUILD_NUMBER")
+		"$ASC_SCRIPT" "${args[@]}"
+	else
+		echo "warning: skipping App Store Connect duplicate-build preflight; no local ASC env file found" >&2
+	fi
+}
+
+prepare_xcode_args() {
+	BUILD_SETTINGS=()
+	XCODE_AUTH_ARGS=()
+
+	[[ -z "$MARKETING_VERSION" ]] || BUILD_SETTINGS+=("MARKETING_VERSION=$MARKETING_VERSION")
+	[[ -z "$BUILD_NUMBER" ]] || BUILD_SETTINGS+=("CURRENT_PROJECT_VERSION=$BUILD_NUMBER")
+
+	if [[ -n "${ASC_KEY_PATH:-}" ]]; then
+		[[ -n "${ASC_KEY_ID:-}" ]] || fail "ASC_KEY_ID is required when ASC_KEY_PATH is set"
+		if [[ -z "${ASC_ISSUER_ID:-}" ]]; then
+			if [[ "${CI:-false}" == "true" ]]; then
+				fail "ASC_ISSUER_ID is required for CI xcodebuild signing/upload authentication"
+			fi
+			echo "warning: ASC_KEY_PATH set without ASC_ISSUER_ID; xcodebuild will use the local Xcode account instead" >&2
+		else
+			XCODE_AUTH_ARGS+=(
+				-authenticationKeyPath "$ASC_KEY_PATH"
+				-authenticationKeyID "$ASC_KEY_ID"
+				-authenticationKeyIssuerID "$ASC_ISSUER_ID"
+			)
+		fi
+	fi
+}
+
+load_env_files
+require_external_capable_options
+
+if [[ "$VALIDATE_ONLY" == "true" ]]; then
+	echo "Export options are external-capable: $EXPORT_OPTIONS"
+	exit 0
+fi
+
+check_build_number_available
+
+rm -rf "$ARCHIVE_PATH" "$EXPORT_PATH"
+
+prepare_xcode_args
+
+DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}" \
+xcodebuild \
+	-project "$PROJECT_PATH" \
+	-scheme "$SCHEME" \
+	-configuration "$CONFIGURATION" \
+	-destination "generic/platform=iOS" \
+	-archivePath "$ARCHIVE_PATH" \
+	"${BUILD_SETTINGS[@]}" \
+	archive \
+	-allowProvisioningUpdates \
+	"${XCODE_AUTH_ARGS[@]}"
+
+archive_metadata
+
+DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}" \
+xcodebuild \
+	-exportArchive \
+	-archivePath "$ARCHIVE_PATH" \
+	-exportPath "$EXPORT_PATH" \
+	-exportOptionsPlist "$EXPORT_OPTIONS" \
+	-allowProvisioningUpdates \
+	"${XCODE_AUTH_ARGS[@]}"


### PR DESCRIPTION
## Summary
- add a main-branch/manual TestFlight workflow
- generate changelog, what-to-test, and TestFlight notes per build
- upload App Store Connect notes and sync the latest eligible build to beta groups
- document required App Store Connect secrets and local validation commands

## Validation
- workflow YAML parses
- Python helper scripts compile
- upload shell script syntax passes
- export options plist validates
- TestFlight export validation passes
- local App Store Connect status check succeeds with team key

## Notes
- GitHub Actions secrets are already configured: ASC_KEY_ID, ASC_ISSUER_ID, ASC_KEY_P8_BASE64
- workflow runs on pushes to main and via manual workflow_dispatch