### PR TITLE
Load Library summary incrementally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Library directory rendering now builds one snapshot per render pass** for filtered shows, alphabet sections, and row numbers, with debounced search input so typing does not repeatedly sort/group the whole library.
 - **Library no longer observes every OPML progress tick at the root page level.** The import strip repaints during batch progress, and the expensive directory snapshot refreshes when the batch reaches a terminal state.
 - **Bulk OPML import now skips already-subscribed feed URLs before network fetch/parse work** using the same normalized feed-key logic as OPML dedupe, so re-importing a large library does not waste rows on feeds that are already tuned.
+- **Library summary loading now avoids hydrating the full unplayed back catalog on open.** The header count and fresh rail load from count/limited fetches first, while per-show unplayed counts fill in incrementally in small chunks.
 
 ### Added — recommendation tuner and signal discovery
 - **Settings now has a three-position recommendation tuner** (`SIGNAL`, `BALANCED`, `DISCOVERY`) so listeners can choose whether OffScript stays strictly inside known local evidence or opens a new-show discovery lane.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -455,40 +455,72 @@ struct LibraryView: View {
 
     @MainActor
     private func loadLibraryEpisodeSummary() {
+        startLibraryEpisodeSummaryLoad(deferWhileImporting: false)
+    }
+
+    @MainActor
+    private func scheduleLibraryEpisodeSummaryLoad() {
+        startLibraryEpisodeSummaryLoad(deferWhileImporting: true)
+    }
+
+    @MainActor
+    private func startLibraryEpisodeSummaryLoad(deferWhileImporting: Bool) {
         summaryLoadTask?.cancel()
-        guard !subscribedPodcasts.isEmpty else {
+        let podcastIDs = subscribedPodcastIDs
+        guard !podcastIDs.isEmpty else {
             freshEpisodes = []
             unplayedEpisodeCount = 0
             freshCountsByPodcastID = [:]
             return
         }
 
+        summaryLoadTask = Task { @MainActor in
+            if deferWhileImporting, BatchImportService.shared.isRunning {
+                try? await Task.sleep(nanoseconds: 1_200_000_000)
+                guard !Task.isCancelled, !BatchImportService.shared.isRunning else { return }
+            }
+            await refreshLibraryEpisodeSummary(podcastIDs: podcastIDs)
+        }
+    }
+
+    @MainActor
+    private func refreshLibraryEpisodeSummary(podcastIDs: [UUID]) async {
         do {
-            let descriptor = FetchDescriptor<Episode>(
+            let countDescriptor = FetchDescriptor<Episode>(
+                predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed }
+            )
+            var freshDescriptor = FetchDescriptor<Episode>(
                 predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed },
                 sortBy: [SortDescriptor(\Episode.pubDate, order: .reverse)]
             )
-            let unplayedEpisodes = try modelContext.fetch(descriptor)
-            unplayedEpisodeCount = unplayedEpisodes.count
-            freshEpisodes = Array(unplayedEpisodes.prefix(10))
-            freshCountsByPodcastID = Dictionary(unplayedEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
+            freshDescriptor.fetchLimit = 10
+
+            unplayedEpisodeCount = try modelContext.fetchCount(countDescriptor)
+            freshEpisodes = try modelContext.fetch(freshDescriptor)
+            freshCountsByPodcastID = Dictionary(freshEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
+
+            var counts = freshCountsByPodcastID
+            let chunkSize = 24
+            for start in stride(from: 0, to: podcastIDs.count, by: chunkSize) {
+                guard !Task.isCancelled else { return }
+                let chunk = podcastIDs[start..<min(start + chunkSize, podcastIDs.count)]
+                for podcastID in chunk {
+                    var descriptor = FetchDescriptor<Episode>(
+                        predicate: #Predicate<Episode> {
+                            $0.podcast.id == podcastID && $0.podcast.isSubscribed && !$0.isPlayed
+                        }
+                    )
+                    let count = try modelContext.fetchCount(descriptor)
+                    counts[podcastID] = count
+                }
+                freshCountsByPodcastID = counts.filter { $0.value > 0 }
+                await Task.yield()
+            }
         } catch {
             freshEpisodes = []
             unplayedEpisodeCount = 0
             freshCountsByPodcastID = [:]
             libraryLogger.error("Library summary load failed: \(error.localizedDescription, privacy: .public)")
-        }
-    }
-
-    @MainActor
-    private func scheduleLibraryEpisodeSummaryLoad() {
-        summaryLoadTask?.cancel()
-        summaryLoadTask = Task { @MainActor in
-            if BatchImportService.shared.isRunning {
-                try? await Task.sleep(nanoseconds: 1_200_000_000)
-                guard !Task.isCancelled, !BatchImportService.shared.isRunning else { return }
-            }
-            loadLibraryEpisodeSummary()
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid hydrating every unplayed episode on Library open
- load total unplayed count with fetchCount and the fresh rail with a 10-episode limited fetch
- fill per-show unplayed counts incrementally in small chunks so large libraries become usable sooner

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: libraryDirectoryOrganizerFiltersAndSortsLargeLibraries, libraryDirectoryOrganizerBuildsAlphabetSections, testLargeLibrarySeedSmoke, testLargeLibraryAlphabetRailJumpsToSelectedLetter passed
- Xcode MCP RunAllTests: 46/46 passed
- git diff --check: passed