### PR TITLE
Rank Home headline by strongest recommendation signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Negative signals now suppress adjacent recommendations, not just the exact episode.** `Less like this`, `Not interested`, skipped, and abandoned signals carry disliked tags/show penalties into Home and Player suggestions.
 - **Home now reloads recommendations immediately after explicit feedback** instead of waiting for the next automatic refresh path, and the headline card shows a small retuning status after Like / More / Less / Not Interested.
 - **Discovery recommendations now inspect the latest feed preview before ranking new shows**, so Apple Podcasts Search hits with episode-level overlap beat generic genre-only catalog matches.
+- **Home headline selection now ranks the strongest authored recommendation across all local sections** instead of blindly promoting the first row of the first section.
 
 ### Fixed — playback queue and Now Playing
 - **Playing a queue row now removes that row before playback starts**, so completion/remote-next does not replay the same episode before advancing.

--- a/OffScript/DiscoveryService.swift
+++ b/OffScript/DiscoveryService.swift
@@ -3,11 +3,19 @@ import OSLog
 import SwiftData
 
 struct ScoredDiscoveryResult: Identifiable {
-    var id: String { result.id }
+    let id: String
     let result: PodcastSearchResult
     let score: Double
     let explanation: String
     let signalTrace: [RecommendationSignal]
+
+    init(result: PodcastSearchResult, score: Double, explanation: String, signalTrace: [RecommendationSignal]) {
+        self.id = result.feedURL.absoluteString
+        self.result = result
+        self.score = score
+        self.explanation = explanation
+        self.signalTrace = signalTrace
+    }
 }
 
 actor DiscoveryService {

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -49,8 +49,9 @@ struct HomeView: View {
                 } else {
                     let episodeSections = sections.filter { !$0.isDiscoverySection }
                     let discoverySections = sections.filter(\.isDiscoverySection)
+                    let leadScoredEpisode = RecommendationService.headlineCandidate(from: episodeSections)
 
-                    if let leadSection = episodeSections.first, let leadScoredEpisode = leadSection.scoredEpisodes.first {
+                    if let leadScoredEpisode {
                         HeroTunerCard(
                             episode: leadScoredEpisode.episode,
                             reason: leadScoredEpisode.explanation,
@@ -58,19 +59,10 @@ struct HomeView: View {
                         )
                         .padding(.horizontal, OffScriptTheme.pagePadding)
                         .padding(.bottom, 6)
-
-                        let remainingLeadEpisodes = Array(leadSection.episodes.dropFirst())
-                        if !remainingLeadEpisodes.isEmpty {
-                            TunerRail(
-                                title: "NEXT BEST PICKS",
-                                episodes: remainingLeadEpisodes,
-                                reasonProvider: { leadSection.explanation(for: $0) },
-                                signalProvider: { leadSection.signalTrace(for: $0) }
-                            )
-                        }
                     }
 
-                    ForEach(Array(episodeSections.dropFirst().enumerated()), id: \.element.id) { _, section in
+                    let railSections = Self.sections(episodeSections, excluding: leadScoredEpisode?.episode.id)
+                    ForEach(Array(railSections.enumerated()), id: \.element.id) { _, section in
                         TunerRail(
                             title: section.title.uppercased(),
                             episodes: section.episodes,
@@ -143,6 +135,15 @@ struct HomeView: View {
             errorMessage = error.localizedDescription
             isLoading = false
             isLoadingDiscovery = false
+        }
+    }
+
+    private static func sections(_ sections: [HomeFeedSection], excluding leadEpisodeID: UUID?) -> [HomeFeedSection] {
+        guard let leadEpisodeID else { return sections }
+        return sections.compactMap { section in
+            let remaining = section.scoredEpisodes.filter { $0.episode.id != leadEpisodeID }
+            guard !remaining.isEmpty else { return nil }
+            return HomeFeedSection(title: section.title, subtitle: section.subtitle, scoredEpisodes: remaining)
         }
     }
 

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -83,6 +83,35 @@ final class RecommendationService {
         let penalizedShows: Set<String>
     }
 
+    static func headlineCandidate(from sections: [HomeFeedSection]) -> ScoredEpisode? {
+        sections
+            .flatMap(\.scoredEpisodes)
+            .max { headlineScore($0) < headlineScore($1) }
+    }
+
+    private static func headlineScore(_ scored: ScoredEpisode) -> Double {
+        let sourceValues = Set(scored.signalTrace
+            .filter { $0.label == "source" }
+            .map { $0.value.lowercased() })
+        var score = scored.score
+        score += Double(min(scored.signalTrace.count, 4)) * 4
+
+        if sourceValues.contains("queue") {
+            score += 40
+        }
+        if sourceValues.contains("resume") {
+            score += 28
+        }
+        if sourceValues.contains("completion") || sourceValues.contains("show affinity") {
+            score += 22
+        }
+        if sourceValues.contains("tag match") || sourceValues.contains("topic overlap") || sourceValues.contains("recent interest") {
+            score += 16
+        }
+
+        return score
+    }
+
     @MainActor
     func discoverySection(
         context: ModelContext,

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -436,6 +436,51 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func headlineCandidateUsesStrongestAuthoredSignalAcrossSections() throws {
+        let lowShow = Podcast(title: "Low Evidence", feedURL: URL(string: "https://example.com/low.xml")!)
+        let strongShow = Podcast(title: "Strong Evidence", feedURL: URL(string: "https://example.com/strong.xml")!)
+        let low = Episode(title: "Generic Queue", pubDate: .now, duration: 1_800, audioURL: URL(string: "https://example.com/low.mp3")!, podcast: lowShow)
+        let strong = Episode(title: "Finished Thread", pubDate: .now, duration: 1_800, audioURL: URL(string: "https://example.com/strong.mp3")!, podcast: strongShow)
+
+        let sections = [
+            HomeFeedSection(
+                title: "Signal Lock",
+                subtitle: "User intent lane.",
+                scoredEpisodes: [
+                    ScoredEpisode(
+                        episode: low,
+                        score: 180,
+                        explanation: "Fits your short-listen setting",
+                        signalTrace: [RecommendationSignal(label: "source", value: "duration")]
+                    )
+                ]
+            ),
+            HomeFeedSection(
+                title: "Shows You Finish",
+                subtitle: "Completion lane.",
+                scoredEpisodes: [
+                    ScoredEpisode(
+                        episode: strong,
+                        score: 220,
+                        explanation: "You keep finishing Strong Evidence",
+                        signalTrace: [
+                            RecommendationSignal(label: "source", value: "completion"),
+                            RecommendationSignal(label: "show", value: "Strong Evidence"),
+                            RecommendationSignal(label: "finishes", value: "3")
+                        ]
+                    )
+                ]
+            )
+        ]
+
+        let headline = try #require(RecommendationService.headlineCandidate(from: sections))
+
+        #expect(headline.episode.id == strong.id)
+        #expect(headline.explanation == "You keep finishing Strong Evidence")
+    }
+
+    @Test
+    @MainActor
     func signalLockedModeExcludesGenreOnlyCandidates() throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- choose Home's headline card from the strongest scored recommendation across local sections instead of first-section order
- remove the promoted episode from the rails so it does not duplicate below the hero
- store discovery result identifiers to clear the Swift isolation warning surfaced by Xcode Cloud #49

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: headlineCandidateUsesStrongestAuthoredSignalAcrossSections, homeRecommendationsPutQueueIntentBeforeFreshness, testPostOnboardingShellSmoke passed
- Xcode MCP RunAllTests: 46/46 passed
- git diff --check: passed