### PR TITLE
docs: README, LICENSE, CONTRIBUTING, CHANGELOG, issue + PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly in the app
+title: "[bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. If your bug is a **crash**, you don't need to fill this out — Sentry already has the trace. But a one-line note about what you were doing right before makes triage way faster.
+
+  - type: input
+    id: build
+    attributes:
+      label: Build version
+      description: TestFlight shows this on the build's page (e.g. `2.0 (23)`)
+      placeholder: "2.0 (23)"
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device + iOS version
+      description: Settings → General → About
+      placeholder: "iPhone 16 Pro, iOS 18.4"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: One paragraph. What you saw, what you expected, what you tapped.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: If you can reproduce reliably, list the steps. If it's intermittent, say so — that's still useful.
+      placeholder: |
+        1. Open the app
+        2. Tap Search
+        3. Type "Acquired"
+        4. Tap the first result
+        5. Crash on detail page open
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "Crash — app dies"
+        - "Blocker — feature unusable"
+        - "Bug — wrong but workaround exists"
+        - "Polish — minor visual or copy issue"
+    validations:
+      required: true
+
+  - type: textarea
+    id: extras
+    attributes:
+      label: Anything else
+      description: Screenshots, logs, hunches, network conditions, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: TestFlight feedback (in-app)
+    url: https://testflight.apple.com/
+    about: From TestFlight, screenshot the app and send feedback — it lands directly with the developer along with device info and crash context.
+  - name: Email the maintainer
+    url: mailto:zachgonser@gmail.com
+    about: For sensitive bugs (PII, security, account issues) — please don't file a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: An idea for something OffScript should do (or stop doing)
+title: "[feature] "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two things help most: **the problem** (what's currently friction-y), and **the user** (who hits it). The solution is the easy part; we'll figure that out together.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's the friction today? Be specific — not "the app is bad at recommendations" but "I subscribed to Acquired last week and it still hasn't shown up in any rail."
+    validations:
+      required: true
+
+  - type: textarea
+    id: who
+    attributes:
+      label: Who hits this
+      description: Yourself, a TestFlight tester, a hypothetical persona — anything that helps us understand the use case.
+    validations:
+      required: false
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: Your idea (optional)
+      description: If you have a specific solution in mind, share it. Not required — sometimes the best ideas come from "here's the problem, what do you think?"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: importance
+    attributes:
+      label: How much do you care
+      options:
+        - "Nice to have"
+        - "Would meaningfully improve the app"
+        - "I'd use the app way more if this existed"
+        - "I'm currently not using OffScript because of this"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!-- For external contributors: please open an issue first to discuss the change. See CONTRIBUTING.md. -->
+
+## Summary
+
+<!-- 1-3 bullets. What changes, why now. -->
+-
+-
+
+## Test plan
+
+<!-- Markdown checklist. Stuff a reviewer should verify before merging. -->
+- [ ] `xcodebuild` clean build succeeds locally
+- [ ] Unit tests pass: `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'`
+- [ ] Manually verified on simulator (note device + iOS version):
+- [ ] No new inline `Color.white.opacity(...)` or raw `Font.system(...)` — used named tokens
+- [ ] No bare `try?` — all errors logged via `OSLog`
+- [ ] If touching SwiftData: predicate-filtered `FetchDescriptor`, no `persistentModelID` in `#Predicate`
+
+## Screenshots / recordings
+
+<!-- For UI changes — drag-drop into the textarea. -->
+
+## Risk
+
+<!-- One line. -->
+- **Affected surfaces:**
+- **Rollback path:** revert this PR, push to `main`, CI auto-deploys the prior build.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to OffScript. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/spec/v2.0.0.html) — though TestFlight builds carry a `YYYYMMDD<run>.<attempt>` build number layered on top of the marketing version.
+
+## [Unreleased]
+
+### Added
+- GitHub repo overhaul: README, CONTRIBUTING, LICENSE, issue + PR templates, this changelog.
+
+## [2.0] — 2026-04-26
+
+### Added
+- **Tuner OLED design direction.** Pure black field, signal-yellow primary accent, function-coded tag pills (record-red / mode-green / power-yellow / info-cyan), single-pixel hairlines, monospaced metadata. Replaces the previous warm-amber editorial direction.
+- New design primitives: `TunerTag`, `TunerRingMeter`, `TunerReadout`, `TunerTrace`, `TunerTransportButton`, `TunerModeToggle`, `TunerLabel`, `TunerArtworkTile`.
+- New onboarding flow: POWER ON welcome → "01 · TASTE / Pick your bands" → "02 · CHANNELS / Tune the bank" → import.
+- New EpisodeDetail spec sheet layout with Ferrari-cluster readouts.
+- New app icon: signal-yellow VU dial on OLED black with REC indicator.
+- **Sentry-Cocoa** integration (errors-only, quota-aware): sampleRate 1.0 for errors, 5% perf transactions, no profiling, screenshot/view-hierarchy capture off for privacy.
+- **MetricKit** subscription via `MetricKitReporter` — daily metric payloads logged via OSLog, crash diagnostics forwarded into Sentry as `.fatal` events.
+
+### Changed
+- All theme tokens (`offscriptAccent`, `offscriptCard`, `offscriptBackground`, etc.) remap to Tuner OLED palette automatically — every existing surface inherits the new look without per-view rewrites.
+- `OffScriptScrubber` rebuilt as instrument-scale rule (60-tick major/minor/fine, thin playhead, NOW caption) — replaces the previous capsule + thumb scrubber.
+- `OffScriptProgressBar` reduced to 1px hairline + signal-yellow fill — replaces the gradient capsule.
+- Surface modifier (`offscriptSurface` / `offscriptUtilitySurface`) switched from gradient cards to flat black + 1px hairline; corner radii reduced to 3-6 pt (was 16-32 pt).
+- Typography swapped from Playfair Display to SF Pro Display at light weights with tight tracking; SF Mono with wide tracking for all metadata.
+
+### Fixed
+- CI TestFlight upload: `AppIcon.appiconset/Contents.json` had iOS universal entries with no `filename`, so the asset compiler shipped icon-less bundles and ASC rejected the upload (missing 120/152 px icons + `CFBundleIconName`). Wired `AppIcon.png` into all three iOS universal entries.
+- CI signing: rotated `ASC_KEY_P8_BASE64` GitHub secret to a working API key with provisioning-profile cloud-fetch permissions.
+
+## [1.14.1] and earlier
+
+See git history. Pre-2.0 versions used the warm-amber editorial direction and shipped via manual `xcodebuild` runs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to OffScript
+
+Thanks for the interest. OffScript is currently a single-maintainer project (with some Claude agent work) and **isn't accepting external code contributions yet**. Bug reports, design feedback, and feature ideas are very welcome.
+
+## If you're a TestFlight tester
+
+- **Crashes** are already in Sentry. You don't need to file anything. If you want to add color (what episode you were on, what you tapped right before), open an issue.
+- **Bugs that aren't crashes** (UI weirdness, wrong recommendations, sync issues, audio glitches): please [open a Bug Report issue](https://github.com/zachyzissou/offscript/issues/new?template=bug_report.yml).
+- **Feature ideas**: [open a Feature Request issue](https://github.com/zachyzissou/offscript/issues/new?template=feature_request.yml).
+
+## If you want to read the code
+
+That's encouraged — it's public for transparency. The architecture overview is in [`README.md`](README.md), the design vocabulary is in [`DESIGN.md`](DESIGN.md), and the agent-readable design bible is [`CLAUDE.md`](CLAUDE.md). Re-using anything in your own project requires permission — see [`LICENSE`](LICENSE).
+
+## Codebase guidelines (for the maintainer + agents)
+
+These live in [`CLAUDE.md`](CLAUDE.md), but the most important ones:
+
+- **Use the named tokens.** No inline `Color.white.opacity(0.XX)` or raw `Font.system(...)` — use `offscriptAccent`, `offscriptCard`, `.offscriptHero`, `.offscriptMeta`, etc. The Tuner palette flows through these.
+- **Tuner primitives.** New UI uses `TunerTag`, `TunerLabel`, `TunerRingMeter`, `TunerReadout`, `TunerTransportButton`, `TunerModeToggle`. Don't reinvent.
+- **No bare `try?`.** Always do/catch with OSLog. The categories are per service (`Logger(subsystem: "OffScript", category: "ServiceName")`).
+- **SwiftData.** Use predicate-filtered `FetchDescriptor`, never fetch-all-then-filter. Never `persistentModelID` in `#Predicate` — use stored UUIDs.
+- **Stay in-app.** Never open external URLs without `SFSafariViewController`.
+- **Build the actual project** before declaring something fixed. SourceKit's "Cannot find type in scope" for cross-file types is a false positive — use `xcodebuild` or the Xcode MCP `BuildProject`.
+
+## Releasing
+
+Push to `main` triggers `.github/workflows/testflight.yml`, which archives, runs unit tests, uploads to TestFlight, waits for ASC processing, and writes the release notes from the commit log. No manual steps.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Copyright (c) 2026 Zach Gonser. All rights reserved.
+
+This software and its source code are proprietary. They are not licensed for
+redistribution, modification, or commercial use by any third party at this time.
+The repository is public for transparency and TestFlight tester convenience —
+not as an offer of license.
+
+If you would like to use any portion of this code in your own project, contact
+zachgonser@gmail.com to discuss licensing terms.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,153 @@
+# OffScript
+
+> A podcast app that listens to what *you* listen to — not to whoever paid for placement.
+
+OffScript is an iOS podcast app with **on-device, privacy-first recommendations**. We use Apple's machine learning stack to build a taste profile from your actual listening — no algorithmic feed manipulation, no paid promotions, no tracking-cookie-of-podcasting "for you" page.
+
+The app is currently shipping the **Tuner OLED** design direction — pure black field, signal-yellow accent, instrument-cluster vocabulary. Think Ferrari dashboard for your earphones, not Spotify pastel.
+
+---
+
+## Status
+
+| Area | State |
+|------|-------|
+| Platform | iOS 17+ (SwiftUI / SwiftData) |
+| Distribution | TestFlight beta — internal + external groups |
+| CI | GitHub Actions → TestFlight on push to `main` |
+| Crash + perf telemetry | Sentry (errors-only, quota-aware) + MetricKit |
+| Marketing version | `2.0` (Tuner redesign) |
+
+[![TestFlight Beta](https://github.com/zachyzissou/offscript/actions/workflows/testflight.yml/badge.svg)](https://github.com/zachyzissou/offscript/actions/workflows/testflight.yml)
+
+---
+
+## What's different
+
+**No algorithm, no paid placements.** Recommendations are computed on-device from your listening history, podcasts you've liked, and topics you've spent the most hours on. Nothing about your taste leaves your phone.
+
+**Audio + video, equal billing.** Most podcast apps treat video as an afterthought. We treat them as the same content with different presentation.
+
+**A taste profile you can actually read and edit.** The on-device ML model is exposed in the Profile tab — you can see what topics you're "tuned to," nudge them up or down, and the recommendations re-rank live.
+
+**Editorial pacing.** Your home feed has *one* lead recommendation per session — not 47 cards in 12 rails. The rest is on demand.
+
+---
+
+## Architecture
+
+```
+OffScript/
+├─ App/
+│  ├─ OffScriptApp.swift          @main — boots Sentry, MetricKit, ModelContainer
+│  ├─ ContentView.swift           Tab shell + MiniPlayer mounting
+│  └─ AppTheme.swift              Tuner palette, typography, primitives
+├─ Models/
+│  └─ Models.swift                Podcast / Episode / QueueItem / TasteProfile (SwiftData)
+├─ Services/
+│  ├─ PodcastServices.swift       Search, RSS sync, queue, taste extraction
+│  ├─ PlaybackController.swift    AVPlayer + MPNowPlaying + remote command center
+│  ├─ RecommendationService.swift On-device ranker
+│  └─ CrashReporter.swift         Sentry init (DSN-gated, errors-only)
+├─ Views/
+│  ├─ HomeView                    Lead recommendation + rails
+│  ├─ LibraryView                 Subscribed shows
+│  ├─ SearchView                  iTunes search + import
+│  ├─ QueueView                   Programmed listening sequence
+│  ├─ PlayerView / MiniPlayer     Full + docked playback UI
+│  ├─ EpisodeDetailView           Spec sheet for an episode
+│  ├─ Onboarding/                 POWER ON → genres → channels → import
+│  └─ SettingsView                Tuning, taste profile, downloads
+└─ Assets.xcassets/AppIcon...     Tuner VU dial icon
+```
+
+**SwiftData with versioned migrations** — see `SchemaMigration.swift`. Migrations are non-destructive; the persistent store survives schema bumps.
+
+---
+
+## Development
+
+```bash
+# Open the project (no SPM resolve needed — Xcode handles it)
+open OffScript.xcodeproj
+```
+
+### Required tooling
+
+- **Xcode 26+** (uses Swift 6 / iOS 17 SDK targets)
+- **Ruby + xcodeproj gem** for the project-mutation scripts in `scripts/` (`gem install xcodeproj`)
+- Optional: **Sentry account + DSN** — without it, Sentry init silently no-ops and dev builds work fine
+
+### Configuring Sentry locally
+
+```bash
+cp Config/Secrets.xcconfig.example Config/Secrets.xcconfig
+# Edit Config/Secrets.xcconfig and paste your DSN
+```
+
+`Config/Secrets.xcconfig` is `.gitignore`d. Don't commit it. CI materializes its own copy from the `SENTRY_DSN` GitHub secret.
+
+### Building locally
+
+Standard Xcode build (`Cmd+B`). The `Sentry-Cocoa` SPM package resolves on first build (~5–10 s).
+
+### Running tests
+
+```bash
+xcodebuild test -project OffScript.xcodeproj -scheme OffScript \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
+```
+
+---
+
+## Shipping
+
+We ship via **GitHub Actions → App Store Connect → TestFlight**. Push to `main` → CI archives, runs tests, uploads, waits for ASC processing, then sets the beta release notes from the commit log.
+
+```bash
+# Manual trigger (e.g. for an out-of-band hotfix)
+gh workflow run testflight.yml --ref main \
+  -f marketing_version=2.0 \
+  -f summary="Hotfix: scrubber crash on background-resume"
+```
+
+The full flow lives in [`.github/workflows/testflight.yml`](.github/workflows/testflight.yml). Required secrets:
+
+| Secret | Purpose |
+|--------|---------|
+| `ASC_KEY_ID` | App Store Connect API key id |
+| `ASC_ISSUER_ID` | ASC issuer UUID |
+| `ASC_KEY_P8_BASE64` | Base64-encoded `.p8` private key |
+| `SENTRY_DSN` *(optional)* | Sentry project DSN — when absent, Sentry is disabled in the resulting build |
+
+The build number is auto-generated as `YYYYMMDD<run>.<attempt>` so consecutive pushes never collide.
+
+---
+
+## Design
+
+The full Tuner direction is documented in [`DESIGN.md`](DESIGN.md). Per-component design tokens live in [`OffScript/AppTheme.swift`](OffScript/AppTheme.swift) — palette, typography, `TunerTag` / `TunerRingMeter` / `TunerReadout` / `TunerTransportButton` primitives. Don't introduce inline `Color.white.opacity(0.XX)` or raw `Font.system(...)` — use the named tokens.
+
+The agent-readable design bible is [`CLAUDE.md`](CLAUDE.md).
+
+---
+
+## Telemetry
+
+- **Sentry** captures errors (`.error` and `.fatal` only) + 5% of perf transactions. Screenshots and view hierarchies are off (privacy: episode titles + queue contents are user-identifying). Release tagged as `MARKETING_VERSION-CFBundleVersion`. Environment auto-detected: `debug` / `testflight` / `production`.
+- **MetricKit** subscribes via `MetricKitReporter`. Daily metric payloads land in OSLog (`Console.app`); crash diagnostics get forwarded into Sentry as `.fatal` events with the MetricKit payload as context. Sentry dedupes on stack signature, so already-reported crashes coalesce.
+- **No third-party analytics.** No GA, no Mixpanel, no Segment, no AppsFlyer.
+
+---
+
+## License
+
+Proprietary — not yet open source. See the [LICENSE](LICENSE) file for the current terms (UNLICENSED).
+
+---
+
+## Contributing
+
+OffScript is currently maintained by [@zachyzissou](https://github.com/zachyzissou) with help from various Claude agents. External contributions aren't being accepted yet, but bug reports and feature ideas are welcome via [GitHub Issues](https://github.com/zachyzissou/offscript/issues).
+
+If you're a TestFlight tester and you hit a crash, the report is already in Sentry — you don't have to do anything. Optional: write a short note in an issue with what you were doing right before the crash, which makes triage 10× faster.


### PR DESCRIPTION
## Summary
The repo was effectively undocumented — no README, no contributing guide, no license, no issue/PR templates. This PR adds the basics so the public repo doesn't look abandoned and so TestFlight testers have a clear place to file bugs.

## What's new
| File | What it does |
|------|--------------|
| \`README.md\` | Project pitch, architecture overview, setup, shipping flow, telemetry policy |
| \`LICENSE\` | Proprietary / all-rights-reserved (repo public for transparency, not as an OSS offer) |
| \`CONTRIBUTING.md\` | Tester + maintainer guidelines mirrored from CLAUDE.md |
| \`CHANGELOG.md\` | Keep-a-Changelog format with the 2.0 Tuner direction entry |
| \`.github/ISSUE_TEMPLATE/bug_report.yml\` | Structured bug form (build, device, severity) |
| \`.github/ISSUE_TEMPLATE/feature_request.yml\` | Problem-first feature ideation |
| \`.github/ISSUE_TEMPLATE/config.yml\` | Disables blank issues; routes TestFlight feedback in-app |
| \`.github/PULL_REQUEST_TEMPLATE.md\` | Summary + test plan + risk sections |

Repo metadata updated in the same change: description, topics (\`ios swiftui swiftdata podcast podcast-player on-device-ml privacy-first testflight sentry tuner-ui\`), issues enabled.

## Test plan
- [x] Markdown renders correctly on GitHub (preview)
- [ ] Issue template form renders correctly when clicking "New issue"
- [ ] PR template populates this PR's description (it does — see above)
- [ ] CI badge in README resolves to a valid workflow URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)