### PR TITLE
fix: use Xcode 16 compatible Bluetooth audio option

### DIFF
--- a/OffScript/PlaybackController.swift
+++ b/OffScript/PlaybackController.swift
@@ -173,7 +173,7 @@ final class PlaybackController: ObservableObject {
     private func configureAudioSession() {
         #if os(iOS)
         let session = AVAudioSession.sharedInstance()
-        try? session.setCategory(.playback, mode: .spokenAudio, policy: .longFormAudio, options: [.allowAirPlay, .allowBluetoothHFP])
+        try? session.setCategory(.playback, mode: .spokenAudio, policy: .longFormAudio, options: [.allowAirPlay, .allowBluetoothA2DP])
         try? session.setActive(true)
         #endif
     }


### PR DESCRIPTION
## Summary
- replace allowBluetoothHFP with allowBluetoothA2DP for the playback audio session
- fixes CI compile failure under GitHub's Xcode 16.4 runner

## Validation
- local xcodebuild test passed with Xcode 26.4.1 on iPhone 17 Pro simulator
- staged diff check passes