### PR TITLE
ci: run TestFlight lane on macOS 26

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   testflight:
     name: Build, Upload, And Annotate TestFlight
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 90
 
     env:
@@ -52,9 +52,22 @@ jobs:
       - name: Select active Xcode
         run: |
           set -euo pipefail
+          for candidate in \
+            /Applications/Xcode_26.4.1.app/Contents/Developer \
+            /Applications/Xcode_26.4.app/Contents/Developer \
+            /Applications/Xcode_26.4.0.app/Contents/Developer \
+            /Applications/Xcode_26.3.app/Contents/Developer \
+            /Applications/Xcode.app/Contents/Developer
+          do
+            if [[ -d "$candidate" ]]; then
+              sudo xcode-select -s "$candidate"
+              break
+            fi
+          done
           echo "DEVELOPER_DIR=$(xcode-select -p)" >> "$GITHUB_ENV"
           echo "ASC_KEY_PATH=$RUNNER_TEMP/AuthKey.p8" >> "$GITHUB_ENV"
           xcodebuild -version
+          xcodebuild -showsdks
 
       - name: Install App Store Connect script dependencies
         run: |


### PR DESCRIPTION
## Summary
- move the TestFlight lane from macos-latest to macos-26
- explicitly select an Xcode 26 developer directory when present
- print installed SDKs for release-run diagnostics

## Why
- macos-latest selected Xcode 16.4, which is incompatible with the current iOS 26.2 deployment target and caused CI simulator hangs

## Validation
- actionlint passes
- workflow YAML parses
- staged diff check passes