### PR TITLE
Speed up onboarding subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Fixed — onboarding, import, and sync UI honesty
 - **Onboarding Sign in with Apple now presents from the actual button window when available** and no longer uses the old crash-prone missing-scene path for the normal sign-in flow.
+- **Onboarding starter subscriptions now commit immediately and hydrate in the background** using the same lightweight bootstrap profile as large imports, so picking three podcasts no longer waits on serial feed parsing, full episode enrichment, or external chapter lookups before entering the app.
 - **Onboarding import no longer auto-completes through failed feeds.** Failed starter channels stay visible with retry and continue actions.
 - **Bulk OPML import cancellation now marks pending/importing rows as cancelled** instead of leaving them stuck mid-import.
 - **Settings no longer claims iCloud sync is active unless the launch actually opened a CloudKit-backed SwiftData container.**

--- a/OffScript/ImportProgressView.swift
+++ b/OffScript/ImportProgressView.swift
@@ -150,19 +150,16 @@ struct ImportProgressView: View {
         if hasFailures {
             return "Retry failed channels or continue with the feeds that tuned successfully."
         }
-        return "Fetching the most recent episodes for each channel. This will not pull the full back catalog; background sync handles that later."
+        return "Subscribing now. Starter episodes tune in behind the scenes so you can get into the app without waiting on feed hydration."
     }
 
-    // Onboarding-time tuning. We deliberately import only the most recent
-    // episodes per podcast so first-launch isn't waiting on a 500-episode
-    // back catalog (common for shows like NPR, etc). Background sync can
-    // backfill the rest later.
-    private let onboardingEpisodeLimit = 15
+    // Onboarding should commit selected subscriptions immediately. Starter
+    // feed hydration runs after the app opens so first launch is not gated by
+    // XML parsing, enrichment, external chapter fetches, or slow feed hosts.
     @MainActor
     private func runImports(onlyFailed: Bool = false) async {
         guard !isImporting else { return }
         isImporting = true
-        defer { isImporting = false }
 
         // Persist genre preferences immediately — doesn't depend on imports.
         UserDefaults.standard.set(selectedGenres.map(\.rawValue), forKey: "offscript.preferredGenres")
@@ -172,44 +169,63 @@ struct ImportProgressView: View {
             : podcasts
 
         // Mark all selected podcasts as importing up front so the UI shows
-        // every row pulsing — better feedback than rows lighting up serially.
+        // every row pulsing while the local subscription rows are committed.
         for podcast in selectedPodcasts {
             statuses[podcast.feedURL] = .importing
         }
 
-        // Keep SwiftData writes on the main actor. This onboarding path imports
-        // a small selected starter set; the heavy OPML path uses BatchImportService.
+        var stagedPodcasts: [Podcast] = []
         for podcast in selectedPodcasts {
             do {
-                let imported = try await syncService.importPodcast(
-                    from: podcast,
-                    into: modelContext,
-                    episodeLimit: onboardingEpisodeLimit
-                )
-                if let newestEpisode = imported.episodes
-                    .sorted(by: { $0.pubDate > $1.pubDate })
-                    .first {
-                    modelContext.insert(PreferenceSignal(action: .like, episode: newestEpisode))
-                }
+                let staged = try syncService.stagePodcastSubscription(from: podcast, into: modelContext)
+                stagedPodcasts.append(staged)
                 statuses[podcast.feedURL] = .done
             } catch {
-                importLogger.error("Onboarding import failed for \(podcast.feedURL, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                importLogger.error("Onboarding subscription staging failed for \(podcast.feedURL, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 statuses[podcast.feedURL] = .failed
             }
-        }
-
-        // Single batched save at the end — far cheaper than saving after each
-        // import (every save runs migration checks + flushes the WAL).
-        do {
-            try modelContext.save()
-        } catch {
-            importLogger.error("Failed to save imported feed: \(error.localizedDescription, privacy: .public)")
         }
 
         hasFinishedAttempt = true
         if failedCount == 0 {
             isComplete = true
+            isImporting = false
             onComplete()
+        } else {
+            isImporting = false
+        }
+
+        Task { @MainActor in
+            await syncStagedPodcastsInBackground(stagedPodcasts)
+        }
+    }
+
+    @MainActor
+    private func syncStagedPodcastsInBackground(_ podcasts: [Podcast]) async {
+        guard !podcasts.isEmpty else { return }
+
+        for podcast in podcasts {
+            do {
+                try await syncService.sync(
+                    podcast: podcast,
+                    in: modelContext,
+                    options: .onboardingBootstrap()
+                )
+                if let newestEpisode = podcast.episodes
+                    .sorted(by: { $0.pubDate > $1.pubDate })
+                    .first {
+                    modelContext.insert(PreferenceSignal(action: .like, episode: newestEpisode))
+                    try modelContext.save()
+                }
+            } catch {
+                let failureCount = podcast.syncFailureCount + 1
+                podcast.syncStatus = "failed"
+                podcast.syncFailureCount = failureCount
+                podcast.syncErrorMessage = error.localizedDescription
+                podcast.nextRetryAt = FeedSyncRetryPolicy.nextRetryDate(afterFailureCount: failureCount)
+                try? modelContext.save()
+                importLogger.error("Onboarding background sync failed for \(podcast.feedURL, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
         }
     }
 }

--- a/OffScript/ImportProgressView.swift
+++ b/OffScript/ImportProgressView.swift
@@ -215,7 +215,7 @@ struct ImportProgressView: View {
                     .sorted(by: { $0.pubDate > $1.pubDate })
                     .first {
                     modelContext.insert(PreferenceSignal(action: .like, episode: newestEpisode))
-                    try modelContext.save()
+                    modelContext.saveOrLog("OnboardingPreferenceSignal")
                 }
             } catch {
                 let failureCount = podcast.syncFailureCount + 1
@@ -223,7 +223,7 @@ struct ImportProgressView: View {
                 podcast.syncFailureCount = failureCount
                 podcast.syncErrorMessage = error.localizedDescription
                 podcast.nextRetryAt = FeedSyncRetryPolicy.nextRetryDate(afterFailureCount: failureCount)
-                try? modelContext.save()
+                modelContext.saveOrLog("OnboardingBackgroundSync")
                 importLogger.error("Onboarding background sync failed for \(podcast.feedURL, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -231,6 +231,14 @@ struct FeedSyncOptions {
             resolveExternalChapters: false
         )
     }
+
+    static func onboardingBootstrap(episodeLimit: Int? = 3) -> FeedSyncOptions {
+        FeedSyncOptions(
+            episodeLimit: episodeLimit,
+            enrichmentMode: .skip,
+            resolveExternalChapters: false
+        )
+    }
 }
 
 enum FeedSyncRetryPolicy {
@@ -309,6 +317,16 @@ final class FeedSyncService {
             context.insert(podcast)
         }
 
+        return podcast
+    }
+
+    @MainActor
+    func stagePodcastSubscription(from result: PodcastSearchResult, into context: ModelContext) throws -> Podcast {
+        let podcast = try upsertPodcast(from: result, into: context)
+        podcast.syncStatus = "syncing"
+        podcast.lastSyncAttemptAt = .now
+        podcast.syncErrorMessage = nil
+        try context.save()
         return podcast
     }
 

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -233,11 +233,7 @@ struct FeedSyncOptions {
     }
 
     static func onboardingBootstrap(episodeLimit: Int? = 3) -> FeedSyncOptions {
-        FeedSyncOptions(
-            episodeLimit: episodeLimit,
-            enrichmentMode: .skip,
-            resolveExternalChapters: false
-        )
+        opmlBootstrap(episodeLimit: episodeLimit)
     }
 }
 
@@ -323,7 +319,7 @@ final class FeedSyncService {
     @MainActor
     func stagePodcastSubscription(from result: PodcastSearchResult, into context: ModelContext) throws -> Podcast {
         let podcast = try upsertPodcast(from: result, into: context)
-        podcast.syncStatus = "syncing"
+        podcast.syncStatus = "idle"
         podcast.lastSyncAttemptAt = .now
         podcast.syncErrorMessage = nil
         try context.save()

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1402,6 +1402,84 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func feedSyncStagesSearchSubscriptionBeforeNetworkWork() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let result = PodcastSearchResult(
+            title: "Starter Show",
+            author: "Starter Author",
+            feedURL: URL(string: "https://example.com/starter.xml")!,
+            artworkURL: URL(string: "https://example.com/starter.jpg")!,
+            websiteURL: URL(string: "https://example.com")!,
+            summary: "A starter show selected during onboarding."
+        )
+
+        let podcast = try FeedSyncService().stagePodcastSubscription(from: result, into: context)
+
+        let podcasts = try context.fetch(FetchDescriptor<Podcast>())
+        #expect(podcasts.count == 1)
+        #expect(podcast.isSubscribed)
+        #expect(podcast.title == "Starter Show")
+        #expect(podcast.author == "Starter Author")
+        #expect(podcast.artworkURL == result.artworkURL)
+        #expect(podcast.websiteURL == result.websiteURL)
+        #expect(podcast.summary == result.summary)
+        #expect(podcast.subscribedAt != nil)
+        #expect(podcast.syncStatus == "syncing")
+        #expect(podcast.lastSyncAttemptAt != nil)
+        #expect(podcast.syncErrorMessage == nil)
+    }
+
+    @Test
+    @MainActor
+    func feedSyncOnboardingBootstrapCapsEpisodesAndSkipsExpensiveEnrichment() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let result = PodcastSearchResult(
+            title: "Onboarding Show",
+            author: "Onboarding Author",
+            feedURL: URL(string: "https://example.com/onboarding.xml")!,
+            artworkURL: nil,
+            websiteURL: nil,
+            summary: nil
+        )
+        let parsed = ParsedFeed(
+            title: "Onboarding Show",
+            author: "Onboarding Author",
+            summary: nil,
+            websiteURL: nil,
+            artworkURL: nil,
+            categories: ["Technology"],
+            items: (1...10).map { index in
+                ParsedFeedItem(
+                    guid: "onboarding-\(index)",
+                    title: "Onboarding Episode \(index)",
+                    summary: "Episode imported during onboarding bootstrap.",
+                    pubDate: Date().addingTimeInterval(TimeInterval(-index)),
+                    duration: 1_800,
+                    audioURL: URL(string: "https://example.com/onboarding-\(index).mp3")!,
+                    externalChapterURL: URL(string: "https://example.com/onboarding-\(index)-chapters.json")!
+                )
+            }
+        )
+
+        let podcast = try await FeedSyncService().importPodcast(
+            from: result,
+            parsedFeed: parsed,
+            into: context,
+            options: .onboardingBootstrap()
+        )
+
+        let episodes = try context.fetch(FetchDescriptor<Episode>())
+        let profiles = try context.fetch(FetchDescriptor<EpisodeProfile>())
+        #expect(episodes.count == 3)
+        #expect(episodes.allSatisfy { $0.chapters.isEmpty })
+        #expect(profiles.isEmpty)
+        #expect(podcast.syncStatus == "idle")
+    }
+
+    @Test
+    @MainActor
     func episodeResolvedChaptersPreferPersistedMetadata() throws {
         let container = try makeContainer()
         let context = container.mainContext

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1425,7 +1425,7 @@ struct OffScriptTests {
         #expect(podcast.websiteURL == result.websiteURL)
         #expect(podcast.summary == result.summary)
         #expect(podcast.subscribedAt != nil)
-        #expect(podcast.syncStatus == "syncing")
+        #expect(podcast.syncStatus == "idle")
         #expect(podcast.lastSyncAttemptAt != nil)
         #expect(podcast.syncErrorMessage == nil)
     }


### PR DESCRIPTION
## Summary
- Stage selected onboarding podcast subscriptions immediately instead of waiting for full feed sync.
- Hydrate starter feeds in the background with a lightweight onboarding bootstrap profile: 3 episodes, no external chapter lookups, no expensive enrichment.
- Add unit coverage for immediate subscription staging and onboarding bootstrap behavior.
- Update the changelog under Unreleased.

## Validation
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: `testOnboardingFirstScreenSmoke`, `testPostOnboardingShellSmoke` passed
- Xcode MCP RunAllTests: 62/62 passed
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:OffScriptTests`: 56 Swift Testing unit tests passed
- `git diff --check`: passed

## Notes
This intentionally changes onboarding from "wait for feed hydration" to "commit subscriptions, enter the app, hydrate starter episodes after." Recommendations can be sparse for a short moment while the first background sync finishes, but the user is no longer blocked by slow feeds.