### PR TITLE
[codex] Add recommendation signal trace UI

### DIFF
--- a/OffScript/AppTheme.swift
+++ b/OffScript/AppTheme.swift
@@ -431,6 +431,36 @@ struct TunerTag: View {
     }
 }
 
+struct RecommendationSignalTraceView: View {
+    let signals: [RecommendationSignal]
+    var limit: Int = 3
+    var color: Color = .offscriptFnInfo
+
+    var body: some View {
+        if !signals.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(signals.prefix(limit)), id: \.self) { signal in
+                    Text(signal.displayText.uppercased())
+                        .font(.system(size: 8.5, weight: .semibold, design: .monospaced))
+                        .tracking(1.2)
+                        .foregroundStyle(color.opacity(0.62))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .padding(.leading, 7)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .overlay(
+                            Rectangle()
+                                .fill(color.opacity(0.4))
+                                .frame(width: 1),
+                            alignment: .leading
+                        )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
 /// Ring meter — colored arc on a hairline base. value 0…1; glyph is the
 /// optical-center text (e.g. "34%", "1.2×", "OFF", "−6"); units optionally sit
 /// inside the ring. Built so a row of meters shares one optical baseline.

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -23,6 +23,18 @@ struct EpisodeDetailView: View {
     @ObservedObject private var downloadService = DownloadService.shared
     @State private var feedbackGiven: PreferenceSignal.Action? = nil
     let episode: Episode
+    let recommendationReason: String?
+    let recommendationSignals: [RecommendationSignal]
+
+    init(
+        episode: Episode,
+        recommendationReason: String? = nil,
+        recommendationSignals: [RecommendationSignal] = []
+    ) {
+        self.episode = episode
+        self.recommendationReason = recommendationReason
+        self.recommendationSignals = recommendationSignals
+    }
 
     private var progressValue: Double {
         guard let duration = episode.duration, duration > 0 else { return 0 }
@@ -42,6 +54,7 @@ struct EpisodeDetailView: View {
                     progressTickStrip
                 }
                 actionRow
+                recommendationSignalSection
                 offlineSection
                 summarySection
                 // Apple-native AI surfaces — all on-device, all hidden when
@@ -212,6 +225,29 @@ struct EpisodeDetailView: View {
             DownloadButton(episode: episode)
 
             Spacer()
+        }
+    }
+
+    // ── Recommendation signal ───────────────────────────────────────
+    @ViewBuilder
+    private var recommendationSignalSection: some View {
+        if let recommendationReason, !recommendationReason.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                TunerLabel(text: "WHY THIS · LOCAL SIGNAL", color: .offscriptSignalYellow)
+                TunerTag(text: recommendationReason, color: .offscriptSignalYellow, dim: true)
+                RecommendationSignalTraceView(signals: recommendationSignals)
+                Text("This comes from local listening, queue, and preference signals on this device.")
+                    .font(.system(size: 12.5, weight: .regular))
+                    .foregroundStyle(Color.offscriptPaperWhite.opacity(0.74))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .overlay(
+                Rectangle().fill(Color.offscriptHairline).frame(height: 1),
+                alignment: .top
+            )
+            .accessibilityIdentifier("RecommendationSignalSection")
         }
     }
 

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -43,10 +43,11 @@ struct HomeView: View {
                     // to work with, `sections` populates and this hides.
                     HomeStarterRail()
                 } else {
-                    if let leadSection = sections.first, let leadEpisode = leadSection.episodes.first {
+                    if let leadSection = sections.first, let leadScoredEpisode = leadSection.scoredEpisodes.first {
                         HeroTunerCard(
-                            episode: leadEpisode,
-                            reason: leadSection.explanation(for: leadEpisode)
+                            episode: leadScoredEpisode.episode,
+                            reason: leadScoredEpisode.explanation,
+                            signals: leadScoredEpisode.signalTrace
                         )
                         .padding(.horizontal, OffScriptTheme.pagePadding)
                         .padding(.bottom, 6)
@@ -56,7 +57,8 @@ struct HomeView: View {
                             TunerRail(
                                 title: "NEXT BEST PICKS",
                                 episodes: remainingLeadEpisodes,
-                                reasonProvider: { leadSection.explanation(for: $0) }
+                                reasonProvider: { leadSection.explanation(for: $0) },
+                                signalProvider: { leadSection.signalTrace(for: $0) }
                             )
                         }
                     }
@@ -65,7 +67,8 @@ struct HomeView: View {
                         TunerRail(
                             title: section.title.uppercased(),
                             episodes: section.episodes,
-                            reasonProvider: { section.explanation(for: $0) }
+                            reasonProvider: { section.explanation(for: $0) },
+                            signalProvider: { section.signalTrace(for: $0) }
                         )
                     }
                 }
@@ -421,6 +424,7 @@ private struct HeroTunerCard: View {
 
     let episode: Episode
     let reason: String
+    let signals: [RecommendationSignal]
 
     private var progressValue: Double {
         guard let duration = episode.duration, duration > 0 else { return 0 }
@@ -453,7 +457,11 @@ private struct HeroTunerCard: View {
             // Title + reason
             VStack(alignment: .leading, spacing: 10) {
                 NavigationLink {
-                    EpisodeDetailView(episode: episode)
+                    EpisodeDetailView(
+                        episode: episode,
+                        recommendationReason: reason,
+                        recommendationSignals: signals
+                    )
                 } label: {
                     Text(episode.title)
                         .font(.system(size: 20, weight: .semibold))
@@ -467,6 +475,7 @@ private struct HeroTunerCard: View {
 
                 // Reason as a TunerTag with signal yellow accent
                 TunerTag(text: reason, color: .offscriptSignalYellow, dim: true)
+                RecommendationSignalTraceView(signals: signals)
 
                 // Mono metadata — date · duration. The "X LEFT" remaining
                 // time used to render here AND in the explanation tag above
@@ -582,6 +591,7 @@ private struct TunerRail: View {
     let title: String
     let episodes: [Episode]
     let reasonProvider: (Episode) -> String
+    let signalProvider: (Episode) -> [RecommendationSignal]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -595,7 +605,11 @@ private struct TunerRail: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 10) {
                     ForEach(episodes) { episode in
-                        TunerRailCard(episode: episode, reason: reasonProvider(episode))
+                        TunerRailCard(
+                            episode: episode,
+                            reason: reasonProvider(episode),
+                            signals: signalProvider(episode)
+                        )
                     }
                 }
                 .padding(.horizontal, OffScriptTheme.pagePadding)
@@ -608,11 +622,16 @@ private struct TunerRailCard: View {
     @Environment(\.modelContext) private var modelContext
     let episode: Episode
     let reason: String
+    let signals: [RecommendationSignal]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationLink {
-                EpisodeDetailView(episode: episode)
+                EpisodeDetailView(
+                    episode: episode,
+                    recommendationReason: reason,
+                    recommendationSignals: signals
+                )
             } label: {
                 VStack(alignment: .leading, spacing: 8) {
                     OffScriptArtworkView(url: episode.artworkURL ?? episode.podcast.artworkURL, cornerRadius: 3)
@@ -630,6 +649,7 @@ private struct TunerRailCard: View {
                         .frame(width: 168, alignment: .leading)
 
                     TunerTag(text: reason, color: .offscriptSignalYellow, dim: true)
+                    RecommendationSignalTraceView(signals: signals, limit: 2, color: .offscriptSoftPaper)
 
                     TunerLabel(text: metadata, color: .offscriptSoftPaper, size: 8)
                 }

--- a/OffScript/Models.swift
+++ b/OffScript/Models.swift
@@ -403,6 +403,10 @@ struct HomeFeedSection: Identifiable {
         scoredEpisodes.first(where: { $0.episode.id == episode.id })?.explanation
             ?? "Subscribed channel: \(episode.podcast.title)"
     }
+
+    func signalTrace(for episode: Episode) -> [RecommendationSignal] {
+        scoredEpisodes.first(where: { $0.episode.id == episode.id })?.signalTrace ?? []
+    }
 }
 
 @Model

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -637,6 +637,7 @@ private struct PlayerSuggestionRow: View {
 
             VStack(alignment: .leading, spacing: 3) {
                 TunerTag(text: scored.explanation, color: .offscriptSignalYellow, dim: true)
+                RecommendationSignalTraceView(signals: scored.signalTrace, limit: 2, color: .offscriptSoftPaper)
                 Text(scored.episode.title)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(Color.offscriptPaperWhite)

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -166,7 +166,8 @@ final class RecommendationService {
                 return ScoredEpisode(
                     episode: episode,
                     score: result.score,
-                    explanation: result.explanation
+                    explanation: result.explanation,
+                    signalTrace: result.signalTrace
                 )
             }
             .sorted { $0.score > $1.score }
@@ -216,7 +217,7 @@ final class RecommendationService {
     private func homeSignal(
         episode: Episode,
         context: ScoringContext
-    ) -> (score: Double, explanation: String)? {
+    ) -> (score: Double, explanation: String, signalTrace: [RecommendationSignal])? {
         let profile = context.profileByEpisodeID[episode.id]
         let profileTags = Self.normalizedTags(profile?.tags ?? [])
         let matchingLikedTags = profileTags.intersection(context.likedTags)
@@ -238,7 +239,11 @@ final class RecommendationService {
             let positionLabel = queuePosition == 0 ? "first" : "#\(queuePosition + 1)"
             return (
                 500 - Double(queuePosition * 10) + freshnessTieBreak,
-                "You put this \(positionLabel) in queue"
+                "You put this \(positionLabel) in queue",
+                [
+                    RecommendationSignal(label: "source", value: "queue"),
+                    RecommendationSignal(label: "position", value: positionLabel)
+                ]
             )
         }
 
@@ -246,7 +251,11 @@ final class RecommendationService {
             let remaining = max(0, (episode.duration ?? 0) - episode.playedPosition)
             return (
                 420 + freshnessTieBreak + durationTieBreak,
-                "\(EpisodeDurationFormatter.short(remaining)) left from your last session"
+                "\(EpisodeDurationFormatter.short(remaining)) left from your last session",
+                [
+                    RecommendationSignal(label: "source", value: "resume"),
+                    RecommendationSignal(label: "left", value: EpisodeDurationFormatter.short(remaining))
+                ]
             )
         }
 
@@ -255,7 +264,12 @@ final class RecommendationService {
             let showSignal = max(completedShowCount, 1)
             return (
                 320 + Double(min(showSignal, 5)) * 18 + freshnessTieBreak + qualityTieBreak,
-                "You keep finishing \(episode.podcast.title)"
+                "You keep finishing \(episode.podcast.title)",
+                [
+                    RecommendationSignal(label: "source", value: "completion"),
+                    RecommendationSignal(label: "show", value: episode.podcast.title),
+                    RecommendationSignal(label: "finishes", value: "\(showSignal)")
+                ]
             )
         }
 
@@ -263,7 +277,11 @@ final class RecommendationService {
             let sample = matchingTags.sorted().prefix(2).joined(separator: ", ")
             return (
                 260 + Double(min(matchingTags.count, 4)) * 16 + freshnessTieBreak + qualityTieBreak,
-                "Matches your saved signal: \(sample)"
+                "Matches your saved signal: \(sample)",
+                [
+                    RecommendationSignal(label: "source", value: "tag match"),
+                    RecommendationSignal(label: "tags", value: sample)
+                ]
             )
         }
 
@@ -272,14 +290,22 @@ final class RecommendationService {
             let genre = genreMatches.sorted().first ?? "saved genre"
             return (
                 210 + freshnessTieBreak + durationTieBreak,
-                "Matches your selected \(genre) lane"
+                "Matches your selected \(genre) lane",
+                [
+                    RecommendationSignal(label: "source", value: "genre"),
+                    RecommendationSignal(label: "lane", value: genre)
+                ]
             )
         }
 
         if AppSettings.preferShortEpisodes, minutes <= 35 {
             return (
                 190 + durationTieBreak + qualityTieBreak,
-                "Fits your short-listen setting"
+                "Fits your short-listen setting",
+                [
+                    RecommendationSignal(label: "source", value: "duration"),
+                    RecommendationSignal(label: "window", value: EpisodeDurationFormatter.short(episode.duration ?? 0))
+                ]
             )
         }
 
@@ -290,7 +316,7 @@ final class RecommendationService {
         episode: Episode,
         context: ScoringContext,
         diversityPenalty: Double = 0
-    ) -> (score: Double, explanation: String) {
+    ) -> (score: Double, explanation: String, signalTrace: [RecommendationSignal]) {
         let profile = context.profileByEpisodeID[episode.id]
         let profileTags = Self.normalizedTags(profile?.tags ?? [])
         let matchingTags = profileTags.intersection(context.likedTags)
@@ -337,32 +363,73 @@ final class RecommendationService {
         }
 
         let explanation: String
+        let signalTrace: [RecommendationSignal]
         if isUnfinished {
             let remaining = max(0, (episode.duration ?? 0) - episode.playedPosition)
             explanation = "\(EpisodeDurationFormatter.short(remaining)) left — pick up where you stopped"
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "resume"),
+                RecommendationSignal(label: "left", value: EpisodeDurationFormatter.short(remaining))
+            ]
         } else if context.showAffinity.contains(episode.podcast.title) {
             explanation = "You keep finishing \(episode.podcast.title)"
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "show affinity"),
+                RecommendationSignal(label: "show", value: episode.podcast.title)
+            ]
         } else if overlap >= 3 {
             let sample = Array(matchingTags.prefix(2)).joined(separator: ", ")
             explanation = "\(Int(overlap)) topic matches: \(sample)"
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "topic overlap"),
+                RecommendationSignal(label: "tags", value: sample)
+            ]
         } else if let topTag = profileTags.intersection(context.topTags).first {
             explanation = "Fits your recent interest in \"\(topTag)\""
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "recent interest"),
+                RecommendationSignal(label: "tag", value: topTag)
+            ]
         } else if overlap >= 1 {
             let sample = matchingTags.first ?? ""
             explanation = "Connects to \"\(sample)\" from episodes you liked"
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "liked episode"),
+                RecommendationSignal(label: "tag", value: sample)
+            ]
         } else if days <= 1 {
             explanation = "Dropped today from \(episode.podcast.title)"
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "fresh"),
+                RecommendationSignal(label: "show", value: episode.podcast.title)
+            ]
         } else if days <= 3 {
             explanation = "Fresh from \(episode.podcast.title) — \(Int(days))d ago"
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "fresh"),
+                RecommendationSignal(label: "age", value: "\(Int(days))d")
+            ]
         } else if minutes <= 20 {
             explanation = "Quick \(EpisodeDurationFormatter.short(episode.duration ?? 0)) listen"
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "duration"),
+                RecommendationSignal(label: "window", value: EpisodeDurationFormatter.short(episode.duration ?? 0))
+            ]
         } else if episode.podcast.isSubscribed {
             explanation = "Subscribed channel: \(episode.podcast.title)"
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "subscription"),
+                RecommendationSignal(label: "show", value: episode.podcast.title)
+            ]
         } else {
             explanation = "Available from \(episode.podcast.title)"
+            signalTrace = [
+                RecommendationSignal(label: "source", value: "available"),
+                RecommendationSignal(label: "show", value: episode.podcast.title)
+            ]
         }
 
-        return (value, explanation)
+        return (value, explanation, signalTrace)
     }
 
     /// Returns contextual recommendations for the player based on the currently playing episode
@@ -411,7 +478,14 @@ final class RecommendationService {
                 // Boost same podcast
                 if episode.podcast.id == currentPodcastID {
                     score += 0.15
-                    result = (score, "More from \(episode.podcast.title)")
+                    result = (
+                        score,
+                        "More from \(episode.podcast.title)",
+                        [
+                            RecommendationSignal(label: "source", value: "same show"),
+                            RecommendationSignal(label: "show", value: episode.podcast.title)
+                        ]
+                    )
                 }
 
                 // Boost episodes with overlapping tags to current episode
@@ -422,11 +496,18 @@ final class RecommendationService {
                     score += Double(currentOverlap.count) * 0.05
                     if episode.podcast.id != currentPodcastID {
                         let tag = currentOverlap.first ?? ""
-                        result = (score, "Also covers \"\(tag)\"")
+                        result = (
+                            score,
+                            "Also covers \"\(tag)\"",
+                            [
+                                RecommendationSignal(label: "source", value: "now playing"),
+                                RecommendationSignal(label: "tag", value: tag)
+                            ]
+                        )
                     }
                 }
 
-                return ScoredEpisode(episode: episode, score: score, explanation: result.explanation)
+                return ScoredEpisode(episode: episode, score: score, explanation: result.explanation, signalTrace: result.signalTrace)
             }
             .sorted { $0.score > $1.score }
             .prefix(limit)
@@ -521,8 +602,25 @@ final class RecommendationService {
     }
 }
 
+struct RecommendationSignal: Hashable {
+    let label: String
+    let value: String
+
+    var displayText: String {
+        "\(label): \(value)"
+    }
+}
+
 struct ScoredEpisode {
     let episode: Episode
     let score: Double
     let explanation: String
+    let signalTrace: [RecommendationSignal]
+
+    init(episode: Episode, score: Double, explanation: String, signalTrace: [RecommendationSignal] = []) {
+        self.episode = episode
+        self.score = score
+        self.explanation = explanation
+        self.signalTrace = signalTrace
+    }
 }

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -233,6 +233,7 @@ struct OffScriptTests {
         #expect(sections.first?.title == "Signal Lock")
         #expect(sections.first?.episodes.first?.id == queued.id)
         #expect(sections.first?.explanation(for: queued).contains("queue") == true)
+        #expect(sections.first?.signalTrace(for: queued).contains(RecommendationSignal(label: "source", value: "queue")) == true)
         #expect(sections.flatMap(\.episodes).contains(where: { $0.id == fresh.id }) == false)
     }
 
@@ -283,6 +284,8 @@ struct OffScriptTests {
 
         #expect(firstEpisode?.id == olderFromAffinity.id)
         #expect(sections.first?.explanation(for: olderFromAffinity) == "You keep finishing Finished Show")
+        #expect(sections.first?.signalTrace(for: olderFromAffinity).contains(RecommendationSignal(label: "source", value: "completion")) == true)
+        #expect(sections.first?.signalTrace(for: olderFromAffinity).contains(RecommendationSignal(label: "show", value: "Finished Show")) == true)
         #expect(sections.flatMap(\.episodes).contains(where: { $0.id == freshRandom.id }) == false)
     }
 
@@ -335,6 +338,54 @@ struct OffScriptTests {
         let sections = try RecommendationService().homeSections(context: context, limit: 3)
 
         #expect(sections.flatMap(\.episodes).contains(where: { $0.id == episode.id }) == false)
+    }
+
+    @Test
+    @MainActor
+    func playerSuggestionsExposeNowPlayingSignalTrace() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let currentPodcast = Podcast(title: "Now Playing", feedURL: URL(string: "https://example.com/current.xml")!)
+        let relatedPodcast = Podcast(title: "Related", feedURL: URL(string: "https://example.com/related.xml")!)
+        let current = Episode(
+            title: "Current Episode",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/current.mp3")!,
+            podcast: currentPodcast
+        )
+        let related = Episode(
+            title: "Shared Signal",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/related.mp3")!,
+            podcast: relatedPodcast
+        )
+        let currentProfile = EpisodeProfile(episodeID: current.id)
+        currentProfile.tags = ["audio craft", "interviews"]
+        let relatedProfile = EpisodeProfile(episodeID: related.id)
+        relatedProfile.tags = ["audio craft"]
+
+        context.insert(currentPodcast)
+        context.insert(relatedPodcast)
+        context.insert(current)
+        context.insert(related)
+        context.insert(currentProfile)
+        context.insert(relatedProfile)
+        try context.save()
+
+        let suggestions = try RecommendationService().playerSuggestions(
+            currentEpisode: current,
+            context: context,
+            limit: 3
+        )
+        let scored = try #require(suggestions.first)
+
+        #expect(scored.episode.id == related.id)
+        #expect(scored.explanation == "Also covers \"audio craft\"")
+        #expect(scored.signalTrace.contains(RecommendationSignal(label: "source", value: "now playing")))
+        #expect(scored.signalTrace.contains(RecommendationSignal(label: "tag", value: "audio craft")))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- carry structured local recommendation signals alongside scored episodes
- render compact Tuner signal traces in Home hero/rails and Player what's-next rows
- preserve recommendation context when opening Episode Detail with a WHY THIS · LOCAL SIGNAL panel
- add regression coverage for queue, completion, and now-playing signal traces

## Verification
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -derivedDataPath /tmp/OffScriptDerivedData2 CODE_SIGNING_ALLOWED=NO
  - 27 unit tests passed
  - 3 UI tests passed
  - result: ** TEST SUCCEEDED **