### PR TITLE
ci: install crypto support for App Store Connect JWTs

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -74,7 +74,7 @@ jobs:
           set -euo pipefail
           python3 -m venv "$RUNNER_TEMP/asc-venv"
           "$RUNNER_TEMP/asc-venv/bin/python" -m pip install --upgrade pip
-          "$RUNNER_TEMP/asc-venv/bin/python" -m pip install PyJWT requests
+          "$RUNNER_TEMP/asc-venv/bin/python" -m pip install PyJWT cryptography requests
           echo "$RUNNER_TEMP/asc-venv/bin" >> "$GITHUB_PATH"
 
       - name: Validate required TestFlight secrets


### PR DESCRIPTION
## Summary
- install cryptography into the App Store Connect helper venv
- fixes PyJWT ES256 signing on GitHub runners

## Validation
- actionlint passes
- workflow YAML parses
- local venv check confirms ES256 support is available