### PR TITLE
Normalize remaining Tuner chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Shared Tuner labels, tags, and readouts now scale through Dynamic Type metrics** while preserving the mono instrument-panel vocabulary.
 - **Compact Tuner keys now keep their visual size but expose 44pt hit targets** across Library, Player, Queue, Search, downloads, and episode detail actions.
 - **Discovery/search copy now names Apple Podcasts Search explicitly** and avoids implying the app is running a generic opaque algorithmic feed.
+- **Remaining app-controlled Liquid Glass controls were replaced with Tuner surfaces**: Settings toggles, Player scrubber, sign-out/unsubscribe confirmations, and sheet presentation chrome now use flat OLED panels, hairlines, and signal-yellow keys.
 
 ### Fixed — onboarding, import, and sync UI honesty
 - **Onboarding Sign in with Apple now presents from the actual button window when available** and no longer uses the old crash-prone missing-scene path for the normal sign-in flow.

--- a/OffScript/AppTheme.swift
+++ b/OffScript/AppTheme.swift
@@ -580,6 +580,16 @@ extension View {
         modifier(OffScriptUtilitySurfaceModifier(radius: radius))
     }
 
+    /// Keep SwiftUI sheet/full-screen hosts from falling back to iOS 26's
+    /// translucent Liquid Glass presentation surface. App-controlled modals
+    /// should read as the same flat OLED instrument panel as the main shell.
+    func tunerModalSurface() -> some View {
+        preferredColorScheme(.dark)
+            .presentationBackground(Color.offscriptStudioBlack)
+            .presentationCornerRadius(0)
+            .presentationDragIndicator(.hidden)
+    }
+
     func measureHeight(_ height: Binding<CGFloat>) -> some View {
         background(
             GeometryReader { proxy in

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -78,9 +78,11 @@ struct ContentView: View {
                 .animation(.easeInOut(duration: 0.2), value: player.currentEpisode != nil)
                 .fullScreenCover(isPresented: $player.isPlayerPresented) {
                     PlayerView()
+                        .tunerModalSurface()
                 }
                 .sheet(isPresented: $isSettingsPresented) {
                     SettingsView()
+                        .tunerModalSurface()
                 }
             } else {
                 OnboardingFlowView {

--- a/OffScript/LibraryImportSheet.swift
+++ b/OffScript/LibraryImportSheet.swift
@@ -88,6 +88,7 @@ struct LibraryImportSheet: View {
             .sheet(isPresented: $isExportShareSheetPresented) {
                 if let exportFileURL {
                     ShareSheet(items: [exportFileURL])
+                        .tunerModalSurface()
                 }
             }
         }

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -355,6 +355,7 @@ struct LibraryView: View {
         // as toolbar items — iOS 26 wraps toolbar buttons in glass chrome.
         .sheet(isPresented: $isImportPresented) {
             LibraryImportSheet()
+                .tunerModalSurface()
         }
     }
 
@@ -1281,7 +1282,9 @@ private struct PodcastDetailTunerHeader: View {
             HStack(spacing: 8) {
                 if podcast.isSubscribed {
                     Button {
-                        showUnsubscribeConfirmation = true
+                        withAnimation(.easeInOut(duration: 0.18)) {
+                            showUnsubscribeConfirmation.toggle()
+                        }
                     } label: {
                         TunerLabel(text: "× UNSUBSCRIBE", color: .offscriptFnRecord, size: 10)
                             .padding(.horizontal, 12)
@@ -1289,25 +1292,6 @@ private struct PodcastDetailTunerHeader: View {
                             .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                     }
                     .buttonStyle(.plain)
-                    .confirmationDialog(
-                        "Unsubscribe from \(podcast.title)?",
-                        isPresented: $showUnsubscribeConfirmation,
-                        titleVisibility: .visible
-                    ) {
-                        Button("Unsubscribe", role: .destructive) {
-                            withAnimation {
-                                // Centralized unsubscribe: clears queue
-                                // items, deletes downloaded files, removes
-                                // Spotlight index entries, and saves once.
-                                // Previously only handled queue cleanup.
-                                _ = PodcastUnsubscribeService.unsubscribe(podcast,
-                                                                          in: modelContext)
-                            }
-                        }
-                        Button("Cancel", role: .cancel) {}
-                    } message: {
-                        Text("Removes the show from your library, dequeues its episodes, deletes any offline downloads, and stops it from appearing in iOS Search. Listening history is preserved.")
-                    }
                 }
 
                 if let url = podcast.websiteURL {
@@ -1327,11 +1311,56 @@ private struct PodcastDetailTunerHeader: View {
             .sheet(item: $safariURL) { item in
                 SafariView(url: item.url)
                     .ignoresSafeArea()
+                    .tunerModalSurface()
+            }
+
+            if showUnsubscribeConfirmation {
+                unsubscribeConfirmationPanel(for: podcast)
             }
 
             Rectangle().fill(Color.offscriptHairline).frame(height: 1)
                 .padding(.top, 6)
         }
+    }
+
+    private func unsubscribeConfirmationPanel(for podcast: Podcast) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            TunerLabel(text: "CONFIRM · UNSUBSCRIBE", color: .offscriptFnRecord)
+            Text("Removes the show from your library, dequeues its episodes, deletes offline downloads, and stops it from appearing in iOS Search. Listening history is preserved.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(Color.offscriptPaperWhite.opacity(0.75))
+                .lineSpacing(2)
+
+            HStack(spacing: 8) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        showUnsubscribeConfirmation = false
+                    }
+                } label: {
+                    TunerLabel(text: "CANCEL", color: .offscriptSoftPaper, size: 10)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 9)
+                        .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        showUnsubscribeConfirmation = false
+                        _ = PodcastUnsubscribeService.unsubscribe(podcast, in: modelContext)
+                    }
+                } label: {
+                    TunerLabel(text: "UNSUBSCRIBE", color: .offscriptFnRecord, size: 10)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 9)
+                        .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(12)
+        .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -168,24 +168,11 @@ struct PlayerView: View {
     }
 
     private var scrubber: some View {
-        // Real Slider with custom track — use SwiftUI's native interaction
-        // (drag, tap-to-seek, accessibility) and overlay the Tuner-visual
-        // rail directly via .background. Earlier version had an invisible
-        // Slider stacked over a separate visual rail, which was fragile —
-        // touch coordinates didn't always reach the slider, and the visual
-        // rail's width could drift from the slider's actual track.
-        Slider(
-            value: Binding(
-                get: { player.currentTime },
-                set: { player.seek(to: $0) }
-            ),
-            in: 0...max(player.duration, 1)
+        TunerScrubber(
+            value: player.currentTime,
+            duration: max(player.duration, 1),
+            onSeek: { player.seek(to: $0) }
         )
-        .tint(Color.offscriptSignalYellow)
-        .frame(height: 24)
-        .padding(.vertical, 2)
-        .accessibilityLabel("Playback position")
-        .accessibilityValue("\(Int(progressValue * 100)) percent")
     }
 
     // MARK: transport
@@ -527,11 +514,6 @@ struct PlayerView: View {
 
     // MARK: helpers
 
-    private var progressValue: Double {
-        guard player.duration > 0 else { return 0 }
-        return player.currentTime / player.duration
-    }
-
     /// True when the podcast has its own rate that differs from the
     /// default — drives the SPEED key's color so the user can tell at a
     /// glance whether they're on a custom pace for this show.
@@ -564,6 +546,84 @@ struct PlayerView: View {
 
     private func formattedDate(_ date: Date) -> String? {
         date.formatted(.dateTime.month(.abbreviated).day().year())
+    }
+}
+
+private struct TunerScrubber: View {
+    let value: Double
+    let duration: Double
+    let onSeek: (Double) -> Void
+
+    @State private var dragValue: Double?
+
+    private var displayValue: Double {
+        min(max(dragValue ?? value, 0), max(duration, 1))
+    }
+
+    private var progress: Double {
+        displayValue / max(duration, 1)
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = max(proxy.size.width, 1)
+            let thumbX = min(max(width * progress, 0), width)
+
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .fill(Color.offscriptHairline)
+                    .frame(height: 2)
+
+                Rectangle()
+                    .fill(Color.offscriptSignalYellow)
+                    .frame(width: max(0, thumbX), height: 2)
+
+                ForEach(0..<9, id: \.self) { index in
+                    Rectangle()
+                        .fill(Color.offscriptHairline)
+                        .frame(width: 1, height: index == 0 || index == 8 ? 14 : 8)
+                        .offset(x: width * CGFloat(index) / 8)
+                }
+
+                Rectangle()
+                    .fill(Color.offscriptSignalYellow)
+                    .frame(width: 6, height: 22)
+                    .offset(x: min(max(thumbX - 3, 0), width - 6))
+            }
+            .frame(height: 44)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { gesture in
+                        dragValue = seekValue(for: gesture.location.x, width: width)
+                    }
+                    .onEnded { gesture in
+                        let newValue = seekValue(for: gesture.location.x, width: width)
+                        dragValue = nil
+                        onSeek(newValue)
+                    }
+            )
+        }
+        .frame(height: 44)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Playback position")
+        .accessibilityValue("\(Int(progress * 100)) percent")
+        .accessibilityAdjustableAction { direction in
+            let step = max(duration * 0.05, 5)
+            switch direction {
+            case .increment:
+                onSeek(min(value + step, duration))
+            case .decrement:
+                onSeek(max(value - step, 0))
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    private func seekValue(for locationX: CGFloat, width: CGFloat) -> Double {
+        let ratio = min(max(Double(locationX / max(width, 1)), 0), 1)
+        return ratio * max(duration, 1)
     }
 }
 

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -508,6 +508,7 @@ private struct SearchResultRow: View {
         .sheet(item: $safariURL) { item in
             SafariView(url: item.url)
                 .ignoresSafeArea()
+                .tunerModalSurface()
         }
     }
 }

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -73,12 +73,6 @@ struct SettingsView: View {
             // No `.toolbar` ToolbarItem — iOS 26 wraps toolbar buttons in
             // glass-capsule chrome that ignores .plain styling. DONE key
             // moved inline into `settingsHeader` below.
-            .alert("Sign Out", isPresented: $showSignOutConfirmation) {
-                Button("Cancel", role: .cancel) {}
-                Button("Sign Out", role: .destructive) { signOut() }
-            } message: {
-                Text("Sync will stop on next launch. Your local data will remain on this device.")
-            }
         }
     }
 
@@ -278,19 +272,41 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func tunerToggle(title: String, detail: String, isOn: Binding<Bool>) -> some View {
-        Toggle(isOn: isOn) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(Color.offscriptPaperWhite)
-                Text(detail)
-                    .font(.system(size: 12.5))
-                    .foregroundStyle(Color.offscriptPaperWhite.opacity(0.75))
-                    .fixedSize(horizontal: false, vertical: true)
-                    .lineSpacing(2)
+        Button {
+            withAnimation(.easeInOut(duration: 0.16)) {
+                isOn.wrappedValue.toggle()
             }
+        } label: {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.offscriptPaperWhite)
+                    Text(detail)
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(Color.offscriptPaperWhite.opacity(0.75))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .lineSpacing(2)
+                }
+
+                Spacer(minLength: 10)
+
+                TunerLabel(
+                    text: isOn.wrappedValue ? "ON" : "OFF",
+                    color: isOn.wrappedValue ? .offscriptStudioBlack : .offscriptSoftPaper,
+                    size: 10
+                )
+                .frame(width: 58, height: 30)
+                .background(isOn.wrappedValue ? Color.offscriptSignalYellow : Color.clear)
+                .overlay(Rectangle().stroke(isOn.wrappedValue ? Color.offscriptSignalYellow : Color.offscriptHairline, lineWidth: 1))
+            }
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
-        .tint(Color.offscriptSignalYellow)
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityValue(isOn.wrappedValue ? "On" : "Off")
+        .accessibilityAddTraits(isOn.wrappedValue ? [.isButton, .isSelected] : .isButton)
         .padding(.vertical, 10)
     }
 
@@ -435,7 +451,9 @@ struct SettingsView: View {
                     identityStatusRows
 
                     Button {
-                        showSignOutConfirmation = true
+                        withAnimation(.easeInOut(duration: 0.18)) {
+                            showSignOutConfirmation.toggle()
+                        }
                     } label: {
                         TunerLabel(text: "× SIGN OUT", color: .offscriptFnRecord, size: 10)
                             .padding(.horizontal, 12)
@@ -444,6 +462,10 @@ struct SettingsView: View {
                     }
                     .buttonStyle(.plain)
                     .padding(.top, 4)
+
+                    if showSignOutConfirmation {
+                        signOutConfirmationPanel
+                    }
                 }
             } else {
                 VStack(alignment: .leading, spacing: 10) {
@@ -563,6 +585,46 @@ struct SettingsView: View {
             settingsLogger.error("Sign in with Apple failed: \(error.localizedDescription, privacy: .public)")
             withAnimation { signInMessage = "Sign-in failed. Please try again." }
         }
+    }
+
+    private var signOutConfirmationPanel: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            TunerLabel(text: "CONFIRM · SIGN OUT", color: .offscriptFnRecord)
+            Text("Sync will stop on next launch. Your local data will remain on this device.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(Color.offscriptPaperWhite.opacity(0.75))
+                .lineSpacing(2)
+
+            HStack(spacing: 8) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        showSignOutConfirmation = false
+                    }
+                } label: {
+                    TunerLabel(text: "CANCEL", color: .offscriptSoftPaper, size: 10)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 9)
+                        .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        showSignOutConfirmation = false
+                    }
+                    signOut()
+                } label: {
+                    TunerLabel(text: "SIGN OUT", color: .offscriptFnRecord, size: 10)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 9)
+                        .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(12)
+        .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+        .accessibilityElement(children: .contain)
     }
 
     private func signOut() {


### PR DESCRIPTION
## Summary
- Replace app-controlled native Liquid Glass surfaces with Tuner OLED controls: Settings toggles, Player scrubber, and destructive confirmations.
- Add a shared Tuner modal presentation modifier so Settings, import/export, Player, and Safari sheets use flat black presentation chrome instead of default translucent sheet surfaces.
- Document the pass in the changelog.

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunAllTests: 43/43 passed
- Static scan: no native Toggle, Slider, .alert, or confirmationDialog usage remains in OffScript Swift sources