### PR TITLE
ci: provide development team for TestFlight archives

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -41,6 +41,7 @@ jobs:
       ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
       ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
       ASC_KEY_TYPE: team
+      DEVELOPMENT_TEAM: 363TRR79UG
       TEST_DESTINATION: platform=iOS Simulator,OS=latest,name=iPhone 17 Pro
 
     steps:

--- a/scripts/upload_testflight.sh
+++ b/scripts/upload_testflight.sh
@@ -13,6 +13,7 @@ VALIDATE_ONLY="false"
 ASC_SCRIPT="$ROOT_DIR/scripts/app_store_connect.py"
 BUILD_NUMBER="${BUILD_NUMBER:-}"
 MARKETING_VERSION="${MARKETING_VERSION:-}"
+DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM:-363TRR79UG}"
 ENV_FILES=(
 	"$ROOT_DIR/.env.appstoreconnect"
 	"$ROOT_DIR/Config/.env.appstoreconnect"
@@ -87,6 +88,7 @@ prepare_xcode_args() {
 
 	[[ -z "$MARKETING_VERSION" ]] || BUILD_SETTINGS+=("MARKETING_VERSION=$MARKETING_VERSION")
 	[[ -z "$BUILD_NUMBER" ]] || BUILD_SETTINGS+=("CURRENT_PROJECT_VERSION=$BUILD_NUMBER")
+	[[ -z "$DEVELOPMENT_TEAM" ]] || BUILD_SETTINGS+=("DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM" "CODE_SIGN_STYLE=Automatic")
 
 	if [[ -n "${ASC_KEY_PATH:-}" ]]; then
 		[[ -n "${ASC_KEY_ID:-}" ]] || fail "ASC_KEY_ID is required when ASC_KEY_PATH is set"


### PR DESCRIPTION
## Summary
- set DEVELOPMENT_TEAM for the TestFlight workflow
- pass DEVELOPMENT_TEAM and automatic signing into xcodebuild archive

## Validation
- actionlint passes
- workflow YAML parses
- upload script syntax passes
- TestFlight export options validation passes