### PR TITLE
Restore Library alphabet carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Library now behaves like a real channel directory for 250+ show libraries.** The shows list has Tuner-styled search, scope filters, sort modes, compact/artwork row density, visible-count readouts, and an A-Z jump rail so large OPML imports are navigable without endless scrolling.
 - **Large libraries default to compact rows.** Artwork-heavy rows remain available for smaller libraries, but 120+ show libraries automatically use dense Tuner rows to reduce scroll distance and image/layout churn.
 - **The alphabet jump rail is now a full A-Z/# key bank with selected and disabled states** so large libraries expose every directory letter as a direct Tuner control instead of hiding letters in a horizontal strip.
+- **The Library alphabet selector is back to the compact `#-Z` carousel form** while keeping the working direct-letter jump behavior and selected/disabled Tuner states.
 
 ### Changed — Library performance
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -788,35 +788,48 @@ private struct LibraryAlphabetRail: View {
     }
 
     var body: some View {
-        LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 44, maximum: 48), spacing: 4)],
-            alignment: .leading,
-            spacing: 4
-        ) {
-            ForEach(keys, id: \.self) { key in
-                let section = sectionsByTitle[key]
-                let isSelected = selectedSectionID == section?.id
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(keys, id: \.self) { key in
+                        let section = sectionsByTitle[key]
+                        let isSelected = selectedSectionID == section?.id
 
-                if let section {
-                    Button {
-                        onSelect(section.id)
-                    } label: {
-                        letterKey(key, isSelected: isSelected, isDisabled: false)
+                        if let section {
+                            Button {
+                                onSelect(section.id)
+                                withAnimation(.easeInOut(duration: 0.18)) {
+                                    proxy.scrollTo(key, anchor: .center)
+                                }
+                            } label: {
+                                letterKey(key, isSelected: isSelected, isDisabled: false)
+                            }
+                            .id(key)
+                            .buttonStyle(.plain)
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel("Jump to \(key)")
+                            .accessibilityIdentifier("LibraryJumpLetter\(key)")
+                            .accessibilityAddTraits(isSelected ? .isSelected : [])
+                        } else {
+                            letterKey(key, isSelected: false, isDisabled: true)
+                                .id(key)
+                                .accessibilityLabel("No \(key) channels")
+                                .accessibilityIdentifier("LibraryJumpLetter\(key)")
+                                .accessibilityAddTraits(.isStaticText)
+                        }
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel("Jump to \(key)")
-                    .accessibilityIdentifier("LibraryJumpLetter\(key)")
-                    .accessibilityAddTraits(isSelected ? .isSelected : [])
-                } else {
-                    letterKey(key, isSelected: false, isDisabled: true)
-                        .accessibilityLabel("No \(key) channels")
-                        .accessibilityIdentifier("LibraryJumpLetter\(key)")
-                        .accessibilityAddTraits(.isStaticText)
+                }
+                .padding(.vertical, 4)
+                .onChange(of: selectedSectionID) { _, newValue in
+                    guard let newValue,
+                          let key = sectionsByTitle.first(where: { $0.value.id == newValue })?.key else { return }
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        proxy.scrollTo(key, anchor: .center)
+                    }
                 }
             }
+            .accessibilityIdentifier("LibraryAlphabetCarousel")
         }
-        .padding(.vertical, 4)
     }
 
     private func letterKey(_ key: String, isSelected: Bool, isDisabled: Bool) -> some View {

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -798,9 +798,6 @@ private struct LibraryAlphabetRail: View {
                         if let section {
                             Button {
                                 onSelect(section.id)
-                                withAnimation(.easeInOut(duration: 0.18)) {
-                                    proxy.scrollTo(key, anchor: .center)
-                                }
                             } label: {
                                 letterKey(key, isSelected: isSelected, isDisabled: false)
                             }

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -56,11 +56,19 @@ final class OffScriptUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 12))
-        let zJump = app.descendants(matching: .any)["LibraryJumpLetterZ"]
-        for _ in 0..<4 where !zJump.exists {
+        XCTAssertTrue(app.staticTexts["SHOWS · DIRECTORY"].waitForExistence(timeout: 8))
+        let carousel = app.scrollViews["LibraryAlphabetCarousel"]
+        XCTAssertTrue(carousel.waitForExistence(timeout: 8))
+        for _ in 0..<4 where !carousel.isHittable {
             app.swipeUp()
         }
+        XCTAssertTrue(carousel.isHittable)
+        let zJump = app.descendants(matching: .any)["LibraryJumpLetterZ"]
+        for _ in 0..<6 where !zJump.isHittable {
+            carousel.swipeLeft()
+        }
         XCTAssertTrue(zJump.waitForExistence(timeout: 8))
+        XCTAssertTrue(zJump.isHittable)
 
         zJump.tap()
 

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -63,12 +63,12 @@ final class OffScriptUITests: XCTestCase {
             app.swipeUp()
         }
         XCTAssertTrue(carousel.isHittable)
-        let zJump = app.descendants(matching: .any)["LibraryJumpLetterZ"]
-        for _ in 0..<6 where !zJump.isHittable {
+        let zJump = carousel.descendants(matching: .any)["LibraryJumpLetterZ"]
+        XCTAssertTrue(zJump.waitForExistence(timeout: 8))
+        for _ in 0..<12 where !zJump.isHittable {
             carousel.swipeLeft()
         }
-        XCTAssertTrue(zJump.waitForExistence(timeout: 8))
-        XCTAssertTrue(zJump.isHittable)
+        XCTAssertTrue(zJump.isHittable, "Expected to reach LibraryJumpLetterZ within the alphabet carousel")
 
         zJump.tap()
 


### PR DESCRIPTION
## Summary
- restore the Library  alphabet selector as a horizontal Tuner carousel
- keep direct section jumps, selected state, disabled letters, and automatic centering of the active key
- update large-library UI coverage to scroll to the carousel, swipe it horizontally, and verify Z jumps correctly

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: testLargeLibrarySeedSmoke, testLargeLibraryAlphabetRailJumpsToSelectedLetter, libraryDirectoryOrganizerBuildsAlphabetSections passed
- Xcode MCP RunAllTests: 46/46 passed
- git diff --check: passed