### PR TITLE
Fix Library alphabet jump rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ### Added — UI QA swarm coverage
 - **Large-library UI smoke coverage now seeds a deterministic 258-show library** and launches directly into Library, giving the 250+ show scrolling case a repeatable simulator test instead of a manual-only complaint.
 - **Debug large-library seeding now resets stale simulator data when an explicit library size is requested**, so visual audits and UI tests are not polluted by previous sample stores.
+- **Large-library UI coverage now verifies alphabet directory jumps** by tapping the `Z` key in a 258-show Library and asserting the list scrolls to the `Z` section.
 
 ### Changed — Tuner UI conformance
 - **Shared Tuner labels, tags, and readouts now scale through Dynamic Type metrics** while preserving the mono instrument-panel vocabulary.
@@ -27,6 +28,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ### Added — large-library directory controls
 - **Library now behaves like a real channel directory for 250+ show libraries.** The shows list has Tuner-styled search, scope filters, sort modes, compact/artwork row density, visible-count readouts, and an A-Z jump rail so large OPML imports are navigable without endless scrolling.
 - **Large libraries default to compact rows.** Artwork-heavy rows remain available for smaller libraries, but 120+ show libraries automatically use dense Tuner rows to reduce scroll distance and image/layout churn.
+- **The alphabet jump rail is now a full A-Z/# key bank with selected and disabled states** so large libraries expose every directory letter as a direct Tuner control instead of hiding letters in a horizontal strip.
 
 ### Changed — Library performance
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -249,9 +249,12 @@ private extension ContentView {
 
         if requestedLibrarySize > 0 {
             let episodesPerShow = max(1, defaults.integer(forKey: "offscript.debugSeedEpisodesPerShow"))
-            let existingShows = (try? modelContext.fetchCount(FetchDescriptor<Podcast>())) ?? 0
             let existingEpisodes = (try? modelContext.fetchCount(FetchDescriptor<Episode>())) ?? 0
-            guard existingShows != requestedLibrarySize || existingEpisodes != requestedLibrarySize * episodesPerShow else { return }
+            guard debugLargeLibraryNeedsReset(
+                requestedLibrarySize: requestedLibrarySize,
+                expectedEpisodes: requestedLibrarySize * episodesPerShow,
+                existingEpisodes: existingEpisodes
+            ) else { return }
             resetDebugLibrary()
             seedLargeDebugLibrary(
                 showCount: requestedLibrarySize,
@@ -311,6 +314,23 @@ private extension ContentView {
         try? modelContext.save()
     }
 
+    private func debugLargeLibraryNeedsReset(
+        requestedLibrarySize: Int,
+        expectedEpisodes: Int,
+        existingEpisodes: Int
+    ) -> Bool {
+        let podcastDescriptor = FetchDescriptor<Podcast>(
+            sortBy: [SortDescriptor(\Podcast.title)]
+        )
+        guard let existingPodcasts = try? modelContext.fetch(podcastDescriptor) else {
+            return true
+        }
+        guard existingPodcasts.count == requestedLibrarySize, existingEpisodes == expectedEpisodes else {
+            return true
+        }
+        return existingPodcasts.first?.title != "A Channel 001"
+    }
+
     private func resetDebugLibrary() {
         for episode in (try? modelContext.fetch(FetchDescriptor<Episode>())) ?? [] {
             modelContext.delete(episode)
@@ -323,8 +343,9 @@ private extension ContentView {
 
     private func seedLargeDebugLibrary(showCount: Int, episodesPerShow: Int) {
         let categories = ["News", "Tech", "Comedy", "Science", "Culture", "Storytelling"]
+        let alphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         for index in 0..<showCount {
-            let channel = String(format: "Channel %03d", index + 1)
+            let channel = "\(alphabet[index % alphabet.count]) Channel \(String(format: "%03d", index + 1))"
             let pod = Podcast(
                 title: channel,
                 author: "Debug Network \(index % 12 + 1)",

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -231,6 +231,7 @@ struct LibraryView: View {
     @State private var directoryScope: LibraryDirectoryScope = .all
     @State private var directorySort: LibraryDirectorySort = .title
     @State private var directoryDensity: LibraryDirectoryDensity = .compact
+    @State private var selectedDirectorySectionID: String?
     @State private var freshEpisodes: [Episode] = []
     @State private var unplayedEpisodeCount = 0
     @State private var freshCountsByPodcastID: [UUID: Int] = [:]
@@ -404,7 +405,11 @@ struct LibraryView: View {
             if snapshot.isEmpty {
                 LibraryDirectoryEmptyState(query: effectiveDirectoryQuery, scope: directoryScope)
             } else {
-                LibraryAlphabetRail(sections: snapshot.sections) { sectionID in
+                LibraryAlphabetRail(
+                    sections: snapshot.sections,
+                    selectedSectionID: selectedDirectorySectionID
+                ) { sectionID in
+                    selectedDirectorySectionID = sectionID
                     withAnimation(.easeInOut(duration: 0.2)) {
                         scrollProxy.scrollTo(sectionID, anchor: .top)
                     }
@@ -415,6 +420,7 @@ struct LibraryView: View {
                         VStack(alignment: .leading, spacing: 0) {
                             HStack {
                                 TunerLabel(text: section.title, color: .offscriptSignalYellow, size: 10)
+                                    .accessibilityIdentifier("LibrarySectionHeader\(section.title)")
                                 Spacer()
                                 TunerLabel(text: "\(section.podcasts.count) CH", color: .offscriptSoftPaper, size: 8)
                             }
@@ -729,29 +735,66 @@ private struct LibraryDirectoryControls: View {
 
 private struct LibraryAlphabetRail: View {
     let sections: [LibraryDirectorySection]
+    let selectedSectionID: String?
     let onSelect: (String) -> Void
 
+    private let keys = ["#"] + (UnicodeScalar("A").value...UnicodeScalar("Z").value).compactMap { value in
+        UnicodeScalar(value).map { String($0) }
+    }
+
+    private var sectionsByTitle: [String: LibraryDirectorySection] {
+        Dictionary(uniqueKeysWithValues: sections.map { ($0.title, $0) })
+    }
+
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 4) {
-                ForEach(sections) { section in
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 44, maximum: 48), spacing: 4)],
+            alignment: .leading,
+            spacing: 4
+        ) {
+            ForEach(keys, id: \.self) { key in
+                let section = sectionsByTitle[key]
+                let isSelected = selectedSectionID == section?.id
+                let isDisabled = section == nil
+
+                if let section {
                     Button {
                         onSelect(section.id)
                     } label: {
-                        Text(section.title)
-                            .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                            .foregroundStyle(Color.offscriptSignalYellow)
-                            .frame(width: 28, height: 30)
-                            .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
-                            .frame(minWidth: 44, minHeight: 44)
-                            .contentShape(Rectangle())
+                        letterKey(key, isSelected: isSelected, isDisabled: false)
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel("Jump to \(section.title)")
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("Jump to \(key)")
+                    .accessibilityIdentifier("LibraryJumpLetter\(key)")
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
+                } else {
+                    letterKey(key, isSelected: false, isDisabled: true)
+                        .accessibilityLabel("No \(key) channels")
+                        .accessibilityIdentifier("LibraryJumpLetter\(key)")
+                        .accessibilityAddTraits(.isStaticText)
                 }
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private func letterKey(_ key: String, isSelected: Bool, isDisabled: Bool) -> some View {
+        Text(key)
+            .font(.system(size: 10, weight: .semibold, design: .monospaced))
+            .foregroundStyle(isDisabled ? Color.offscriptTextMuted : Color.offscriptSignalYellow)
+            .frame(width: 30, height: 30)
+            .background(isSelected ? Color.offscriptSignalYellow.opacity(0.14) : Color.clear)
+            .overlay(
+                Rectangle()
+                    .stroke(
+                        isSelected ? Color.offscriptSignalYellow : Color.offscriptHairline,
+                        lineWidth: isSelected ? 1.5 : 1
+                    )
+            )
+            .frame(minWidth: 44, minHeight: 44)
+            .contentShape(Rectangle())
+            .opacity(isDisabled ? 0.42 : 1)
     }
 }
 

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -50,6 +50,24 @@ final class OffScriptUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["SHOWS · DIRECTORY"].waitForExistence(timeout: 8))
     }
 
+    @MainActor
+    func testLargeLibraryAlphabetRailJumpsToSelectedLetter() throws {
+        let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 258, debugEpisodesPerShow: 1, debugLaunchTab: 1)
+        app.launch()
+
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 12))
+        let zJump = app.descendants(matching: .any)["LibraryJumpLetterZ"]
+        for _ in 0..<4 where !zJump.exists {
+            app.swipeUp()
+        }
+        XCTAssertTrue(zJump.waitForExistence(timeout: 8))
+
+        zJump.tap()
+
+        XCTAssertTrue(app.staticTexts["LibrarySectionHeaderZ"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Z Channel 026"].waitForExistence(timeout: 5))
+    }
+
     private func makeApp(
         hasSeenOnboarding: Bool,
         debugLibrarySize: Int = 0,


### PR DESCRIPTION
## Summary
- Replace the Library directory's horizontal letter strip with a full A-Z/# Tuner key bank with selected and disabled states.
- Add stable accessibility identifiers for jump keys and section headers.
- Update the deterministic large-library debug seed so it covers every alphabet section and resets stale all-C simulator data.
- Add a UI regression test that taps the Z jump key and verifies the Library scrolls to the Z section.

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests OffScriptUITests/testLargeLibraryAlphabetRailJumpsToSelectedLetter(): failed before fix, passed after fix
- Xcode MCP RunAllTests: 43/43 passed