### PR TITLE
Fix background and silent-switch playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ### Changed — taste profile quality
 - **Taste refresh now uses weighted, decayed evidence instead of equal counts.** Recent explicit `More like this` signals beat old passive completions, while `Less like this`, `Not interested`, quick skips, and abandons demote matching tags and shows.
 
+### Fixed — playback audio session
+- **Playback now uses an iOS-supported `.playback` audio-session configuration** instead of pairing the `.longFormAudio` route-sharing policy with AirPlay/Bluetooth category options. iOS rejects that combination with `OSStatus -50`; when the category set fails, the app falls back toward Silent-Mode-bound foreground audio. Keeping the session on `.playback` is what lets podcast audio survive lock, backgrounding, and the ringer switch.
+
 ### Fixed — Apple identity / iCloud sync state
 - **Settings now validates stored Sign in with Apple credentials** before treating the user as signed in. Revoked or missing credentials clear local identity and disable sync.
 - **iCloud account availability is checked separately from Apple identity.** Sign in with Apple no longer blindly enables sync when CloudKit is unavailable on the device.

--- a/OffScript.xcodeproj/project.pbxproj
+++ b/OffScript.xcodeproj/project.pbxproj
@@ -472,7 +472,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OffScript/OffScript.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 363TRR79UG;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -488,7 +488,7 @@
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
-				INFOPLIST_KEY_UIBackgroundModes = "audio fetch";
+				INFOPLIST_KEY_UIBackgroundModes = "audio processing";
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
@@ -520,7 +520,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OffScript/OffScript.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 363TRR79UG;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -536,7 +536,7 @@
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
-				INFOPLIST_KEY_UIBackgroundModes = "audio fetch";
+				INFOPLIST_KEY_UIBackgroundModes = "audio processing";
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
@@ -565,7 +565,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 2.3.11;
@@ -588,7 +588,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 2.3.11;
@@ -610,7 +610,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 2.3.11;
@@ -632,7 +632,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 2.3.11;
@@ -657,7 +657,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = OffScriptWidgets/OffScriptWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 363TRR79UG;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OffScriptWidgets/Info.plist;
@@ -687,7 +687,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = OffScriptWidgets/OffScriptWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 363TRR79UG;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OffScriptWidgets/Info.plist;

--- a/OffScript.xcodeproj/project.pbxproj
+++ b/OffScript.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
-				INFOPLIST_KEY_UIBackgroundModes = "audio processing";
+				INFOPLIST_KEY_UIBackgroundModes = "audio fetch processing";
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
@@ -536,7 +536,7 @@
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
-				INFOPLIST_KEY_UIBackgroundModes = "audio processing";
+				INFOPLIST_KEY_UIBackgroundModes = "audio fetch processing";
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;

--- a/OffScript/Info.plist
+++ b/OffScript/Info.plist
@@ -38,9 +38,10 @@
 		<string>LaunchBackground</string>
 	</dict>
 	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-		<string>processing</string>
-	</array>
-</dict>
+		<array>
+			<string>audio</string>
+			<string>fetch</string>
+			<string>processing</string>
+		</array>
+	</dict>
 </plist>

--- a/OffScript/PlaybackController.swift
+++ b/OffScript/PlaybackController.swift
@@ -6,6 +6,15 @@ import SwiftData
 import SwiftUI
 import UIKit
 
+#if os(iOS)
+enum OffScriptAudioSessionConfiguration {
+    static let category: AVAudioSession.Category = .playback
+    static let mode: AVAudioSession.Mode = .spokenAudio
+    static let options: AVAudioSession.CategoryOptions = [.allowAirPlay, .allowBluetoothA2DP]
+    static let usesExplicitRouteSharingPolicy = false
+}
+#endif
+
 @MainActor
 final class PlaybackController: ObservableObject {
     static let shared = PlaybackController()
@@ -421,11 +430,16 @@ final class PlaybackController: ObservableObject {
         #if os(iOS)
         let session = AVAudioSession.sharedInstance()
         do {
-            // .playback + .spokenAudio + .longFormAudio is the supported combo
-            // for podcast apps that need lock-screen controls and background
-            // audio. .longFormAudio prevents iOS from quietly switching us
-            // into a duck-other-audio category.
-            try session.setCategory(.playback, mode: .spokenAudio, policy: .longFormAudio, options: [.allowAirPlay, .allowBluetoothA2DP])
+            // .playback is what makes podcast audio ignore Silent Mode and
+            // continue under lock/background when UIBackgroundModes includes
+            // audio. Do not pass .longFormAudio here: iOS rejects that route
+            // sharing policy when paired with our AirPlay/Bluetooth options,
+            // leaving the app on the default Silent-Mode-bound category.
+            try session.setCategory(
+                OffScriptAudioSessionConfiguration.category,
+                mode: OffScriptAudioSessionConfiguration.mode,
+                options: OffScriptAudioSessionConfiguration.options
+            )
         } catch {
             logger.error("AVAudioSession setCategory failed: \(error.localizedDescription, privacy: .public)")
         }

--- a/OffScript/PlaybackController.swift
+++ b/OffScript/PlaybackController.swift
@@ -7,11 +7,21 @@ import SwiftUI
 import UIKit
 
 #if os(iOS)
+protocol OffScriptAudioSessionApplying {
+    func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode, options: AVAudioSession.CategoryOptions) throws
+    func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode, policy: AVAudioSession.RouteSharingPolicy, options: AVAudioSession.CategoryOptions) throws
+}
+
+extension AVAudioSession: OffScriptAudioSessionApplying {}
+
 enum OffScriptAudioSessionConfiguration {
     static let category: AVAudioSession.Category = .playback
     static let mode: AVAudioSession.Mode = .spokenAudio
     static let options: AVAudioSession.CategoryOptions = [.allowAirPlay, .allowBluetoothA2DP]
-    static let routeSharingPolicy: AVAudioSession.RouteSharingPolicy? = nil
+
+    static func apply(to session: OffScriptAudioSessionApplying) throws {
+        try session.setCategory(category, mode: mode, options: options)
+    }
 }
 #endif
 
@@ -435,20 +445,7 @@ final class PlaybackController: ObservableObject {
             // audio. Do not pass .longFormAudio here: iOS rejects that route
             // sharing policy when paired with our AirPlay/Bluetooth options,
             // leaving the app on the default Silent-Mode-bound category.
-            if let routeSharingPolicy = OffScriptAudioSessionConfiguration.routeSharingPolicy {
-                try session.setCategory(
-                    OffScriptAudioSessionConfiguration.category,
-                    mode: OffScriptAudioSessionConfiguration.mode,
-                    policy: routeSharingPolicy,
-                    options: OffScriptAudioSessionConfiguration.options
-                )
-            } else {
-                try session.setCategory(
-                    OffScriptAudioSessionConfiguration.category,
-                    mode: OffScriptAudioSessionConfiguration.mode,
-                    options: OffScriptAudioSessionConfiguration.options
-                )
-            }
+            try OffScriptAudioSessionConfiguration.apply(to: session)
         } catch {
             logger.error("AVAudioSession setCategory failed: \(error.localizedDescription, privacy: .public)")
         }

--- a/OffScript/PlaybackController.swift
+++ b/OffScript/PlaybackController.swift
@@ -11,7 +11,7 @@ enum OffScriptAudioSessionConfiguration {
     static let category: AVAudioSession.Category = .playback
     static let mode: AVAudioSession.Mode = .spokenAudio
     static let options: AVAudioSession.CategoryOptions = [.allowAirPlay, .allowBluetoothA2DP]
-    static let usesExplicitRouteSharingPolicy = false
+    static let routeSharingPolicy: AVAudioSession.RouteSharingPolicy? = nil
 }
 #endif
 
@@ -435,11 +435,20 @@ final class PlaybackController: ObservableObject {
             // audio. Do not pass .longFormAudio here: iOS rejects that route
             // sharing policy when paired with our AirPlay/Bluetooth options,
             // leaving the app on the default Silent-Mode-bound category.
-            try session.setCategory(
-                OffScriptAudioSessionConfiguration.category,
-                mode: OffScriptAudioSessionConfiguration.mode,
-                options: OffScriptAudioSessionConfiguration.options
-            )
+            if let routeSharingPolicy = OffScriptAudioSessionConfiguration.routeSharingPolicy {
+                try session.setCategory(
+                    OffScriptAudioSessionConfiguration.category,
+                    mode: OffScriptAudioSessionConfiguration.mode,
+                    policy: routeSharingPolicy,
+                    options: OffScriptAudioSessionConfiguration.options
+                )
+            } else {
+                try session.setCategory(
+                    OffScriptAudioSessionConfiguration.category,
+                    mode: OffScriptAudioSessionConfiguration.mode,
+                    options: OffScriptAudioSessionConfiguration.options
+                )
+            }
         } catch {
             logger.error("AVAudioSession setCategory failed: \(error.localizedDescription, privacy: .public)")
         }

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -12,7 +12,7 @@ struct OffScriptTests {
         #expect(OffScriptAudioSessionConfiguration.mode == .spokenAudio)
         #expect(OffScriptAudioSessionConfiguration.options.contains(.allowAirPlay))
         #expect(OffScriptAudioSessionConfiguration.options.contains(.allowBluetoothA2DP))
-        #expect(!OffScriptAudioSessionConfiguration.usesExplicitRouteSharingPolicy)
+        #expect(OffScriptAudioSessionConfiguration.routeSharingPolicy == nil)
         #endif
     }
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -21,6 +21,7 @@ struct OffScriptTests {
         #expect(session.options.contains(.allowAirPlay))
         #expect(session.options.contains(.allowBluetoothA2DP))
         #expect(session.routeSharingPolicy == nil)
+        #expect(session.didCallSetCategoryWithPolicy == false)
         #endif
     }
 
@@ -1014,6 +1015,7 @@ private final class RecordingAudioSession: OffScriptAudioSessionApplying {
     private(set) var mode: AVAudioSession.Mode?
     private(set) var options: AVAudioSession.CategoryOptions = []
     private(set) var routeSharingPolicy: AVAudioSession.RouteSharingPolicy?
+    private(set) var didCallSetCategoryWithPolicy = false
 
     func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode, options: AVAudioSession.CategoryOptions) throws {
         self.category = category
@@ -1032,6 +1034,7 @@ private final class RecordingAudioSession: OffScriptAudioSessionApplying {
         self.mode = mode
         self.options = options
         routeSharingPolicy = policy
+        didCallSetCategoryWithPolicy = true
     }
 }
 #endif

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -6,13 +6,21 @@ import Testing
 
 struct OffScriptTests {
     @Test
-    func playbackAudioSessionUsesSilentSwitchSafeCategory() {
+    func playbackAudioSessionUsesSilentSwitchSafeCategory() throws {
         #if os(iOS)
+        let session = RecordingAudioSession()
+
+        try OffScriptAudioSessionConfiguration.apply(to: session)
+
         #expect(OffScriptAudioSessionConfiguration.category == .playback)
         #expect(OffScriptAudioSessionConfiguration.mode == .spokenAudio)
         #expect(OffScriptAudioSessionConfiguration.options.contains(.allowAirPlay))
         #expect(OffScriptAudioSessionConfiguration.options.contains(.allowBluetoothA2DP))
-        #expect(OffScriptAudioSessionConfiguration.routeSharingPolicy == nil)
+        #expect(session.category == .playback)
+        #expect(session.mode == .spokenAudio)
+        #expect(session.options.contains(.allowAirPlay))
+        #expect(session.options.contains(.allowBluetoothA2DP))
+        #expect(session.routeSharingPolicy == nil)
         #endif
     }
 
@@ -999,3 +1007,31 @@ struct OffScriptTests {
         return try ModelContainer(for: schema, configurations: [configuration])
     }
 }
+
+#if os(iOS)
+private final class RecordingAudioSession: OffScriptAudioSessionApplying {
+    private(set) var category: AVAudioSession.Category?
+    private(set) var mode: AVAudioSession.Mode?
+    private(set) var options: AVAudioSession.CategoryOptions = []
+    private(set) var routeSharingPolicy: AVAudioSession.RouteSharingPolicy?
+
+    func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode, options: AVAudioSession.CategoryOptions) throws {
+        self.category = category
+        self.mode = mode
+        self.options = options
+        routeSharingPolicy = nil
+    }
+
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        policy: AVAudioSession.RouteSharingPolicy,
+        options: AVAudioSession.CategoryOptions
+    ) throws {
+        self.category = category
+        self.mode = mode
+        self.options = options
+        routeSharingPolicy = policy
+    }
+}
+#endif

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1,9 +1,21 @@
+import AVFoundation
 import Foundation
 import SwiftData
 import Testing
 @testable import OffScript
 
 struct OffScriptTests {
+    @Test
+    func playbackAudioSessionUsesSilentSwitchSafeCategory() {
+        #if os(iOS)
+        #expect(OffScriptAudioSessionConfiguration.category == .playback)
+        #expect(OffScriptAudioSessionConfiguration.mode == .spokenAudio)
+        #expect(OffScriptAudioSessionConfiguration.options.contains(.allowAirPlay))
+        #expect(OffScriptAudioSessionConfiguration.options.contains(.allowBluetoothA2DP))
+        #expect(!OffScriptAudioSessionConfiguration.usesExplicitRouteSharingPolicy)
+        #endif
+    }
+
     @Test
     func recommendationScoreRewardsBetterFit() {
         let strongFit = RecommendationScorer.score(


### PR DESCRIPTION
## Summary
- remove the unsupported AVAudioSession .longFormAudio route-sharing policy from podcast playback setup
- keep the app on .playback + .spokenAudio with AirPlay/Bluetooth options so audio is not tied to Silent Mode/default foreground playback
- align source/generated UIBackgroundModes as audio + fetch + processing and bump build 2.3.11 (38)
- add a regression test for the intended audio-session configuration

## Root Cause
The app already had UIBackgroundModes/audio. The failure was the session category call itself: the previous setCategory(.playback, mode: .spokenAudio, policy: .longFormAudio, options: [.allowAirPlay, .allowBluetoothA2DP]) combination is rejected by iOS with OSStatus -50. When that call fails, the session does not reliably stick to .playback, which matches the reported symptoms: audio stops on lock/background and obeys the ringer/silent switch.

## Verification
- Xcode MCP BuildProject: succeeded before PR and after Copilot follow-up
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -derivedDataPath /tmp/OffScriptDerivedDataAudio CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -derivedDataPath /tmp/OffScriptDerivedDataAudio2 CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -derivedDataPath /tmp/OffScriptDerivedDataAudio3 CODE_SIGNING_ALLOWED=NO
- processed app plist check: CFBundleVersion 38 and UIBackgroundModes [audio, fetch, processing]
- scripts/app_store_connect.py doctor: build 2.3.11 (38) not yet uploaded; latest uploaded build 37 remains internal-only

## Device Note
Simulator tests cannot physically validate the hardware silent switch or locked-device background playback. This patch directly fixes the logged failing AVAudioSession call that would cause those exact device behaviors.