### PR TITLE
Improve recommendation explanation copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home can render a Tuner-styled discovery rail** sourced from the existing taste profile, with trace rows explaining whether each new podcast came from genre, tag, show-affinity, or discovery signal. Discovery rows can be tuned into the library without leaving Home.
 
 ### Changed — taste profile quality
+- **Home, Discovery, and Player recommendation cards now use authored local signal explanations** instead of raw algorithm fallback strings like `Matches your saved signal`, keeping WHY copy concrete even when Apple Intelligence is unavailable.
 - **Taste refresh now uses weighted, decayed evidence instead of equal counts.** Recent explicit `More like this` signals beat old passive completions, while `Less like this`, `Not interested`, quick skips, and abandons demote matching tags and shows.
 - **Recommendation modes now materially change Home ranking.** `SIGNAL` excludes genre-only candidates, while `BALANCED` and `DISCOVERY` can include a separate tuned-genre lane after local evidence.
 - **Negative signals now suppress adjacent recommendations, not just the exact episode.** `Less like this`, `Not interested`, skipped, and abandoned signals carry disliked tags/show penalties into Home and Player suggestions.

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -553,6 +553,10 @@ private struct TunerDiscoveryRail: View {
         let key = result.feedURL.normalizedFeedKey
         let isAdded = addedIDs.contains(key) || subscribedFeedURLs.contains(key)
         let isImporting = importingID == key
+        let displayReason = RecommendationExplainer.authoredReason(
+            fallback: scored.explanation,
+            signals: scored.signalTrace
+        )
 
         return VStack(alignment: .leading, spacing: 8) {
             OffScriptArtworkView(url: result.artworkURL, cornerRadius: 3)
@@ -569,7 +573,7 @@ private struct TunerDiscoveryRail: View {
                 .multilineTextAlignment(.leading)
                 .frame(width: 168, alignment: .leading)
 
-            TunerTag(text: scored.explanation, color: .offscriptFnInfo, dim: true, wraps: true)
+            TunerTag(text: displayReason, color: .offscriptFnInfo, dim: true, wraps: true)
             RecommendationSignalTraceView(signals: scored.signalTrace, limit: 2, color: .offscriptSoftPaper)
 
             Button {
@@ -592,7 +596,7 @@ private struct TunerDiscoveryRail: View {
         }
         .frame(width: 168, alignment: .leading)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(result.title) from \(result.author). \(scored.explanation)")
+        .accessibilityLabel("\(result.title) from \(result.author). \(displayReason)")
     }
 
     @MainActor
@@ -628,6 +632,10 @@ private struct HeroTunerCard: View {
         return episode.playedPosition / duration
     }
 
+    private var displayReason: String {
+        RecommendationExplainer.authoredReason(fallback: reason, signals: signals)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header strip — two TunerLabels mirroring the spec-sheet header
@@ -656,7 +664,7 @@ private struct HeroTunerCard: View {
                 NavigationLink {
                     EpisodeDetailView(
                         episode: episode,
-                        recommendationReason: reason,
+                        recommendationReason: displayReason,
                         recommendationSignals: signals
                     )
                 } label: {
@@ -671,7 +679,7 @@ private struct HeroTunerCard: View {
                 .buttonStyle(.plain)
 
                 // Reason as a TunerTag with signal yellow accent
-                TunerTag(text: reason, color: .offscriptSignalYellow, dim: true, wraps: true)
+                TunerTag(text: displayReason, color: .offscriptSignalYellow, dim: true, wraps: true)
                 RecommendationSignalTraceView(signals: signals)
                 HomePreferenceStatusRow(message: feedbackStatusMessage)
 
@@ -742,7 +750,7 @@ private struct HeroTunerCard: View {
         }
         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(episode.title) from \(episode.podcast.title). \(reason)")
+        .accessibilityLabel("\(episode.title) from \(episode.podcast.title). \(displayReason)")
         .onDisappear { feedbackClearTask?.cancel() }
     }
 
@@ -874,12 +882,16 @@ private struct TunerRailCard: View {
     let reason: String
     let signals: [RecommendationSignal]
 
+    private var displayReason: String {
+        RecommendationExplainer.authoredReason(fallback: reason, signals: signals)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationLink {
                 EpisodeDetailView(
                     episode: episode,
-                    recommendationReason: reason,
+                    recommendationReason: displayReason,
                     recommendationSignals: signals
                 )
             } label: {
@@ -898,7 +910,7 @@ private struct TunerRailCard: View {
                         .multilineTextAlignment(.leading)
                         .frame(width: 168, alignment: .leading)
 
-                    TunerTag(text: reason, color: .offscriptSignalYellow, dim: true, wraps: true)
+                    TunerTag(text: displayReason, color: .offscriptSignalYellow, dim: true, wraps: true)
                     RecommendationSignalTraceView(signals: signals, limit: 2, color: .offscriptSoftPaper)
 
                     TunerLabel(text: metadata, color: .offscriptSoftPaper, size: 8)

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -958,7 +958,7 @@ private struct TunerRailCard: View {
         .frame(width: 188, alignment: .leading)
         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(episode.title) from \(episode.podcast.title). \(reason)")
+        .accessibilityLabel("\(episode.title) from \(episode.podcast.title). \(displayReason)")
     }
 
     private var metadata: String {

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -685,6 +685,13 @@ private struct PlayerSuggestionRow: View {
     let scored: ScoredEpisode
     let rank: Int
 
+    private var displayReason: String {
+        RecommendationExplainer.authoredReason(
+            fallback: scored.explanation,
+            signals: scored.signalTrace
+        )
+    }
+
     var body: some View {
         HStack(spacing: 12) {
             Text(String(format: "%02d", rank))
@@ -701,7 +708,7 @@ private struct PlayerSuggestionRow: View {
             .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
 
             VStack(alignment: .leading, spacing: 3) {
-                TunerTag(text: scored.explanation, color: .offscriptSignalYellow, dim: true, wraps: true)
+                TunerTag(text: displayReason, color: .offscriptSignalYellow, dim: true, wraps: true)
                 RecommendationSignalTraceView(signals: scored.signalTrace, limit: 2, color: .offscriptSoftPaper)
                 Text(scored.episode.title)
                     .font(.system(size: 13, weight: .semibold))

--- a/OffScript/RecommendationExplainer.swift
+++ b/OffScript/RecommendationExplainer.swift
@@ -119,6 +119,14 @@ enum RecommendationExplainer {
             }
             return "Fresh from your subscribed channels"
         case "duration":
+            if fallback.localizedCaseInsensitiveContains("quick"),
+               let window = lookup["window"],
+               !window.isEmpty {
+                return "Quick \(window) listen"
+            }
+            if !fallback.localizedCaseInsensitiveContains("short-listen setting") {
+                return fallback
+            }
             return "Fits your short-listen setting"
         case "latest episode":
             if let tags = lookup["tags"], !tags.isEmpty {

--- a/OffScript/RecommendationExplainer.swift
+++ b/OffScript/RecommendationExplainer.swift
@@ -33,6 +33,152 @@ private struct RephraseResult {
 enum RecommendationExplainer {
     private static var cache: [UUID: String] = [:]
 
+    /// Deterministic copy pass for the synchronous UI path. This uses the
+    /// same signal trace that produced the score, so Home and Player can show
+    /// authored WHY copy without waiting on FoundationModels availability.
+    static func authoredReason(fallback: String, signals: [RecommendationSignal]) -> String {
+        var lookup: [String: String] = [:]
+        for signal in signals {
+            let key = signal.label.lowercased()
+            if lookup[key] == nil {
+                lookup[key] = signal.value
+            }
+        }
+        let sources = signals
+            .filter { $0.label.caseInsensitiveCompare("source") == .orderedSame }
+            .map { $0.value.lowercased() }
+        let source = authoredSource(from: sources)
+
+        switch source {
+        case "queue":
+            if let position = lookup["position"] {
+                return "Queued \(position) because you chose it"
+            }
+            return "Queued because you chose it"
+        case "resume":
+            if let left = lookup["left"] {
+                return "\(left) left from your last session"
+            }
+            return "Ready to pick up from your last session"
+        case "completion":
+            if let show = lookup["show"], !show.isEmpty {
+                return "More from \(show), a show you keep finishing"
+            }
+            return "More from a show you keep finishing"
+        case "show affinity":
+            if let show = lookup["show"], !show.isEmpty {
+                return "More from \(show), a show you already trust"
+            }
+            return "Similar to shows you keep finishing"
+        case "same show":
+            if let show = lookup["show"], !show.isEmpty {
+                return "More from \(show)"
+            }
+            return "More from the show already playing"
+        case "tag match":
+            if let tags = lookup["tags"], !tags.isEmpty {
+                return "Tuned to your saved \(joinedList(tags)) signal\(isPluralList(tags) ? "s" : "")"
+            }
+            return "Tuned to your saved listening signals"
+        case "taste tag":
+            if let tags = lookup["tags"], !tags.isEmpty {
+                return "Covers your \(joinedList(tags)) signal\(isPluralList(tags) ? "s" : "")"
+            }
+            return "Covers topics you keep choosing"
+        case "topic overlap":
+            if let tags = lookup["tags"], !tags.isEmpty {
+                return "Multiple topic matches: \(joinedList(tags))"
+            }
+            return "Multiple topic matches from your listens"
+        case "recent interest":
+            if let tag = lookup["tag"], !tag.isEmpty {
+                return "Fits your recent \(tag) signal"
+            }
+            return "Fits your recent listening signal"
+        case "liked episode":
+            if let tag = lookup["tag"], !tag.isEmpty {
+                return "Connects to \(tag) from episodes you liked"
+            }
+            return "Connects to episodes you liked"
+        case "now playing":
+            if let tag = lookup["tag"], !tag.isEmpty {
+                return "Pairs with your current \(tag) listen"
+            }
+            return "Pairs with what is playing now"
+        case "genre":
+            if let lane = lookup["lane"], !lane.isEmpty {
+                return "A \(lane) lane pick with local evidence behind it"
+            }
+            return "A genre-lane pick with local evidence behind it"
+        case "fresh":
+            if let show = lookup["show"], !show.isEmpty {
+                return "Fresh from \(show)"
+            }
+            if let age = lookup["age"] {
+                return "Fresh episode, \(age) old"
+            }
+            return "Fresh from your subscribed channels"
+        case "duration":
+            return "Fits your short-listen setting"
+        case "latest episode":
+            if let tags = lookup["tags"], !tags.isEmpty {
+                return "Latest episodes overlap your \(joinedList(tags)) signal"
+            }
+            return "Latest episodes overlap your saved signals"
+        case "subscription":
+            if let show = lookup["show"], !show.isEmpty {
+                return "From your subscribed show \(show)"
+            }
+            return "From a show in your library"
+        case "available":
+            if let show = lookup["show"], !show.isEmpty {
+                return "Available from \(show)"
+            }
+            return "Available from your library"
+        case "discovery":
+            return "Discovery match from your saved signals"
+        default:
+            return fallback
+        }
+    }
+
+    private static func authoredSource(from sources: [String]) -> String? {
+        let priority = [
+            "queue",
+            "resume",
+            "latest episode",
+            "tag match",
+            "taste tag",
+            "topic overlap",
+            "recent interest",
+            "liked episode",
+            "now playing",
+            "completion",
+            "show affinity",
+            "same show",
+            "genre",
+            "duration",
+            "fresh",
+            "subscription",
+            "available",
+            "discovery"
+        ]
+        return priority.first { sources.contains($0) } ?? sources.first
+    }
+
+    private static func joinedList(_ value: String) -> String {
+        let parts = value
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard parts.count > 1 else { return parts.first ?? value }
+        return parts.dropLast().joined(separator: ", ") + " and " + parts.last!
+    }
+
+    private static func isPluralList(_ value: String) -> Bool {
+        value.split(separator: ",").count > 1
+    }
+
     /// Returns a cached AI reason if one exists (from either the full
     /// generator or the rephraser), nil otherwise. Synchronous — safe to call
     /// from view bodies for the cache-hit path.

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -657,6 +657,59 @@ struct OffScriptTests {
     }
 
     @Test
+    func recommendationExplainerRewritesSavedSignalReasonsFromTrace() {
+        let reason = RecommendationExplainer.authoredReason(
+            fallback: "Matches your saved signal: audio craft, interviews",
+            signals: [
+                RecommendationSignal(label: "source", value: "tag match"),
+                RecommendationSignal(label: "tags", value: "audio craft, interviews")
+            ]
+        )
+
+        #expect(reason == "Tuned to your saved audio craft and interviews signals")
+    }
+
+    @Test
+    func recommendationExplainerRewritesGenreLaneReasonsFromTrace() {
+        let reason = RecommendationExplainer.authoredReason(
+            fallback: "Matches your selected technology lane",
+            signals: [
+                RecommendationSignal(label: "source", value: "genre"),
+                RecommendationSignal(label: "lane", value: "technology")
+            ]
+        )
+
+        #expect(reason == "A technology lane pick with local evidence behind it")
+    }
+
+    @Test
+    func recommendationExplainerPrioritizesEvidenceInMixedDiscoveryTraces() {
+        let reason = RecommendationExplainer.authoredReason(
+            fallback: "Matches your saved technology lane",
+            signals: [
+                RecommendationSignal(label: "source", value: "genre"),
+                RecommendationSignal(label: "lane", value: "technology"),
+                RecommendationSignal(label: "source", value: "latest episode"),
+                RecommendationSignal(label: "tags", value: "audio craft")
+            ]
+        )
+
+        #expect(reason == "Latest episodes overlap your audio craft signal")
+    }
+
+    @Test
+    func recommendationExplainerKeepsUnknownFallbacks() {
+        let fallback = "Special editorial pick"
+
+        let reason = RecommendationExplainer.authoredReason(
+            fallback: fallback,
+            signals: [RecommendationSignal(label: "source", value: "editor")]
+        )
+
+        #expect(reason == fallback)
+    }
+
+    @Test
     @MainActor
     func appSettingsRoundTripsPreferences() {
         let originalAutoPlay = AppSettings.autoPlayNext

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -698,6 +698,32 @@ struct OffScriptTests {
     }
 
     @Test
+    func recommendationExplainerPreservesGenericQuickDurationReasons() {
+        let reason = RecommendationExplainer.authoredReason(
+            fallback: "Quick 18m listen",
+            signals: [
+                RecommendationSignal(label: "source", value: "duration"),
+                RecommendationSignal(label: "window", value: "18m")
+            ]
+        )
+
+        #expect(reason == "Quick 18m listen")
+    }
+
+    @Test
+    func recommendationExplainerKeepsShortListenPreferenceReason() {
+        let reason = RecommendationExplainer.authoredReason(
+            fallback: "Fits your short-listen setting",
+            signals: [
+                RecommendationSignal(label: "source", value: "duration"),
+                RecommendationSignal(label: "window", value: "28m")
+            ]
+        )
+
+        #expect(reason == "Fits your short-listen setting")
+    }
+
+    @Test
     func recommendationExplainerKeepsUnknownFallbacks() {
         let fallback = "Special editorial pick"
 


### PR DESCRIPTION
## Summary
- add deterministic authored recommendation explanations from local signal traces
- wire authored WHY copy into Home hero/rails, Discovery cards, and Player suggestion rows
- prioritize stronger evidence in mixed discovery traces so tag/latest-episode signals beat generic genre fallback copy

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: 4 recommendation explainer tests passed
- Xcode MCP RunAllTests: 53 passed, 0 failed
- git diff --check: passed

## Notes
- Follow-up from subagent review: mixed source traces now scan every source and choose the strongest authored source before formatting.