### PR TITLE
fix(ci): mark export-compliance exempt so TestFlight builds aren't held

### DIFF
--- a/OffScript.xcodeproj/project.pbxproj
+++ b/OffScript.xcodeproj/project.pbxproj
@@ -418,6 +418,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_SentryDSN = "$(SENTRY_DSN)";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -460,6 +461,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_SentryDSN = "$(SENTRY_DSN)";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;


### PR DESCRIPTION
## Summary
CI uploads were succeeding all the way through ASC validation but never appearing in TestFlight. Root cause: the generated Info.plist was missing \`ITSAppUsesNonExemptEncryption\`, so every CI build got stuck in \`MISSING_EXPORT_COMPLIANCE\` waiting on a human to click through the encryption questionnaire in ASC.

## Fix
- **\`INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO\`** on Debug + Release. OffScript only uses standard HTTPS — qualifies for the export exemption under EAR Category 5 Part 2.
- Already-stuck CI builds (20260427131, 141, 151, 161) PATCHed via the ASC API with \`usesNonExemptEncryption=false\` directly, so they're visible in TestFlight right now without waiting for this PR.

## Test plan
- [x] Local build clean
- [ ] Next CI build lands in TestFlight directly (no \`MISSING_EXPORT_COMPLIANCE\` flag)
- [ ] Existing builds visible in TestFlight pull-to-refresh

## Caveat
If we ever add a feature that does its own encryption (custom DRM, E2EE sync, etc.), revisit — that may push us into needing an EAR exemption letter (form CCATS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)