### PR TITLE
Improve large OPML import bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **The Library alphabet selector is back to the compact `#-Z` carousel form** while keeping the working direct-letter jump behavior and selected/disabled Tuner states.
 
 ### Changed — Library performance
+- **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.
+- **OPML batch hydration now uses a lightweight bootstrap pass** that imports only a small first slice of episodes and skips episode profile enrichment, avoiding thousands of episode/profile writes during the initial import.
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**
 - **Library summary reloads are coalesced during background OPML imports** so each imported show does not immediately retrigger the expensive per-show count path while the list is being scrolled.
 - **Library summary counts no longer issue one SwiftData `fetchCount` per subscribed show.** The page now loads the unplayed episode set once, derives the latest rail and per-show counts from that result, and avoids 250+ synchronous count queries on Library open.

--- a/OffScript/BackgroundFeedRefresh.swift
+++ b/OffScript/BackgroundFeedRefresh.swift
@@ -65,8 +65,7 @@ enum BackgroundFeedRefresh {
                 let failureCount = podcast.syncFailureCount + 1
                 podcast.syncFailureCount = failureCount
                 podcast.syncErrorMessage = error.localizedDescription
-                let retryDelay = min(pow(2.0, Double(failureCount)) * 60, 60 * 60 * 6)
-                podcast.nextRetryAt = Date().addingTimeInterval(retryDelay)
+                podcast.nextRetryAt = FeedSyncRetryPolicy.nextRetryDate(afterFailureCount: failureCount)
                 context.saveOrLog("BackgroundFeedRefresh")
                 logger.warning("Background refresh: failed to sync \(podcast.title, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }

--- a/OffScript/BatchImportService.swift
+++ b/OffScript/BatchImportService.swift
@@ -186,10 +186,10 @@ final class BatchImportService: ObservableObject {
             try Task.checkCancellation()
             return (entry.feedURL, .added)
         } catch is CancellationError {
-            await markStagedSubscriptionCancelled(entry: entry, in: modelContext)
+            markStagedSubscriptionCancelled(entry: entry, in: modelContext)
             return (entry.feedURL, .cancelled)
         } catch {
-            await markStagedSubscriptionFailed(entry: entry, error: error, in: modelContext)
+            markStagedSubscriptionFailed(entry: entry, error: error, in: modelContext)
             batchImportLogger.error("OPML row failed for \(entry.feedURL.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
             return (entry.feedURL, .failed)
         }
@@ -291,7 +291,7 @@ final class BatchImportService: ObservableObject {
             podcast.syncStatus = "failed"
             podcast.syncFailureCount = failureCount
             podcast.syncErrorMessage = error.localizedDescription
-            podcast.nextRetryAt = Date().addingTimeInterval(min(pow(2.0, Double(failureCount)) * 60, 60 * 60 * 6))
+            podcast.nextRetryAt = FeedSyncRetryPolicy.nextRetryDate(afterFailureCount: failureCount)
             try modelContext.save()
         } catch {
             batchImportLogger.error("Failed to mark staged OPML row failed: \(error.localizedDescription, privacy: .public)")
@@ -305,7 +305,7 @@ final class BatchImportService: ObservableObject {
         do {
             guard let podcast = try stagedPodcast(for: entry, in: modelContext) else { return }
             podcast.syncStatus = "idle"
-            podcast.syncErrorMessage = "Import cancelled."
+            podcast.syncErrorMessage = nil
             podcast.nextRetryAt = nil
             try modelContext.save()
         } catch {
@@ -317,8 +317,19 @@ final class BatchImportService: ObservableObject {
         for entries: [OPMLFeedEntry],
         in modelContext: ModelContext
     ) {
-        for entry in entries {
-            markStagedSubscriptionCancelled(entry: entry, in: modelContext)
+        do {
+            let feedKeys = Set(entries.map { $0.feedURL.normalizedFeedKey })
+            guard !feedKeys.isEmpty else { return }
+            let podcasts = try modelContext.fetch(FetchDescriptor<Podcast>())
+                .filter { feedKeys.contains($0.feedURL.normalizedFeedKey) }
+            for podcast in podcasts {
+                podcast.syncStatus = "idle"
+                podcast.syncErrorMessage = nil
+                podcast.nextRetryAt = nil
+            }
+            try modelContext.save()
+        } catch {
+            batchImportLogger.error("Failed to mark staged OPML rows cancelled: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/OffScript/BatchImportService.swift
+++ b/OffScript/BatchImportService.swift
@@ -55,6 +55,7 @@ final class BatchImportService: ObservableObject {
 
     private let syncService = FeedSyncService()
     private var task: Task<Void, Never>?
+    private var activeModelContext: ModelContext?
 
     private init() {}
 
@@ -68,12 +69,20 @@ final class BatchImportService: ObservableObject {
         let existingFeedKeys = Self.subscribedFeedKeys(in: modelContext)
         let plan = Self.importPlan(for: uniqueEntries, existingFeedKeys: existingFeedKeys)
         self.entries = uniqueEntries
+        activeModelContext = modelContext
         progress = plan.initialProgress
         phase = .running
 
         guard !plan.entriesToImport.isEmpty else {
             phase = .finished(added: addedCount, failed: failedCount)
+            activeModelContext = nil
             return
+        }
+
+        do {
+            _ = try Self.stageSubscriptions(for: plan.entriesToImport, in: modelContext)
+        } catch {
+            batchImportLogger.error("OPML subscription staging failed: \(error.localizedDescription, privacy: .public)")
         }
 
         task = Task { [weak self] in
@@ -88,8 +97,16 @@ final class BatchImportService: ObservableObject {
         task?.cancel()
         task = nil
         if isRunning {
+            let unfinishedEntries = entries.filter { entry in
+                let status = progress[entry.feedURL]
+                return status == .pending || status == .importing
+            }
             markUnfinishedRowsCancelled()
+            if let activeModelContext {
+                Self.markStagedSubscriptionsCancelled(for: unfinishedEntries, in: activeModelContext)
+            }
             phase = .finished(added: addedCount, failed: failedCount)
+            activeModelContext = nil
         }
     }
 
@@ -143,9 +160,11 @@ final class BatchImportService: ObservableObject {
         guard !Task.isCancelled else {
             markUnfinishedRowsCancelled()
             phase = .finished(added: addedCount, failed: failedCount)
+            activeModelContext = nil
             return
         }
         phase = .finished(added: addedCount, failed: failedCount)
+        activeModelContext = nil
     }
 
     private func markUnfinishedRowsCancelled() {
@@ -163,12 +182,14 @@ final class BatchImportService: ObservableObject {
             try Task.checkCancellation()
             _ = try await syncService.importPodcast(from: entry,
                                                     into: modelContext,
-                                                    options: .fastBatchImport(episodeLimit: 25))
+                                                    options: .opmlBootstrap())
             try Task.checkCancellation()
             return (entry.feedURL, .added)
         } catch is CancellationError {
-            return (entry.feedURL, .failed)
+            await markStagedSubscriptionCancelled(entry: entry, in: modelContext)
+            return (entry.feedURL, .cancelled)
         } catch {
+            await markStagedSubscriptionFailed(entry: entry, error: error, in: modelContext)
             batchImportLogger.error("OPML row failed for \(entry.feedURL.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
             return (entry.feedURL, .failed)
         }
@@ -203,6 +224,125 @@ final class BatchImportService: ObservableObject {
         }
 
         return (entriesToImport, initialProgress)
+    }
+
+    @discardableResult
+    static func stageSubscriptions(
+        for entries: [OPMLFeedEntry],
+        in modelContext: ModelContext
+    ) throws -> Int {
+        guard !entries.isEmpty else { return 0 }
+
+        let existingPodcasts = try modelContext.fetch(FetchDescriptor<Podcast>())
+        var podcastByFeedKey = Dictionary(
+            existingPodcasts.map { ($0.feedURL.normalizedFeedKey, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var stagedCount = 0
+        let now = Date()
+
+        for entry in entries {
+            let key = entry.feedURL.normalizedFeedKey
+            let title = entry.title.flatMap(Self.trimmedNonEmpty)
+                ?? entry.feedURL.host
+                ?? entry.feedURL.absoluteString
+            let author = entry.author.flatMap(Self.trimmedNonEmpty)
+
+            if let podcast = podcastByFeedKey[key] {
+                podcast.feedURL = entry.feedURL
+                podcast.isSubscribed = true
+                podcast.title = title
+                podcast.author = author ?? podcast.author
+                if podcast.subscribedAt == nil {
+                    podcast.subscribedAt = now
+                }
+                podcast.lastSyncAttemptAt = now
+                podcast.syncStatus = "syncing"
+                podcast.syncErrorMessage = nil
+            } else {
+                let podcast = Podcast(
+                    title: title,
+                    author: author,
+                    feedURL: entry.feedURL,
+                    isSubscribed: true
+                )
+                podcast.subscribedAt = now
+                podcast.lastSyncAttemptAt = now
+                podcast.syncStatus = "syncing"
+                modelContext.insert(podcast)
+                podcastByFeedKey[key] = podcast
+            }
+
+            stagedCount += 1
+        }
+
+        try modelContext.save()
+        return stagedCount
+    }
+
+    static func markStagedSubscriptionFailed(
+        entry: OPMLFeedEntry,
+        error: Error,
+        in modelContext: ModelContext
+    ) {
+        do {
+            guard let podcast = try stagedPodcast(for: entry, in: modelContext) else { return }
+            let failureCount = podcast.syncFailureCount + 1
+            podcast.syncStatus = "failed"
+            podcast.syncFailureCount = failureCount
+            podcast.syncErrorMessage = error.localizedDescription
+            podcast.nextRetryAt = Date().addingTimeInterval(min(pow(2.0, Double(failureCount)) * 60, 60 * 60 * 6))
+            try modelContext.save()
+        } catch {
+            batchImportLogger.error("Failed to mark staged OPML row failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private static func markStagedSubscriptionCancelled(
+        entry: OPMLFeedEntry,
+        in modelContext: ModelContext
+    ) {
+        do {
+            guard let podcast = try stagedPodcast(for: entry, in: modelContext) else { return }
+            podcast.syncStatus = "idle"
+            podcast.syncErrorMessage = "Import cancelled."
+            podcast.nextRetryAt = nil
+            try modelContext.save()
+        } catch {
+            batchImportLogger.error("Failed to mark staged OPML row cancelled: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    static func markStagedSubscriptionsCancelled(
+        for entries: [OPMLFeedEntry],
+        in modelContext: ModelContext
+    ) {
+        for entry in entries {
+            markStagedSubscriptionCancelled(entry: entry, in: modelContext)
+        }
+    }
+
+    private static func stagedPodcast(
+        for entry: OPMLFeedEntry,
+        in modelContext: ModelContext
+    ) throws -> Podcast? {
+        let feedURL = entry.feedURL
+        var descriptor = FetchDescriptor<Podcast>(
+            predicate: #Predicate<Podcast> { $0.feedURL == feedURL }
+        )
+        descriptor.fetchLimit = 1
+        if let exact = try modelContext.fetch(descriptor).first {
+            return exact
+        }
+
+        let feedKey = entry.feedURL.normalizedFeedKey
+        return try modelContext.fetch(FetchDescriptor<Podcast>())
+            .first { $0.feedURL.normalizedFeedKey == feedKey }
+    }
+
+    private static func trimmedNonEmpty(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private static func subscribedFeedKeys(in modelContext: ModelContext) -> Set<String> {

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -223,6 +223,14 @@ struct FeedSyncOptions {
             resolveExternalChapters: false
         )
     }
+
+    static func opmlBootstrap(episodeLimit: Int? = 3) -> FeedSyncOptions {
+        FeedSyncOptions(
+            episodeLimit: episodeLimit,
+            enrichmentMode: .skip,
+            resolveExternalChapters: false
+        )
+    }
 }
 
 final class FeedSyncService {

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -233,6 +233,16 @@ struct FeedSyncOptions {
     }
 }
 
+enum FeedSyncRetryPolicy {
+    static func delay(afterFailureCount failureCount: Int) -> TimeInterval {
+        min(pow(2.0, Double(failureCount)) * 60, 60 * 60 * 6)
+    }
+
+    static func nextRetryDate(afterFailureCount failureCount: Int, from date: Date = Date()) -> Date {
+        date.addingTimeInterval(delay(afterFailureCount: failureCount))
+    }
+}
+
 final class FeedSyncService {
     private let topicExtractionService = TopicExtractionService()
 

--- a/OffScript/SyncCoordinator.swift
+++ b/OffScript/SyncCoordinator.swift
@@ -74,8 +74,7 @@ final class SyncCoordinator: ObservableObject {
             let failureCount = podcast.syncFailureCount + 1
             podcast.syncFailureCount = failureCount
             podcast.syncErrorMessage = error.localizedDescription
-            let retryDelay = min(pow(2.0, Double(failureCount)) * 60, 60 * 60 * 6)
-            podcast.nextRetryAt = Date().addingTimeInterval(retryDelay)
+            podcast.nextRetryAt = FeedSyncRetryPolicy.nextRetryDate(afterFailureCount: failureCount)
             updateSnapshot(for: podcast, isSyncing: false, errorMessage: error.localizedDescription)
             modelContext.saveOrLog("SyncCoordinator")
         }

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -129,6 +129,109 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func opmlBatchStagesSubscriptionsBeforeNetworkWork() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entries = (1...258).map { index in
+            OPMLFeedEntry(
+                feedURL: URL(string: "https://example.com/feed-\(index).xml")!,
+                title: "Imported Show \(index)",
+                author: "Author \(index)"
+            )
+        }
+
+        let stagedCount = try BatchImportService.stageSubscriptions(
+            for: entries,
+            in: context
+        )
+
+        let podcasts = try context.fetch(FetchDescriptor<Podcast>())
+        #expect(stagedCount == 258)
+        #expect(podcasts.count == 258)
+        #expect(podcasts.allSatisfy { $0.isSubscribed } == true)
+        #expect(podcasts.first(where: { $0.title == "Imported Show 258" })?.syncStatus == "syncing")
+    }
+
+    @Test
+    @MainActor
+    func opmlBatchStagingResubscribesExistingNormalizedFeeds() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let existing = Podcast(
+            title: "Old Title",
+            feedURL: try #require(URL(string: "http://example.com/feed.xml/")),
+            isSubscribed: false
+        )
+        context.insert(existing)
+        try context.save()
+        let entry = OPMLFeedEntry(
+            feedURL: try #require(URL(string: "https://example.com/feed.xml")),
+            title: "New OPML Title",
+            author: "OPML Author"
+        )
+
+        let stagedCount = try BatchImportService.stageSubscriptions(for: [entry], in: context)
+
+        let podcasts = try context.fetch(FetchDescriptor<Podcast>())
+        #expect(stagedCount == 1)
+        #expect(podcasts.count == 1)
+        #expect(existing.isSubscribed)
+        #expect(existing.title == "New OPML Title")
+        #expect(existing.author == "OPML Author")
+        #expect(existing.syncStatus == "syncing")
+    }
+
+    @Test
+    @MainActor
+    func failedOPMLBootstrapMarksStagedSubscriptionRetryable() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entry = OPMLFeedEntry(
+            feedURL: try #require(URL(string: "https://example.com/bad-feed.xml")),
+            title: "Bad Feed",
+            author: nil
+        )
+        try BatchImportService.stageSubscriptions(for: [entry], in: context)
+
+        BatchImportService.markStagedSubscriptionFailed(
+            entry: entry,
+            error: URLError(.timedOut),
+            in: context
+        )
+
+        let podcast = try #require(try context.fetch(FetchDescriptor<Podcast>()).first)
+        #expect(podcast.isSubscribed)
+        #expect(podcast.syncStatus == "failed")
+        #expect(podcast.syncFailureCount == 1)
+        #expect(podcast.syncErrorMessage?.isEmpty == false)
+        #expect(podcast.nextRetryAt != nil)
+    }
+
+    @Test
+    @MainActor
+    func cancelledOPMLBootstrapClearsUnlaunchedStagedSubscriptions() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entries = (1...12).map { index in
+            OPMLFeedEntry(
+                feedURL: URL(string: "https://example.com/cancel-\(index).xml")!,
+                title: "Cancel Show \(index)",
+                author: nil
+            )
+        }
+        try BatchImportService.stageSubscriptions(for: entries, in: context)
+
+        BatchImportService.markStagedSubscriptionsCancelled(for: entries, in: context)
+
+        let podcasts = try context.fetch(FetchDescriptor<Podcast>())
+        #expect(podcasts.count == 12)
+        #expect(podcasts.contains(where: { $0.syncStatus == "syncing" }) == false)
+        #expect(podcasts.allSatisfy { $0.isSubscribed } == true)
+        #expect(podcasts.allSatisfy { $0.nextRetryAt == nil } == true)
+    }
+
+    @Test
+    @MainActor
     func queueServiceMovesItemsAndPersistsOrder() throws {
         let container = try makeContainer()
         let context = container.mainContext
@@ -1247,6 +1350,53 @@ struct OffScriptTests {
         #expect(episode.chapters.isEmpty)
         #expect(profile.episodeID == episode.id)
         #expect(!profile.tags.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func feedSyncOPMLBootstrapCapsEpisodesAndSkipsProfiles() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let result = PodcastSearchResult(
+            title: "Bootstrap Show",
+            author: "Bootstrap Author",
+            feedURL: URL(string: "https://example.com/bootstrap.xml")!,
+            artworkURL: nil,
+            websiteURL: nil,
+            summary: nil
+        )
+        let parsed = ParsedFeed(
+            title: "Bootstrap Show",
+            author: "Bootstrap Author",
+            summary: nil,
+            websiteURL: nil,
+            artworkURL: nil,
+            categories: ["Technology"],
+            items: (1...10).map { index in
+                ParsedFeedItem(
+                    guid: "bootstrap-\(index)",
+                    title: "Bootstrap Episode \(index)",
+                    summary: "Episode imported during OPML bootstrap.",
+                    pubDate: Date().addingTimeInterval(TimeInterval(-index)),
+                    duration: 1_800,
+                    audioURL: URL(string: "https://example.com/bootstrap-\(index).mp3")!,
+                    externalChapterURL: URL(string: "https://example.com/bootstrap-\(index)-chapters.json")!
+                )
+            }
+        )
+
+        _ = try await FeedSyncService().importPodcast(
+            from: result,
+            parsedFeed: parsed,
+            into: context,
+            options: .opmlBootstrap()
+        )
+
+        let episodes = try context.fetch(FetchDescriptor<Episode>())
+        let profiles = try context.fetch(FetchDescriptor<EpisodeProfile>())
+        #expect(episodes.count == 3)
+        #expect(episodes.allSatisfy { $0.chapters.isEmpty })
+        #expect(profiles.isEmpty)
     }
 
     @Test

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -227,6 +227,7 @@ struct OffScriptTests {
         #expect(podcasts.count == 12)
         #expect(podcasts.contains(where: { $0.syncStatus == "syncing" }) == false)
         #expect(podcasts.allSatisfy { $0.isSubscribed } == true)
+        #expect(podcasts.allSatisfy { $0.syncErrorMessage == nil } == true)
         #expect(podcasts.allSatisfy { $0.nextRetryAt == nil } == true)
     }
 


### PR DESCRIPTION
## Summary
- stage OPML subscriptions into SwiftData before network feed sync finishes, so large libraries appear immediately
- add lightweight OPML bootstrap sync mode with a 3-episode cap, no profile enrichment, and no external chapter resolution
- mark staged rows retryable on bootstrap failure and clear unlaunched staged rows on cancellation so subscriptions do not stay stuck syncing

## Verification
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: 5 OPML/bootstrap tests passed
- Xcode MCP RunAllTests: 60 passed, 0 failed
- git diff --check: passed
- Subagent final review: no blocking issues; unit target passed independently

## Notes
- This targets perceived performance for 250+ feed OPML imports. Full feed hydration still happens in the existing background batch path.