### PR TITLE
Clear Library summary descriptor warning

### DIFF
--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -505,7 +505,7 @@ struct LibraryView: View {
                 guard !Task.isCancelled else { return }
                 let chunk = podcastIDs[start..<min(start + chunkSize, podcastIDs.count)]
                 for podcastID in chunk {
-                    var descriptor = FetchDescriptor<Episode>(
+                    let descriptor = FetchDescriptor<Episode>(
                         predicate: #Predicate<Episode> {
                             $0.podcast.id == podcastID && $0.podcast.isSubscribed && !$0.isPlayed
                         }


### PR DESCRIPTION
## Summary
- use let for the per-podcast count descriptor in the incremental Library summary loader

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: testLargeLibrarySeedSmoke, testLargeLibraryAlphabetRailJumpsToSelectedLetter passed
- git diff --check: passed

## Context
Xcode Cloud build #52 reported this warning from the Library summary branch. This cleanup keeps the next cloud build warning-clean except for the existing StoreKit receipt deprecation.