### PR TITLE
Skip existing feeds during OPML batch import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Library summary counts no longer issue one SwiftData `fetchCount` per subscribed show.** The page now loads the unplayed episode set once, derives the latest rail and per-show counts from that result, and avoids 250+ synchronous count queries on Library open.
 - **Library directory rendering now builds one snapshot per render pass** for filtered shows, alphabet sections, and row numbers, with debounced search input so typing does not repeatedly sort/group the whole library.
 - **Library no longer observes every OPML progress tick at the root page level.** The import strip repaints during batch progress, and the expensive directory snapshot refreshes when the batch reaches a terminal state.
+- **Bulk OPML import now skips already-subscribed feed URLs before network fetch/parse work** using the same normalized feed-key logic as OPML dedupe, so re-importing a large library does not waste rows on feeds that are already tuned.
 
 ### Added — recommendation tuner and signal discovery
 - **Settings now has a three-position recommendation tuner** (`SIGNAL`, `BALANCED`, `DISCOVERY`) so listeners can choose whether OffScript stays strictly inside known local evidence or opens a new-show discovery lane.

--- a/OffScript/BatchImportService.swift
+++ b/OffScript/BatchImportService.swift
@@ -41,11 +41,15 @@ final class BatchImportService: ObservableObject {
         progress.values.filter { if case .failed = $0 { true } else { false } }.count
     }
 
+    var skippedCount: Int {
+        progress.values.filter { if case .skipped = $0 { true } else { false } }.count
+    }
+
     var cancelledCount: Int {
         progress.values.filter { if case .cancelled = $0 { true } else { false } }.count
     }
 
-    var completedCount: Int { addedCount + failedCount + cancelledCount }
+    var completedCount: Int { addedCount + skippedCount + failedCount + cancelledCount }
 
     var totalCount: Int { entries.count }
 
@@ -61,12 +65,19 @@ final class BatchImportService: ObservableObject {
         guard !isRunning else { return }
 
         let uniqueEntries = Self.deduplicated(entries)
+        let existingFeedKeys = Self.subscribedFeedKeys(in: modelContext)
+        let plan = Self.importPlan(for: uniqueEntries, existingFeedKeys: existingFeedKeys)
         self.entries = uniqueEntries
-        progress = Dictionary(uniqueKeysWithValues: uniqueEntries.map { ($0.feedURL, ImportRowStatus.pending) })
+        progress = plan.initialProgress
         phase = .running
 
+        guard !plan.entriesToImport.isEmpty else {
+            phase = .finished(added: addedCount, failed: failedCount)
+            return
+        }
+
         task = Task { [weak self] in
-            await self?.runBatch(entries: uniqueEntries, modelContext: modelContext)
+            await self?.runBatch(entries: plan.entriesToImport, modelContext: modelContext)
         }
     }
 
@@ -173,5 +184,36 @@ final class BatchImportService: ObservableObject {
             result.append(entry)
         }
         return result
+    }
+
+    static func importPlan(
+        for entries: [OPMLFeedEntry],
+        existingFeedKeys: Set<String>
+    ) -> (entriesToImport: [OPMLFeedEntry], initialProgress: [URL: ImportRowStatus]) {
+        var entriesToImport: [OPMLFeedEntry] = []
+        var initialProgress: [URL: ImportRowStatus] = [:]
+
+        for entry in entries {
+            if existingFeedKeys.contains(entry.feedURL.normalizedFeedKey) {
+                initialProgress[entry.feedURL] = .skipped
+            } else {
+                initialProgress[entry.feedURL] = .pending
+                entriesToImport.append(entry)
+            }
+        }
+
+        return (entriesToImport, initialProgress)
+    }
+
+    private static func subscribedFeedKeys(in modelContext: ModelContext) -> Set<String> {
+        do {
+            let descriptor = FetchDescriptor<Podcast>(
+                predicate: #Predicate<Podcast> { $0.isSubscribed }
+            )
+            return Set(try modelContext.fetch(descriptor).map { $0.feedURL.normalizedFeedKey })
+        } catch {
+            batchImportLogger.error("Existing feed preflight failed: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
     }
 }

--- a/OffScript/LibraryImportSheet.swift
+++ b/OffScript/LibraryImportSheet.swift
@@ -509,6 +509,7 @@ enum ImportRowStatus {
     case pending
     case importing
     case added
+    case skipped
     case failed
     case cancelled
 
@@ -517,6 +518,7 @@ enum ImportRowStatus {
         case .pending: "○ STANDBY"
         case .importing: "● IMPORTING"
         case .added: "✓ ADDED"
+        case .skipped: "✓ EXISTS"
         case .failed: "✕ FAILED"
         case .cancelled: "× CANCELLED"
         }
@@ -527,6 +529,7 @@ enum ImportRowStatus {
         case .pending: .offscriptSoftPaper
         case .importing: .offscriptSignalYellow
         case .added: .offscriptFnMode
+        case .skipped: .offscriptFnInfo
         case .failed: .offscriptFnRecord
         case .cancelled: .offscriptSoftPaper
         }

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -1566,9 +1566,7 @@ private struct LibraryBatchImportStrip: View {
                         text: failed == 0 ? "✓ IMPORT COMPLETE" : "● IMPORT FINISHED",
                         color: failed == 0 ? .offscriptFnMode : .offscriptSignalYellow
                     )
-                    Text(failed == 0
-                         ? "Added \(added) shows"
-                         : "Added \(added), \(failed) failed")
+                    Text(finishedSummary(added: added, failed: failed))
                         .font(.system(size: 12.5))
                         .foregroundStyle(Color.offscriptPaperWhite)
                     Spacer()
@@ -1602,6 +1600,20 @@ private struct LibraryBatchImportStrip: View {
                 onFinished()
             }
         }
+    }
+
+    private func finishedSummary(added: Int, failed: Int) -> String {
+        let skipped = importer.skippedCount
+        if failed == 0, skipped == 0 {
+            return "Added \(added) shows"
+        }
+        if failed == 0 {
+            return "Added \(added), \(skipped) already tuned"
+        }
+        if skipped == 0 {
+            return "Added \(added), \(failed) failed"
+        }
+        return "Added \(added), \(skipped) already tuned, \(failed) failed"
     }
 }
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -105,6 +105,30 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func opmlImportPlanSkipsExistingNormalizedFeedsBeforeNetworkWork() throws {
+        let existing = OPMLFeedEntry(
+            feedURL: try #require(URL(string: "http://Example.com/feed.xml/")),
+            title: "Existing",
+            author: nil
+        )
+        let fresh = OPMLFeedEntry(
+            feedURL: try #require(URL(string: "https://example.com/fresh.xml")),
+            title: "Fresh",
+            author: nil
+        )
+
+        let plan = BatchImportService.importPlan(
+            for: [existing, fresh],
+            existingFeedKeys: ["https://example.com/feed.xml"]
+        )
+
+        #expect(plan.entriesToImport == [fresh])
+        #expect(plan.initialProgress[existing.feedURL] == .skipped)
+        #expect(plan.initialProgress[fresh.feedURL] == .pending)
+    }
+
+    @Test
+    @MainActor
     func queueServiceMovesItemsAndPersistsOrder() throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- preflight OPML batch imports against normalized subscribed feed URLs
- mark already-tuned rows as ✓ EXISTS and skip network fetch/parse/import work for them
- include skipped rows in progress completion and final import summaries
- add unit coverage for normalized existing-feed skips

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: 4/4 passed
- Xcode MCP RunAllTests: 44/44 passed
- git diff --check: passed