### PR TITLE
fix(ci): skip internal beta-group assignment in sync-latest

### DIFF
--- a/scripts/app_store_connect.py
+++ b/scripts/app_store_connect.py
@@ -486,8 +486,30 @@ def command_sync_latest(args: argparse.Namespace) -> None:
         print("Dry run only. Re-run with --apply to add build access to these groups.")
         return
 
-    add_build_to_beta_groups(client, build["id"], [group["id"] for group in missing_groups])
-    print("Applied: latest eligible build now has access to the missing beta groups.")
+    # Apple's TestFlight API does not allow attaching a build to an *internal*
+    # beta group — internal groups auto-provision on every newly-uploaded
+    # eligible build (the request returns 422 ENTITY_UNPROCESSABLE with
+    # "Cannot add internal group to a build"). Only explicit external-group
+    # assignment is supported.
+    external_missing = [
+        g for g in missing_groups
+        if not attrs(g).get("isInternalGroup")
+    ]
+    skipped_internal = [
+        g for g in missing_groups
+        if attrs(g).get("isInternalGroup")
+    ]
+
+    for group in skipped_internal:
+        group_attrs = attrs(group)
+        print(f"Skipping internal group {group_attrs.get('name')!r} — internal groups auto-receive eligible builds")
+
+    if not external_missing:
+        print("Done: no external beta groups need an explicit add (internal groups auto-provision).")
+        return
+
+    add_build_to_beta_groups(client, build["id"], [group["id"] for group in external_missing])
+    print("Applied: latest eligible build now has access to the missing external beta groups.")
 
 
 def command_apps(args: argparse.Namespace) -> None:


### PR DESCRIPTION
## Summary
The TestFlight workflow's last step (\`sync-latest --apply\`) was failing with:
\`\`\`
422 ENTITY_UNPROCESSABLE
Cannot add internal group to a build.
\`\`\`
Apple's TestFlight API doesn't allow manual build attachment to **internal** beta groups — they auto-receive every newly-uploaded eligible build. Only external groups need explicit assignment.

The previous CI run on main (\`24971005994\`) succeeded through archive → export → upload → ASC validation (build \`20260427131\` went VALID), and only failed at this final cosmetic step. So the fix is small and surgical.

## What changed
\`scripts/app_store_connect.py\` \`command_sync_latest\`:
- Filters missing beta groups into internal vs external
- Logs the skipped internal groups (so you can see they exist)
- Calls \`add_build_to_beta_groups\` only for external missing groups
- Returns cleanly when all missing groups are internal-only

## Test plan
- [ ] Merge → CI on main → \`Wait for processing and publish TestFlight notes\` step succeeds
- [ ] Build is visible to "Friends [internal]" group in TestFlight (it auto-receives)
- [ ] Build is NOT yet attached to "Friends [external]" — that group needs review approval first

🤖 Generated with [Claude Code](https://claude.com/claude-code)