### PR TITLE
Polish Tuner navigation and library imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Compact Tuner keys now keep their visual size but expose 44pt hit targets** across Library, Player, Queue, Search, downloads, and episode detail actions.
 - **Discovery/search copy now names Apple Podcasts Search explicitly** and avoids implying the app is running a generic opaque algorithmic feed.
 - **Remaining app-controlled Liquid Glass controls were replaced with Tuner surfaces**: Settings toggles, Player scrubber, sign-out/unsubscribe confirmations, and sheet presentation chrome now use flat OLED panels, hairlines, and signal-yellow keys.
+- **Long recommendation reason tags now wrap inside Tuner cards** instead of forcing fixed-width mono pills that could run off Home cards.
+- **Library import is now an explicit `IMPORT` Tuner key** with an icon-only fallback when width is constrained, so the OPML/paste entry point is visible without guessing the glyph.
+- **The bottom Tuner tab indicator now slides between Home, Library, Queue, and Search** with selection haptics instead of appearing abruptly in each cell.
+- **Root page headers sit tighter to the safe area** to reclaim top-of-app space while keeping the iOS status/Dynamic Island safe region intact.
 
 ### Fixed — onboarding, import, and sync UI honesty
 - **Onboarding Sign in with Apple now presents from the actual button window when available** and no longer uses the old crash-prone missing-scene path for the normal sign-in flow.
@@ -36,6 +40,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Library summary reloads are coalesced during background OPML imports** so each imported show does not immediately retrigger the expensive per-show count path while the list is being scrolled.
 - **Library summary counts no longer issue one SwiftData `fetchCount` per subscribed show.** The page now loads the unplayed episode set once, derives the latest rail and per-show counts from that result, and avoids 250+ synchronous count queries on Library open.
 - **Library directory rendering now builds one snapshot per render pass** for filtered shows, alphabet sections, and row numbers, with debounced search input so typing does not repeatedly sort/group the whole library.
+- **Library no longer observes every OPML progress tick at the root page level.** The import strip repaints during batch progress, and the expensive directory snapshot refreshes when the batch reaches a terminal state.
 
 ### Added — recommendation tuner and signal discovery
 - **Settings now has a three-position recommendation tuner** (`SIGNAL`, `BALANCED`, `DISCOVERY`) so listeners can choose whether OffScript stays strictly inside known local evidence or opens a new-show discovery lane.

--- a/OffScript/AppTheme.swift
+++ b/OffScript/AppTheme.swift
@@ -80,6 +80,7 @@ struct IdentifiableURL: Identifiable {
 
 enum OffScriptTheme {
     static let pagePadding: CGFloat = 16        // Tuner is tighter than the editorial direction
+    static let rootContentTopPadding: CGFloat = 2
     static let spaciousPadding: CGFloat = 20
     static let sectionSpacing: CGFloat = 24
     static let itemSpacing: CGFloat = 12
@@ -417,8 +418,22 @@ struct TunerTag: View {
     let text: String
     var color: Color = .offscriptSignalYellow
     var dim: Bool = false
+    var wraps: Bool = false
 
     var body: some View {
+        if wraps {
+            baseTag
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        } else {
+            baseTag
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: true)
+        }
+    }
+
+    private var baseTag: some View {
         Text(text.uppercased())
             .font(.system(size: CGFloat(8.5).offscriptScaled(), weight: .semibold, design: .monospaced))
             .tracking(1.4)
@@ -432,8 +447,6 @@ struct TunerTag: View {
                 // (hero cards, rail cards, AI reason badges).
                 Rectangle().stroke(color.opacity(dim ? 0.33 : 0.66), lineWidth: 1)
             )
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: true)
     }
 }
 

--- a/OffScript/CardComponents.swift
+++ b/OffScript/CardComponents.swift
@@ -46,7 +46,7 @@ struct EpisodeVerticalCard: View {
             // Tuner text + transport zone
             VStack(alignment: .leading, spacing: 8) {
                 if let tag = explanationTag {
-                    TunerTag(text: tag, color: .offscriptSignalYellow, dim: true)
+                    TunerTag(text: tag, color: .offscriptSignalYellow, dim: true, wraps: true)
                 }
 
                 // Podcast title in info-cyan per the function-coded color

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -169,6 +169,7 @@ struct ContentView: View {
 private struct TunerTabBar: View {
     @Binding var selection: AppTab
     let queueBadge: Int
+    @Namespace private var indicatorNamespace
 
     var body: some View {
         VStack(spacing: 0) {
@@ -179,7 +180,9 @@ private struct TunerTabBar: View {
             HStack(spacing: 0) {
                 ForEach(AppTab.allCases) { tab in
                     Button {
-                        selection = tab
+                        withAnimation(.easeInOut(duration: 0.22)) {
+                            selection = tab
+                        }
                     } label: {
                         tabContent(for: tab)
                     }
@@ -193,6 +196,7 @@ private struct TunerTabBar: View {
             .padding(.bottom, 2)
             .background(Color.offscriptStudioBlack)
         }
+        .sensoryFeedback(.selection, trigger: selection.rawValue)
     }
 
     @ViewBuilder
@@ -233,6 +237,7 @@ private struct TunerTabBar: View {
                     .fill(Color.offscriptSignalYellow)
                     .frame(width: 36, height: 1)
                     .offset(y: -6)
+                    .matchedGeometryEffect(id: "tuner-tab-indicator", in: indicatorNamespace)
             }
         }
     }

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -238,7 +238,7 @@ struct EpisodeDetailView: View {
         if let recommendationReason, !recommendationReason.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
                 TunerLabel(text: "WHY THIS · LOCAL SIGNAL", color: .offscriptSignalYellow)
-                TunerTag(text: recommendationReason, color: .offscriptSignalYellow, dim: true)
+                TunerTag(text: recommendationReason, color: .offscriptSignalYellow, dim: true, wraps: true)
                 RecommendationSignalTraceView(signals: recommendationSignals)
                 Text("This comes from local listening, queue, and preference signals on this device.")
                     .font(.system(size: 12.5, weight: .regular))

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -87,7 +87,7 @@ struct HomeView: View {
                     }
                 }
             }
-            .padding(.top, 8)
+            .padding(.top, OffScriptTheme.rootContentTopPadding)
             .padding(.bottom, 28)
         }
         .background(Color.offscriptStudioBlack.ignoresSafeArea())
@@ -532,7 +532,7 @@ private struct TunerDiscoveryRail: View {
                 .multilineTextAlignment(.leading)
                 .frame(width: 168, alignment: .leading)
 
-            TunerTag(text: scored.explanation, color: .offscriptFnInfo, dim: true)
+            TunerTag(text: scored.explanation, color: .offscriptFnInfo, dim: true, wraps: true)
             RecommendationSignalTraceView(signals: scored.signalTrace, limit: 2, color: .offscriptSoftPaper)
 
             Button {
@@ -632,7 +632,7 @@ private struct HeroTunerCard: View {
                 .buttonStyle(.plain)
 
                 // Reason as a TunerTag with signal yellow accent
-                TunerTag(text: reason, color: .offscriptSignalYellow, dim: true)
+                TunerTag(text: reason, color: .offscriptSignalYellow, dim: true, wraps: true)
                 RecommendationSignalTraceView(signals: signals)
 
                 // Mono metadata — date · duration. The "X LEFT" remaining
@@ -806,7 +806,7 @@ private struct TunerRailCard: View {
                         .multilineTextAlignment(.leading)
                         .frame(width: 168, alignment: .leading)
 
-                    TunerTag(text: reason, color: .offscriptSignalYellow, dim: true)
+                    TunerTag(text: reason, color: .offscriptSignalYellow, dim: true, wraps: true)
                     RecommendationSignalTraceView(signals: signals, limit: 2, color: .offscriptSoftPaper)
 
                     TunerLabel(text: metadata, color: .offscriptSoftPaper, size: 8)

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -206,7 +206,6 @@ private extension BatchImportService.Phase {
 
 struct LibraryView: View {
     @Environment(\.modelContext) private var modelContext
-    @ObservedObject private var batchImporter = BatchImportService.shared
     @Query(
         filter: #Predicate<Podcast> { $0.isSubscribed },
         sort: [SortDescriptor(\Podcast.title)]
@@ -282,7 +281,9 @@ struct LibraryView: View {
                     // Background OPML import status — visible whenever the
                     // batch importer is mid-flight or has just finished and
                     // hasn't been dismissed yet.
-                    LibraryBatchImportStrip()
+                    LibraryBatchImportStrip(onFinished: {
+                        scheduleLibraryEpisodeSummaryLoad()
+                    })
 
                     if subscribedPodcasts.isEmpty {
                         emptyState
@@ -326,7 +327,7 @@ struct LibraryView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, OffScriptTheme.pagePadding)
-                .padding(.top, 8)
+                .padding(.top, OffScriptTheme.rootContentTopPadding)
                 .padding(.bottom, 90)
             }
         }
@@ -341,11 +342,6 @@ struct LibraryView: View {
         .onAppear { effectiveDirectoryQuery = directoryQuery }
         .onChange(of: subscribedPodcastIDs) { _, _ in scheduleLibraryEpisodeSummaryLoad() }
         .onChange(of: directoryQuery) { _, newValue in scheduleDirectoryQuery(newValue) }
-        .onChange(of: batchImporter.phase) { _, phase in
-            if !phase.isRunning {
-                loadLibraryEpisodeSummary()
-            }
-        }
         .onDisappear {
             summaryLoadTask?.cancel()
             directoryQueryTask?.cancel()
@@ -488,9 +484,9 @@ struct LibraryView: View {
     private func scheduleLibraryEpisodeSummaryLoad() {
         summaryLoadTask?.cancel()
         summaryLoadTask = Task { @MainActor in
-            if batchImporter.isRunning {
+            if BatchImportService.shared.isRunning {
                 try? await Task.sleep(nanoseconds: 1_200_000_000)
-                guard !Task.isCancelled, !batchImporter.isRunning else { return }
+                guard !Task.isCancelled, !BatchImportService.shared.isRunning else { return }
             }
             loadLibraryEpisodeSummary()
         }
@@ -549,13 +545,25 @@ private struct LibraryTunerHeader: View {
                 // missing feature in podcast apps; lives next to settings
                 // since both are operational chrome rather than per-content.
                 Button(action: onOpenImport) {
-                    Image(systemName: "square.and.arrow.down")
-                        .font(.system(size: 13, weight: .semibold))
+                    ViewThatFits(in: .horizontal) {
+                        HStack(spacing: 7) {
+                            Image(systemName: "square.and.arrow.down")
+                                .font(.system(size: 12, weight: .semibold))
+                            TunerLabel(text: "IMPORT", color: .offscriptSignalYellow, size: 9)
+                        }
                         .foregroundStyle(Color.offscriptSignalYellow)
-                        .frame(width: 36, height: 30)
+                        .padding(.horizontal, 10)
+                        .frame(height: 30)
                         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
-                        .frame(width: 44, height: 44)
-                        .contentShape(Rectangle())
+
+                        Image(systemName: "square.and.arrow.down")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Color.offscriptSignalYellow)
+                            .frame(width: 36, height: 30)
+                            .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+                    }
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Import podcasts")
@@ -873,7 +881,7 @@ private struct TunerLibraryCard: View {
                             .foregroundStyle(Color.offscriptPaperWhite)
                             .lineLimit(2)
                             .multilineTextAlignment(.leading)
-                        TunerTag(text: reason, color: .offscriptSignalYellow, dim: true)
+                        TunerTag(text: reason, color: .offscriptSignalYellow, dim: true, wraps: true)
                     }
                     Spacer()
                 }
@@ -1512,79 +1520,87 @@ private struct FilterRow: View {
 /// the user always sees what's happening once they leave the sheet.
 private struct LibraryBatchImportStrip: View {
     @ObservedObject private var importer = BatchImportService.shared
+    var onFinished: () -> Void = {}
 
     var body: some View {
-        switch importer.phase {
-        case .idle:
-            EmptyView()
-        case .running:
-            VStack(alignment: .leading, spacing: 6) {
-                HStack {
-                    TunerLabel(text: "● IMPORTING IN BACKGROUND",
-                               color: .offscriptSignalYellow)
-                    Spacer()
-                    TunerLabel(text: "\(importer.completedCount)/\(importer.totalCount)",
-                               color: .offscriptFnInfo)
-                }
-
-                GeometryReader { proxy in
-                    let total = max(1, importer.totalCount)
-                    let done = importer.completedCount
-                    let clamped = min(max(Double(done) / Double(total), 0), 1)
-                    ZStack(alignment: .leading) {
-                        Rectangle().fill(Color.offscriptHairline)
-                        Rectangle()
-                            .fill(Color.offscriptSignalYellow)
-                            .frame(width: proxy.size.width * clamped)
+        Group {
+            switch importer.phase {
+            case .idle:
+                EmptyView()
+            case .running:
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        TunerLabel(text: "● IMPORTING IN BACKGROUND",
+                                   color: .offscriptSignalYellow)
+                        Spacer()
+                        TunerLabel(text: "\(importer.completedCount)/\(importer.totalCount)",
+                                   color: .offscriptFnInfo)
                     }
-                }
-                .frame(height: 2)
-            }
-            .padding(.vertical, 10)
-            .overlay(
-                Rectangle().fill(Color.offscriptHairline).frame(height: 1),
-                alignment: .top
-            )
-            .overlay(
-                Rectangle().fill(Color.offscriptHairline).frame(height: 1),
-                alignment: .bottom
-            )
 
-        case .finished(let added, let failed):
-            HStack(spacing: 12) {
-                TunerLabel(
-                    text: failed == 0 ? "✓ IMPORT COMPLETE" : "● IMPORT FINISHED",
-                    color: failed == 0 ? .offscriptFnMode : .offscriptSignalYellow
-                )
-                Text(failed == 0
-                     ? "Added \(added) shows"
-                     : "Added \(added), \(failed) failed")
-                    .font(.system(size: 12.5))
-                    .foregroundStyle(Color.offscriptPaperWhite)
-                Spacer()
-                Button {
-                    importer.dismiss()
-                } label: {
-                    TunerLabel(text: "× DISMISS",
-                               color: .offscriptSoftPaper, size: 9)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
-                        .frame(minHeight: 44)
-                        .contentShape(Rectangle())
+                    GeometryReader { proxy in
+                        let total = max(1, importer.totalCount)
+                        let done = importer.completedCount
+                        let clamped = min(max(Double(done) / Double(total), 0), 1)
+                        ZStack(alignment: .leading) {
+                            Rectangle().fill(Color.offscriptHairline)
+                            Rectangle()
+                                .fill(Color.offscriptSignalYellow)
+                                .frame(width: proxy.size.width * clamped)
+                        }
+                    }
+                    .frame(height: 2)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Dismiss import status")
+                .padding(.vertical, 10)
+                .overlay(
+                    Rectangle().fill(Color.offscriptHairline).frame(height: 1),
+                    alignment: .top
+                )
+                .overlay(
+                    Rectangle().fill(Color.offscriptHairline).frame(height: 1),
+                    alignment: .bottom
+                )
+
+            case .finished(let added, let failed):
+                HStack(spacing: 12) {
+                    TunerLabel(
+                        text: failed == 0 ? "✓ IMPORT COMPLETE" : "● IMPORT FINISHED",
+                        color: failed == 0 ? .offscriptFnMode : .offscriptSignalYellow
+                    )
+                    Text(failed == 0
+                         ? "Added \(added) shows"
+                         : "Added \(added), \(failed) failed")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(Color.offscriptPaperWhite)
+                    Spacer()
+                    Button {
+                        importer.dismiss()
+                    } label: {
+                        TunerLabel(text: "× DISMISS",
+                                   color: .offscriptSoftPaper, size: 9)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+                            .frame(minHeight: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Dismiss import status")
+                }
+                .padding(.vertical, 10)
+                .overlay(
+                    Rectangle().fill(Color.offscriptHairline).frame(height: 1),
+                    alignment: .top
+                )
+                .overlay(
+                    Rectangle().fill(Color.offscriptHairline).frame(height: 1),
+                    alignment: .bottom
+                )
             }
-            .padding(.vertical, 10)
-            .overlay(
-                Rectangle().fill(Color.offscriptHairline).frame(height: 1),
-                alignment: .top
-            )
-            .overlay(
-                Rectangle().fill(Color.offscriptHairline).frame(height: 1),
-                alignment: .bottom
-            )
+        }
+        .onChange(of: importer.phase) { oldPhase, phase in
+            if oldPhase.isRunning && !phase.isRunning {
+                onFinished()
+            }
         }
     }
 }

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -701,7 +701,7 @@ private struct PlayerSuggestionRow: View {
             .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
 
             VStack(alignment: .leading, spacing: 3) {
-                TunerTag(text: scored.explanation, color: .offscriptSignalYellow, dim: true)
+                TunerTag(text: scored.explanation, color: .offscriptSignalYellow, dim: true, wraps: true)
                 RecommendationSignalTraceView(signals: scored.signalTrace, limit: 2, color: .offscriptSoftPaper)
                 Text(scored.episode.title)
                     .font(.system(size: 13, weight: .semibold))

--- a/OffScript/QueueView.swift
+++ b/OffScript/QueueView.swift
@@ -44,7 +44,7 @@ struct QueueView: View {
                 }
             }
             .padding(.horizontal, OffScriptTheme.pagePadding)
-            .padding(.top, 8)
+            .padding(.top, OffScriptTheme.rootContentTopPadding)
             .padding(.bottom, 90)
         }
         .background(Color.offscriptStudioBlack.ignoresSafeArea())

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -67,7 +67,7 @@ struct SearchView: View {
                 }
             }
             .padding(.horizontal, OffScriptTheme.pagePadding)
-            .padding(.top, 8)
+            .padding(.top, OffScriptTheme.rootContentTopPadding)
             .padding(.bottom, 90)
             .frame(maxWidth: 760, alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .center)

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -478,7 +478,7 @@ struct SettingsView: View {
                     } onCompletion: { result in
                         handleSignInResult(result)
                     }
-                    .signInWithAppleButtonStyle(.white)
+                    .signInWithAppleButtonStyle(.whiteOutline)
                     .frame(height: 48)
 
                     if let signInMessage {


### PR DESCRIPTION
## Summary
- wraps long Tuner recommendation tags so Home cards and recommendation rows do not overflow
- makes the Library import affordance an explicit IMPORT key with compact fallback
- animates the bottom Tuner tab indicator between tabs with selection feedback
- tightens root page top padding while preserving the iOS safe area
- isolates root Library from per-row OPML progress observation so only the import strip repaints during batch progress

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: 6/6 passed (shell smoke, 258-show Library UI tests, library organizer, OPML dedupe)
- Xcode MCP RunAllTests: 43/43 passed
- git diff --check: passed