### PR TITLE
Rank discovery shows with preview evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Recommendation modes now materially change Home ranking.** `SIGNAL` excludes genre-only candidates, while `BALANCED` and `DISCOVERY` can include a separate tuned-genre lane after local evidence.
 - **Negative signals now suppress adjacent recommendations, not just the exact episode.** `Less like this`, `Not interested`, skipped, and abandoned signals carry disliked tags/show penalties into Home and Player suggestions.
 - **Home now reloads recommendations immediately after explicit feedback** instead of waiting for the next automatic refresh path, and the headline card shows a small retuning status after Like / More / Less / Not Interested.
+- **Discovery recommendations now inspect the latest feed preview before ranking new shows**, so Apple Podcasts Search hits with episode-level overlap beat generic genre-only catalog matches.
 
 ### Fixed — playback queue and Now Playing
 - **Playing a queue row now removes that row before playback starts**, so completion/remote-next does not replay the same episode before advancing.

--- a/OffScript/DiscoveryService.swift
+++ b/OffScript/DiscoveryService.swift
@@ -14,6 +14,7 @@ actor DiscoveryService {
     private let logger = Logger(subsystem: "com.offscript", category: "Discovery")
     private var cachedResults: [ScoredDiscoveryResult] = []
     private var cacheTimestamp: Date = .distantPast
+    private var cacheSignature = ""
 
     private let cacheDuration: TimeInterval = 3600 // 1 hour
 
@@ -22,10 +23,15 @@ actor DiscoveryService {
         subscribedFeedURLs: Set<String>,
         limit: Int = 10
     ) async -> [ScoredDiscoveryResult] {
+        let normalizedSubscribedFeedURLs = Set(subscribedFeedURLs.map(Self.normalizedFeedKey))
+        let signature = Self.cacheSignature(for: tasteProfile, subscribedFeedURLs: normalizedSubscribedFeedURLs)
+
         // Return cached results if fresh
-        if Date().timeIntervalSince(cacheTimestamp) < cacheDuration, !cachedResults.isEmpty {
+        if signature == cacheSignature,
+           Date().timeIntervalSince(cacheTimestamp) < cacheDuration,
+           !cachedResults.isEmpty {
             // Filter out any results the user has since subscribed to
-            let stillRelevant = cachedResults.filter { !subscribedFeedURLs.contains($0.result.feedURL.absoluteString) }
+            let stillRelevant = cachedResults.filter { !normalizedSubscribedFeedURLs.contains(Self.normalizedFeedKey($0.result.feedURL.absoluteString)) }
             if !stillRelevant.isEmpty {
                 return Array(stillRelevant.prefix(limit))
             }
@@ -47,29 +53,39 @@ actor DiscoveryService {
                 continue
             }
             for result in results {
-                let feedKey = result.feedURL.absoluteString
-                guard !subscribedFeedURLs.contains(feedKey),
+                let feedKey = Self.normalizedFeedKey(result.feedURL.absoluteString)
+                guard !normalizedSubscribedFeedURLs.contains(feedKey),
                       !seenFeedURLs.contains(feedKey) else { continue }
                 seenFeedURLs.insert(feedKey)
                 allResults.append(result)
             }
         }
 
-        let scored = allResults.map { result in
-            scoreResult(result, tasteProfile: tasteProfile)
+        let baselineScored = allResults.map { result in
+            Self.score(result: result, tasteProfile: tasteProfile)
         }
         .sorted { $0.score > $1.score }
+
+        let previewLimit = min(max(limit * 2, 6), 10, baselineScored.count)
+        let previewCandidates = Array(baselineScored.prefix(previewLimit).map(\.result))
+        let previewScored = await scorePreviewCandidates(previewCandidates, tasteProfile: tasteProfile)
+        let previewScoredByID = Dictionary(uniqueKeysWithValues: previewScored.map { ($0.result.id, $0) })
+        let scored = baselineScored
+            .map { previewScoredByID[$0.result.id] ?? $0 }
+            .sorted { $0.score > $1.score }
 
         let cacheLimit = max(limit, AppSettings.RecommendationMode.discovery.discoveryLimit)
         let topResults = Array(scored.prefix(cacheLimit))
         cachedResults = topResults
         cacheTimestamp = Date()
+        cacheSignature = signature
         return Array(topResults.prefix(limit))
     }
 
     func invalidateCache() {
         cachedResults = []
         cacheTimestamp = .distantPast
+        cacheSignature = ""
     }
 
     // MARK: - Query Generation
@@ -107,9 +123,36 @@ actor DiscoveryService {
 
     // MARK: - Scoring
 
-    private func scoreResult(
-        _ result: PodcastSearchResult,
+    private func scorePreviewCandidates(
+        _ candidates: [PodcastSearchResult],
         tasteProfile: UserTasteProfile
+    ) async -> [ScoredDiscoveryResult] {
+        await withTaskGroup(of: ScoredDiscoveryResult?.self) { group in
+            for result in candidates {
+                group.addTask {
+                    do {
+                        let preview = try await PodcastPreviewService.preview(for: result, episodeLimit: 3)
+                        return Self.score(result: result, tasteProfile: tasteProfile, preview: preview)
+                    } catch {
+                        return nil
+                    }
+                }
+            }
+
+            var scored: [ScoredDiscoveryResult] = []
+            for await result in group {
+                if let result {
+                    scored.append(result)
+                }
+            }
+            return scored
+        }
+    }
+
+    nonisolated static func score(
+        result: PodcastSearchResult,
+        tasteProfile: UserTasteProfile,
+        preview: PodcastPreviewSnapshot? = nil
     ) -> ScoredDiscoveryResult {
         var score: Double = 0.0
         var explanations: [String] = []
@@ -117,27 +160,52 @@ actor DiscoveryService {
 
         let titleLower = result.title.lowercased()
         let summaryLower = (result.summary ?? "").lowercased()
-        let searchableText = "\(titleLower) \(summaryLower)"
+        let previewSummaryLower = (preview?.summary ?? "").lowercased()
+        let categoryText = (preview?.categories ?? []).joined(separator: " ").lowercased()
+        let episodeText = (preview?.latestEpisodes ?? [])
+            .map { "\($0.title) \($0.summary ?? "")" }
+            .joined(separator: " ")
+            .lowercased()
+        let searchableText = "\(titleLower) \(summaryLower) \(previewSummaryLower) \(categoryText)"
 
         // Genre match — iTunes returns primaryGenreName in summary field
         let preferredGenresLower = Set(tasteProfile.preferredGenres.map { $0.lowercased() })
-        if let resultGenre = result.summary?.lowercased(),
-           preferredGenresLower.contains(resultGenre) {
+        let resultGenres = Set(([result.summary] + (preview?.categories ?? []).map(Optional.some))
+            .compactMap { $0?.lowercased() })
+        if let resultGenre = resultGenres.intersection(preferredGenresLower).sorted().first {
             score += 0.35
-            explanations.append("Matches your interest in \(result.summary ?? "")")
+            explanations.append("Matches your saved \(resultGenre) lane")
             signals.append(RecommendationSignal(label: "source", value: "genre"))
-            signals.append(RecommendationSignal(label: "lane", value: result.summary ?? "saved genre"))
+            signals.append(RecommendationSignal(label: "lane", value: resultGenre))
         }
 
         // Tag overlap
         var matchedTags: [String] = []
+        var latestEpisodeMatchedTags: [String] = []
         for tag in tasteProfile.topTags {
-            if searchableText.contains(tag.lowercased()) {
+            let normalizedTag = tag.lowercased()
+            if episodeText.contains(normalizedTag) {
+                score += 0.24
+                latestEpisodeMatchedTags.append(tag)
+                matchedTags.append(tag)
+            } else if searchableText.contains(normalizedTag) {
                 score += 0.15
                 matchedTags.append(tag)
             }
         }
-        if !matchedTags.isEmpty {
+        if !latestEpisodeMatchedTags.isEmpty {
+            let sample = latestEpisodeMatchedTags.prefix(2).joined(separator: ", ")
+            explanations.insert("Latest episodes overlap your \(sample) signal", at: 0)
+            signals.append(RecommendationSignal(label: "source", value: "latest episode"))
+            signals.append(RecommendationSignal(label: "tags", value: sample))
+            if let title = preview?.latestEpisodes.first(where: { episode in
+                latestEpisodeMatchedTags.contains(where: { tag in
+                    "\(episode.title) \(episode.summary ?? "")".localizedCaseInsensitiveContains(tag)
+                })
+            })?.title {
+                signals.append(RecommendationSignal(label: "episode", value: Self.truncated(title, limit: 42)))
+            }
+        } else if !matchedTags.isEmpty {
             let sample = matchedTags.prefix(2).joined(separator: ", ")
             explanations.append("Covers topics you like: \(sample)")
             signals.append(RecommendationSignal(label: "source", value: "taste tag"))
@@ -153,6 +221,20 @@ actor DiscoveryService {
                 score += 0.10
                 explanations.append("Similar to shows you finish")
                 signals.append(RecommendationSignal(label: "source", value: "show affinity"))
+                break
+            }
+        }
+
+        if let freshestEpisode = preview?.latestEpisodes.compactMap(\.pubDate).max() {
+            let days = max(0, Date().timeIntervalSince(freshestEpisode) / 86_400)
+            switch days {
+            case ..<14:
+                score += 0.08
+                signals.append(RecommendationSignal(label: "freshness", value: "active feed"))
+            case ..<45:
+                score += 0.04
+                signals.append(RecommendationSignal(label: "freshness", value: "recent feed"))
+            default:
                 break
             }
         }
@@ -175,5 +257,40 @@ actor DiscoveryService {
         }
 
         return ScoredDiscoveryResult(result: result, score: score, explanation: explanation, signalTrace: signals)
+    }
+
+    private nonisolated static func normalizedFeedKey(_ raw: String) -> String {
+        guard var components = URLComponents(string: raw) else {
+            return raw.lowercased()
+        }
+        let scheme = components.scheme?.lowercased()
+        components.scheme = (scheme == "http" || scheme == "feed") ? "https" : scheme
+        components.host = components.host?.lowercased()
+        if components.port == 80 || components.port == 443 {
+            components.port = nil
+        }
+        components.fragment = nil
+        if components.path == "/" {
+            components.path = ""
+        } else {
+            while components.path.hasSuffix("/") {
+                components.path.removeLast()
+            }
+        }
+        return components.url?.absoluteString.lowercased() ?? raw.lowercased()
+    }
+
+    private nonisolated static func cacheSignature(for profile: UserTasteProfile, subscribedFeedURLs: Set<String>) -> String {
+        [
+            profile.topTags.map { $0.lowercased() }.joined(separator: "|"),
+            profile.preferredGenres.map { $0.lowercased() }.joined(separator: "|"),
+            profile.showAffinity.map { $0.lowercased() }.joined(separator: "|"),
+            subscribedFeedURLs.sorted().joined(separator: "|")
+        ].joined(separator: "||")
+    }
+
+    private nonisolated static func truncated(_ value: String, limit: Int) -> String {
+        guard value.count > limit else { return value }
+        return String(value.prefix(limit - 1)) + "…"
     }
 }

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -10,6 +10,24 @@ struct PodcastPreviewEpisode: Identifiable, Hashable {
     let audioURL: URL
     let artworkURL: URL?
 
+    init(
+        id: String,
+        title: String,
+        pubDate: Date?,
+        duration: TimeInterval?,
+        summary: String?,
+        audioURL: URL,
+        artworkURL: URL?
+    ) {
+        self.id = id
+        self.title = title
+        self.pubDate = pubDate
+        self.duration = duration
+        self.summary = summary
+        self.audioURL = audioURL
+        self.artworkURL = artworkURL
+    }
+
     init(item: ParsedFeedItem) {
         self.id = item.guid ?? item.audioURL.absoluteString
         self.title = item.title

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -514,6 +514,57 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func discoveryPreviewEvidenceBeatsGenreOnlyCatalogMatch() throws {
+        let tasteProfile = UserTasteProfile()
+        tasteProfile.topTags = ["audio craft"]
+        tasteProfile.preferredGenres = ["Technology"]
+
+        let genreOnly = PodcastSearchResult(
+            title: "Generic Technology Weekly",
+            author: "Catalog Network",
+            feedURL: URL(string: "https://example.com/generic-tech.xml")!,
+            artworkURL: nil,
+            websiteURL: nil,
+            summary: "Technology"
+        )
+        let evidenced = PodcastSearchResult(
+            title: "Signal Workshop",
+            author: "Independent Audio Lab",
+            feedURL: URL(string: "https://example.com/signal-workshop.xml")!,
+            artworkURL: nil,
+            websiteURL: nil,
+            summary: "Technology"
+        )
+        let preview = PodcastPreviewSnapshot(
+            title: "Signal Workshop",
+            author: "Independent Audio Lab",
+            summary: "Field notes for makers and editors.",
+            categories: ["Technology"],
+            websiteURL: nil,
+            latestEpisodes: [
+                PodcastPreviewEpisode(
+                    id: "episode-1",
+                    title: "Audio craft for sharper interviews",
+                    pubDate: .now,
+                    duration: 1_800,
+                    summary: "Practical audio craft choices for hosts.",
+                    audioURL: URL(string: "https://example.com/signal-workshop-1.mp3")!,
+                    artworkURL: nil
+                )
+            ]
+        )
+
+        let genericScore = DiscoveryService.score(result: genreOnly, tasteProfile: tasteProfile)
+        let evidencedScore = DiscoveryService.score(result: evidenced, tasteProfile: tasteProfile, preview: preview)
+
+        #expect(evidencedScore.score > genericScore.score)
+        #expect(evidencedScore.explanation == "Latest episodes overlap your audio craft signal")
+        #expect(evidencedScore.signalTrace.contains(RecommendationSignal(label: "source", value: "latest episode")))
+        #expect(evidencedScore.signalTrace.contains(RecommendationSignal(label: "tags", value: "audio craft")))
+    }
+
+    @Test
+    @MainActor
     func playerSuggestionsExposeNowPlayingSignalTrace() throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- rank Discovery candidates with bounded RSS preview evidence instead of only Apple Podcasts Search catalog metadata
- prefer latest-episode overlap explanations when preview content matches saved taste tags
- normalize feed-key filtering and cache discovery results by taste/subscription signature

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: discoveryPreviewEvidenceBeatsGenreOnlyCatalogMatch, homeRecommendationsFilterNegativePreferenceSignals, lessLikeThisSuppressesSharedTagsAcrossHomeAndPlayer passed
- Xcode MCP RunAllTests: 45/45 passed
- git diff --check: passed