### PR TITLE
Use StoreKit app transactions for Sentry environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Bulk OPML import cancellation now marks pending/importing rows as cancelled** instead of leaving them stuck mid-import.
 - **Settings no longer claims iCloud sync is active unless the launch actually opened a CloudKit-backed SwiftData container.**
 - **The SwiftData test container is explicitly local-only** so CloudKit entitlements do not break in-memory unit tests.
+- **Sentry TestFlight/App Store environment tagging now uses StoreKit 2 app transactions** instead of the deprecated receipt URL path, clearing the recurring iOS 18 `appStoreReceiptURL` archive warning.
 
 ### Fixed — Xcode Cloud signing
 - **Build number advanced to 41 after Xcode Cloud runs #40 and #41 failed exporting app build 40.**

--- a/OffScript/CrashReporter.swift
+++ b/OffScript/CrashReporter.swift
@@ -1,6 +1,24 @@
 import Foundation
 import OSLog
 import Sentry
+import StoreKit
+
+enum SentryEnvironmentResolver {
+    static let cacheKey = "offscript.sentryEnvironment"
+
+    static func sentryEnvironment(storeKitEnvironmentRawValue rawValue: String) -> String {
+        switch rawValue.lowercased() {
+        case "sandbox":
+            return "testflight"
+        case "xcode":
+            return "debug"
+        case "production":
+            return "production"
+        default:
+            return "production"
+        }
+    }
+}
 
 /// Quota-aware Sentry initializer.
 ///
@@ -80,6 +98,7 @@ enum CrashReporter {
         }
 
         logger.info("Sentry initialized — release \(Self.releaseTag, privacy: .public), env \(Self.environment, privacy: .public)")
+        refreshStoreKitEnvironment()
     }
 
     /// `1.14.2-23` — matches App Store Connect release identifiers so you
@@ -95,13 +114,33 @@ enum CrashReporter {
         #if DEBUG
         return "debug"
         #else
-        // Sentry distinguishes TestFlight (sandbox receipt) from App Store
-        // (production receipt) automatically via the receipt URL path.
-        if let receipt = Bundle.main.appStoreReceiptURL?.lastPathComponent,
-           receipt == "sandboxReceipt" {
-            return "testflight"
+        return UserDefaults.standard.string(forKey: SentryEnvironmentResolver.cacheKey) ?? "production"
+        #endif
+    }
+
+    private static func refreshStoreKitEnvironment() {
+        #if !DEBUG
+        Task {
+            do {
+                let rawValue: String
+                switch try await AppTransaction.shared {
+                case .verified(let transaction):
+                    rawValue = transaction.environment.rawValue
+                case .unverified(let transaction, let error):
+                    rawValue = transaction.environment.rawValue
+                    logger.warning("StoreKit app transaction was unverified: \(String(describing: error), privacy: .public)")
+                }
+
+                let environment = SentryEnvironmentResolver.sentryEnvironment(storeKitEnvironmentRawValue: rawValue)
+                UserDefaults.standard.set(environment, forKey: SentryEnvironmentResolver.cacheKey)
+                SentrySDK.configureScope { scope in
+                    scope.setTag(value: environment, key: "storekit.environment")
+                }
+                logger.info("Resolved StoreKit environment \(environment, privacy: .public)")
+            } catch {
+                logger.warning("Unable to resolve StoreKit environment: \(error.localizedDescription, privacy: .public)")
+            }
         }
-        return "production"
         #endif
     }
 }

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -705,6 +705,14 @@ struct OffScriptTests {
     }
 
     @Test
+    func sentryEnvironmentUsesStoreKitAppTransactionEnvironment() {
+        #expect(SentryEnvironmentResolver.sentryEnvironment(storeKitEnvironmentRawValue: "Production") == "production")
+        #expect(SentryEnvironmentResolver.sentryEnvironment(storeKitEnvironmentRawValue: "Sandbox") == "testflight")
+        #expect(SentryEnvironmentResolver.sentryEnvironment(storeKitEnvironmentRawValue: "Xcode") == "debug")
+        #expect(SentryEnvironmentResolver.sentryEnvironment(storeKitEnvironmentRawValue: "Unexpected") == "production")
+    }
+
+    @Test
     @MainActor
     func libraryDirectoryOrganizerFiltersAndSortsLargeLibraries() {
         let stale = Podcast(


### PR DESCRIPTION
Summary:
- Replace deprecated receipt URL based TestFlight detection with StoreKit 2 app transaction environment resolution.
- Cache the resolved Sentry environment for future launch-time configuration and tag the active Sentry scope after StoreKit resolves.
- Add resolver unit coverage and changelog coverage.

Verification:
- Xcode MCP BuildProject passed.
- Xcode MCP RunSomeTests passed: sentryEnvironmentUsesStoreKitAppTransactionEnvironment.
- Xcode MCP RunAllTests passed: 49/49.
- git diff --check passed.

Notes:
- Apple documents AppTransaction.shared as the StoreKit 2 app transaction source. The old Bundle.appStoreReceiptURL reference is removed entirely, which should clear the recurring iOS 18 archive warning.
