### PR TITLE
Retune recommendations after explicit feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Taste refresh now uses weighted, decayed evidence instead of equal counts.** Recent explicit `More like this` signals beat old passive completions, while `Less like this`, `Not interested`, quick skips, and abandons demote matching tags and shows.
 - **Recommendation modes now materially change Home ranking.** `SIGNAL` excludes genre-only candidates, while `BALANCED` and `DISCOVERY` can include a separate tuned-genre lane after local evidence.
 - **Negative signals now suppress adjacent recommendations, not just the exact episode.** `Less like this`, `Not interested`, skipped, and abandoned signals carry disliked tags/show penalties into Home and Player suggestions.
+- **Home now reloads recommendations immediately after explicit feedback** instead of waiting for the next automatic refresh path, and the headline card shows a small retuning status after Like / More / Less / Not Interested.
 
 ### Fixed — playback queue and Now Playing
 - **Playing a queue row now removes that row before playback starts**, so completion/remote-next does not replay the same episode before advancing.

--- a/OffScript/DeepLinkRouter.swift
+++ b/OffScript/DeepLinkRouter.swift
@@ -5,13 +5,11 @@ import SwiftUI
 
 private let deepLinkLogger = Logger(subsystem: "com.offscript", category: "DeepLink")
 
-/// Tab-switch notification. ContentView observes this and updates its
-/// `selectedTab` binding when an `offscript://tab/<name>` URL fires. Single
-/// userInfo key `tab` carrying a String matching one of "home", "library",
-/// "queue", "search". Lives at file scope so DeepLinkRouter doesn't need a
-/// reference to ContentView's @State.
+/// App-local notifications used to route events between independent SwiftUI
+/// surfaces without threading bindings through the whole shell.
 extension Notification.Name {
     static let offscriptSwitchTab = Notification.Name("offscript.switchTab")
+    static let offscriptRecommendationFeedbackChanged = Notification.Name("offscript.recommendationFeedbackChanged")
 }
 
 /// Centralized handler for `offscript://` URLs coming from:

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -23,6 +23,8 @@ struct HomeView: View {
     @State private var errorMessage: String?
     @State private var isLoading = true
     @State private var isLoadingDiscovery = false
+    @State private var loadGeneration = 0
+    @State private var feedbackRetuneTask: Task<Void, Never>?
     let onOpenSettings: () -> Void
 
     private let recommendationService = RecommendationService()
@@ -104,39 +106,73 @@ struct HomeView: View {
         // in HomeTunerHeader instead, where we have full control.
         .task(id: recommendationModeRaw) { await loadSections() }
         .refreshable { await loadSections() }
+        .onReceive(NotificationCenter.default.publisher(for: .offscriptRecommendationFeedbackChanged)) { _ in
+            feedbackRetuneTask?.cancel()
+            feedbackRetuneTask = Task {
+                do {
+                    try await Task.sleep(nanoseconds: 180_000_000)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled else { return }
+                await retuneAfterExplicitFeedback()
+            }
+        }
+        .onDisappear { feedbackRetuneTask?.cancel() }
     }
 
     @MainActor
     private func loadSections() async {
+        loadGeneration += 1
+        let generation = loadGeneration
+        isLoadingDiscovery = false
         do {
             let mode = AppSettings.recommendationMode
             let loaded = try recommendationService.homeSections(context: modelContext, mode: mode)
+            guard generation == loadGeneration else { return }
             withAnimation(.easeInOut(duration: 0.25)) {
                 sections = loaded
                 errorMessage = nil
                 isLoading = false
                 isLoadingDiscovery = false
             }
-            await loadDiscovery(mode: mode, existingSections: loaded)
+            await loadDiscovery(mode: mode, existingSections: loaded, generation: generation)
         } catch {
+            guard generation == loadGeneration else { return }
             homeLogger.error("loadSections failed: \(error.localizedDescription, privacy: .public)")
             errorMessage = error.localizedDescription
             isLoading = false
+            isLoadingDiscovery = false
         }
     }
 
     @MainActor
-    private func loadDiscovery(mode: AppSettings.RecommendationMode, existingSections: [HomeFeedSection]) async {
+    private func loadDiscovery(mode: AppSettings.RecommendationMode, existingSections: [HomeFeedSection], generation: Int) async {
         guard mode.allowsDiscovery else { return }
+        guard generation == loadGeneration else { return }
         isLoadingDiscovery = true
-        defer { isLoadingDiscovery = false }
+        defer {
+            if generation == loadGeneration {
+                isLoadingDiscovery = false
+            }
+        }
 
         if let discovery = await recommendationService.discoverySection(context: modelContext, mode: mode) {
-            guard !Task.isCancelled, AppSettings.recommendationMode == mode else { return }
+            guard !Task.isCancelled,
+                  AppSettings.recommendationMode == mode,
+                  generation == loadGeneration else { return }
             withAnimation(.easeInOut(duration: 0.25)) {
                 sections = existingSections + [discovery]
             }
         }
+    }
+
+    @MainActor
+    private func retuneAfterExplicitFeedback() async {
+        // `homeSections` reads fresh PreferenceSignal rows directly, so this
+        // updates visible recommendations without forcing a full taste-profile
+        // rebuild on the tap path.
+        await loadSections()
     }
 }
 
@@ -583,6 +619,8 @@ private struct HeroTunerCard: View {
     let episode: Episode
     let reason: String
     let signals: [RecommendationSignal]
+    @State private var feedbackStatusMessage: String?
+    @State private var feedbackClearTask: Task<Void, Never>?
 
     private var progressValue: Double {
         guard let duration = episode.duration, duration > 0 else { return 0 }
@@ -634,6 +672,7 @@ private struct HeroTunerCard: View {
                 // Reason as a TunerTag with signal yellow accent
                 TunerTag(text: reason, color: .offscriptSignalYellow, dim: true, wraps: true)
                 RecommendationSignalTraceView(signals: signals)
+                HomePreferenceStatusRow(message: feedbackStatusMessage)
 
                 // Mono metadata — date · duration. The "X LEFT" remaining
                 // time used to render here AND in the explanation tag above
@@ -703,6 +742,7 @@ private struct HeroTunerCard: View {
         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("\(episode.title) from \(episode.podcast.title). \(reason)")
+        .onDisappear { feedbackClearTask?.cancel() }
     }
 
     @ViewBuilder
@@ -737,9 +777,60 @@ private struct HeroTunerCard: View {
     }
 
     private func register(_ action: PreferenceSignal.Action) {
-        modelContext.insert(PreferenceSignal(action: action, episode: episode))
-        do { try modelContext.save() }
-        catch { homeLogger.error("Failed to save preference: \(error.localizedDescription, privacy: .public)") }
+        let signal = PreferenceSignal(action: action, episode: episode)
+        modelContext.insert(signal)
+        do {
+            try modelContext.save()
+            withAnimation(.easeInOut(duration: 0.18)) {
+                feedbackStatusMessage = statusMessage(for: action)
+            }
+            scheduleFeedbackStatusClear()
+            NotificationCenter.default.post(name: .offscriptRecommendationFeedbackChanged, object: nil)
+        } catch {
+            modelContext.delete(signal)
+            homeLogger.error("Failed to save preference: \(error.localizedDescription, privacy: .public)")
+            withAnimation(.easeInOut(duration: 0.18)) {
+                feedbackStatusMessage = "COULDN'T SAVE SIGNAL"
+            }
+            scheduleFeedbackStatusClear(delay: 3_000_000_000)
+        }
+    }
+
+    private func statusMessage(for action: PreferenceSignal.Action) -> String {
+        switch action {
+        case .like: "LIKED · RETUNING"
+        case .moreLikeThis: "MORE LIKE THIS · RETUNING"
+        case .lessLikeThis: "LESS LIKE THIS · RETUNING"
+        case .notInterested: "HIDDEN FROM SIGNAL · RETUNING"
+        }
+    }
+
+    private func scheduleFeedbackStatusClear(delay: UInt64 = 2_000_000_000) {
+        feedbackClearTask?.cancel()
+        feedbackClearTask = Task {
+            do {
+                try await Task.sleep(nanoseconds: delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    feedbackStatusMessage = nil
+                }
+            }
+        }
+    }
+}
+
+private struct HomePreferenceStatusRow: View {
+    let message: String?
+
+    var body: some View {
+        if let message {
+            TunerLabel(text: message, color: .offscriptFnMode, size: 8)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- reload Home recommendation sections immediately after Like / More / Less / Not Interested feedback
- debounce feedback-triggered reloads and guard discovery updates with a generation token so stale discovery results cannot overwrite newer sections
- show a brief Tuner retuning status on the headline card and cancel its cleanup task on card teardown
- document the recommendation behavior in the changelog

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: passed
- Xcode MCP RunAllTests: 44/44 passed
- git diff --check: passed