### PR TITLE
Clean up discovery Swift isolation warnings

### DIFF
--- a/OffScript/AppSettings.swift
+++ b/OffScript/AppSettings.swift
@@ -45,7 +45,7 @@ enum AppSettings {
         case recentlyPlayed
     }
 
-    enum RecommendationMode: String, CaseIterable {
+    nonisolated enum RecommendationMode: String, CaseIterable {
         case signalLocked
         case balanced
         case discovery

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -52,8 +52,8 @@ enum PodcastPreviewService {
     }
 }
 
-struct PodcastSearchService {
-    func search(query: String) async throws -> [PodcastSearchResult] {
+nonisolated struct PodcastSearchService {
+    nonisolated func search(query: String) async throws -> [PodcastSearchResult] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
 
@@ -576,11 +576,11 @@ enum QueueService {
 }
 
 
-private struct ItunesSearchResponse: Decodable {
+nonisolated private struct ItunesSearchResponse: Decodable {
     let results: [ItunesPodcast]
 }
 
-private struct ItunesPodcast: Decodable {
+nonisolated private struct ItunesPodcast: Decodable {
     let collectionName: String
     let artistName: String
     let feedURL: URL?


### PR DESCRIPTION
## Summary
- Mark recommendation mode values nonisolated so discovery actors can read tuner limits without Swift 6 actor-isolation warnings.
- Mark iTunes search DTO/service code nonisolated so background discovery search can decode results without main-actor leakage.

## Verification
- `xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/OffScriptDerivedDataWarnings CODE_SIGNING_ALLOWED=NO 2>&1 | rg -n "DiscoveryService.swift|PodcastServices.swift|warning:|error:"` confirmed no DiscoveryService/PodcastServices warnings remain.
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -derivedDataPath /tmp/OffScriptDerivedData3 CODE_SIGNING_ALLOWED=NO`
- `git diff --check`