### PR TITLE
Remove Library rail warning

### DIFF
--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -755,7 +755,6 @@ private struct LibraryAlphabetRail: View {
             ForEach(keys, id: \.self) { key in
                 let section = sectionsByTitle[key]
                 let isSelected = selectedSectionID == section?.id
-                let isDisabled = section == nil
 
                 if let section {
                     Button {


### PR DESCRIPTION
## Summary
- Remove the unused local introduced in the Library alphabet key bank.

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests OffScriptUITests/testLargeLibraryAlphabetRailJumpsToSelectedLetter(): passed