### PR TITLE
Fix Settings crash without CloudKit entitlements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Episode switches reset duration immediately and guard artwork updates** so stale duration/artwork from the previous episode cannot race into Player or Now Playing.
 
 ### Fixed — Apple identity / iCloud sync state
+- **Opening Settings no longer crashes builds without CloudKit entitlements.** iCloud account-status checks are now gated behind a CloudKit entitlement/profile check, and Settings reports `ICLOUD · NOT CONFIGURED` until the signed CloudKit profile lands.
 - **CloudKit sync is guarded by runtime container state** so failed or unavailable iCloud-backed stores fall back to local storage instead of presenting as active sync.
 - **Settings now validates stored Sign in with Apple credentials** before treating the user as signed in. Revoked or missing credentials clear local identity and disable sync.
 - **Transient Apple credential validation failures no longer clear a saved Apple ID.** Credentials are cleared only for revoked or not-found states.

--- a/OffScript/AppleIdentityService.swift
+++ b/OffScript/AppleIdentityService.swift
@@ -32,6 +32,7 @@ enum CloudKitAccountAvailability: Equatable {
     case restricted
     case couldNotDetermine
     case temporarilyUnavailable
+    case notConfigured
 
     var allowsSync: Bool {
         self == .available
@@ -44,6 +45,7 @@ enum CloudKitAccountAvailability: Equatable {
         case .restricted: "ICLOUD · RESTRICTED"
         case .couldNotDetermine: "ICLOUD · UNKNOWN"
         case .temporarilyUnavailable: "ICLOUD · TEMPORARY ISSUE"
+        case .notConfigured: "ICLOUD · NOT CONFIGURED"
         }
     }
 }
@@ -86,6 +88,8 @@ enum AppleIdentityService {
 
 enum CloudKitAccountService {
     static func currentStatus() async -> CloudKitAccountAvailability {
+        guard hasCloudKitEntitlement else { return .notConfigured }
+
         do {
             let status = try await CKContainer.default().accountStatus()
             switch status {
@@ -105,5 +109,50 @@ enum CloudKitAccountService {
         } catch {
             return .couldNotDetermine
         }
+    }
+
+    static func entitlementsAllowCloudKitAccountStatus(
+        services: Any?,
+        containerIdentifiers: Any?
+    ) -> Bool {
+        guard let services = services as? [String],
+              services.contains("CloudKit"),
+              let containerIdentifiers = containerIdentifiers as? [String] else {
+            return false
+        }
+        return !containerIdentifiers.isEmpty
+    }
+
+    private static var hasCloudKitEntitlement: Bool {
+        #if targetEnvironment(simulator)
+        return false
+        #else
+        guard let entitlements = embeddedProvisioningProfileEntitlements else { return false }
+        return entitlementsAllowCloudKitAccountStatus(
+            services: entitlements["com.apple.developer.icloud-services"],
+            containerIdentifiers: entitlements["com.apple.developer.icloud-container-identifiers"]
+        )
+        #endif
+    }
+
+    private static var embeddedProvisioningProfileEntitlements: [String: Any]? {
+        guard let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision"),
+              let data = try? Data(contentsOf: url),
+              let rawProfile = String(data: data, encoding: .isoLatin1),
+              let plistStart = rawProfile.range(of: "<plist"),
+              let plistEnd = rawProfile.range(of: "</plist>", options: .backwards) else {
+            return nil
+        }
+
+        let plistText = String(rawProfile[plistStart.lowerBound..<plistEnd.upperBound])
+        guard let plistData = plistText.data(using: .utf8),
+              let profile = try? PropertyListSerialization.propertyList(
+                from: plistData,
+                options: [],
+                format: nil
+              ) as? [String: Any] else {
+            return nil
+        }
+        return profile["Entitlements"] as? [String: Any]
     }
 }

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -659,6 +659,9 @@ struct SettingsView: View {
             return "Apple sign-in needs repair before sync can resume."
         }
         guard cloudKitAvailability.allowsSync else {
+            if cloudKitAvailability == .notConfigured {
+                return "This build is missing iCloud entitlements. Sync stays local until the signed CloudKit profile lands."
+            }
             return "Apple identity is saved; iCloud sync waits for an available iCloud account."
         }
         guard cloudSyncEnabled else {

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -689,6 +689,22 @@ struct OffScriptTests {
     }
 
     @Test
+    func cloudKitAccountStatusRequiresCloudKitEntitlements() {
+        #expect(CloudKitAccountService.entitlementsAllowCloudKitAccountStatus(
+            services: nil,
+            containerIdentifiers: nil
+        ) == false)
+        #expect(CloudKitAccountService.entitlementsAllowCloudKitAccountStatus(
+            services: ["CloudKit"],
+            containerIdentifiers: nil
+        ) == false)
+        #expect(CloudKitAccountService.entitlementsAllowCloudKitAccountStatus(
+            services: ["CloudKit"],
+            containerIdentifiers: ["iCloud.com.offscript.app"]
+        ) == true)
+    }
+
+    @Test
     @MainActor
     func libraryDirectoryOrganizerFiltersAndSortsLargeLibraries() {
         let stale = Podcast(

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -41,6 +41,21 @@ final class OffScriptUITests: XCTestCase {
     }
 
     @MainActor
+    func testSettingsPanelOpensFromHome() throws {
+        let app = makeApp(hasSeenOnboarding: true)
+        app.launch()
+
+        XCTAssertTrue(app.screen("HomeScreen").waitForExistence(timeout: 10))
+        app.buttons["Open settings"].tap()
+
+        let settingsLabel = app.staticTexts["SETTINGS · CONFIG PANEL"]
+        if !settingsLabel.waitForExistence(timeout: 10) {
+            XCTFail("Settings panel did not appear. Hierarchy:\n\(app.debugDescription)")
+        }
+        XCTAssertTrue(app.buttons["Close settings"].waitForExistence(timeout: 5))
+    }
+
+    @MainActor
     func testLargeLibrarySeedSmoke() throws {
         let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 258, debugEpisodesPerShow: 3, debugLaunchTab: 1)
         app.launch()


### PR DESCRIPTION
Summary:
- Gate CloudKit account-status checks behind CloudKit entitlement/profile detection so Settings can open in builds that do not yet ship CloudKit entitlements.
- Surface `ICLOUD · NOT CONFIGURED` instead of crashing or implying account availability when CloudKit is not signed into the build.
- Add a Settings UI smoke test and entitlement-gate unit coverage.

Root cause:
- Settings started `refreshIdentityStatus()` on presentation and always called `CKContainer.default().accountStatus()`. In current builds without CloudKit entitlements, that call traps before throwing, killing Settings on open.

Verification:
- Reproduced with `xcodebuild test -only-testing:OffScriptUITests/OffScriptUITests/testSettingsPanelOpensFromHome`; crash report pointed at `CloudKitAccountService.currentStatus()` from `SettingsView.refreshIdentityStatus()`.
- Xcode MCP BuildProject passed.
- Xcode MCP RunSomeTests passed: testSettingsPanelOpensFromHome, cloudKitAccountStatusRequiresCloudKitEntitlements.
- Xcode MCP RunAllTests passed: 48/48.
- git diff --check passed.
