### PR TITLE
Improve large library scrolling performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.
 - **OPML batch hydration now uses a lightweight bootstrap pass** that imports only a small first slice of episodes and skips episode profile enrichment, avoiding thousands of episode/profile writes during the initial import.
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**
+- **Large-library scrolling no longer waits on per-show unplayed count churn by default.** Library now loads the aggregate unplayed count, fresh rail, and bounded in-progress rail first; exact per-show counts are deferred until `UNPLAYED` or `ATTN` directory modes need them.
+- **Library show rows now navigate through a single selected destination** instead of embedding a detail destination in every row of a 250+ show directory.
 - **Library summary reloads are coalesced during background OPML imports** so each imported show does not immediately retrigger the expensive per-show count path while the list is being scrolled.
 - **Library summary counts no longer issue one SwiftData `fetchCount` per subscribed show.** The page now loads the unplayed episode set once, derives the latest rail and per-show counts from that result, and avoids 250+ synchronous count queries on Library open.
 - **Library directory rendering now builds one snapshot per render pass** for filtered shows, alphabet sections, and row numbers, with debounced search input so typing does not repeatedly sort/group the whole library.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -68,6 +68,13 @@ nonisolated struct LibraryDirectorySnapshot {
 }
 
 nonisolated enum LibraryDirectoryOrganizer {
+    static func needsPerShowUnplayedCounts(
+        scope: LibraryDirectoryScope,
+        sort: LibraryDirectorySort
+    ) -> Bool {
+        scope == .unplayed || sort == .attention
+    }
+
     static func snapshot(
         for podcasts: [Podcast],
         query: String,
@@ -212,15 +219,6 @@ struct LibraryView: View {
     )
     private var podcasts: [Podcast]
 
-    // Predicate-filtered query for the small in-progress set. Fresh/unplayed
-    // summary data is loaded below with fetch limits and fetchCount so Library
-    // does not materialize a full back catalog just to draw the first rail.
-    @Query(
-        filter: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed && $0.playedPosition > 0 },
-        sort: [SortDescriptor(\Episode.lastPlayedAt, order: .reverse)]
-    )
-    private var inProgressEpisodes: [Episode]
-
     let onOpenSettings: () -> Void
 
     private let syncService = FeedSyncService()
@@ -231,11 +229,17 @@ struct LibraryView: View {
     @State private var directorySort: LibraryDirectorySort = .title
     @State private var directoryDensity: LibraryDirectoryDensity = .compact
     @State private var selectedDirectorySectionID: String?
+    @State private var inProgressEpisodes: [Episode] = []
+    @State private var inProgressEpisodeCount = 0
     @State private var freshEpisodes: [Episode] = []
     @State private var unplayedEpisodeCount = 0
-    @State private var freshCountsByPodcastID: [UUID: Int] = [:]
+    @State private var freshUnplayedCountsByPodcastID: [UUID: Int] = [:]
+    @State private var fullUnplayedCountsByPodcastID: [UUID: Int] = [:]
+    @State private var isLoadingFullUnplayedCounts = false
     @State private var summaryLoadTask: Task<Void, Never>?
+    @State private var fullCountLoadTask: Task<Void, Never>?
     @State private var directoryQueryTask: Task<Void, Never>?
+    @State private var selectedPodcast: Podcast?
 
     private var subscribedPodcasts: [Podcast] {
         podcasts
@@ -247,9 +251,17 @@ struct LibraryView: View {
             query: effectiveDirectoryQuery,
             scope: directoryScope,
             sort: directorySort,
-            unplayedCounts: freshCountsByPodcastID,
+            unplayedCounts: directoryUnplayedCountsByPodcastID,
             inProgressCounts: inProgressCountsByPodcastID
         )
+    }
+
+    private var directoryNeedsFullUnplayedCounts: Bool {
+        LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: directoryScope, sort: directorySort)
+    }
+
+    private var directoryUnplayedCountsByPodcastID: [UUID: Int] {
+        directoryNeedsFullUnplayedCounts ? fullUnplayedCountsByPodcastID : freshUnplayedCountsByPodcastID
     }
 
     private var isCompactDirectory: Bool {
@@ -273,7 +285,7 @@ struct LibraryView: View {
                         showCount: subscribedPodcasts.count,
                         visibleCount: snapshot.visibleCount,
                         unplayedCount: unplayedEpisodeCount,
-                        inProgressCount: inProgressEpisodes.count,
+                        inProgressCount: inProgressEpisodeCount,
                         onOpenImport: { isImportPresented = true },
                         onOpenSettings: onOpenSettings
                     )
@@ -338,12 +350,18 @@ struct LibraryView: View {
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .navigationDestination(item: $selectedPodcast) { podcast in
+            PodcastDetailView(podcast: podcast)
+        }
         .task { loadLibraryEpisodeSummary() }
         .onAppear { effectiveDirectoryQuery = directoryQuery }
         .onChange(of: subscribedPodcastIDs) { _, _ in scheduleLibraryEpisodeSummaryLoad() }
         .onChange(of: directoryQuery) { _, newValue in scheduleDirectoryQuery(newValue) }
+        .onChange(of: directoryScope) { _, _ in ensureFullUnplayedCountsIfNeeded() }
+        .onChange(of: directorySort) { _, _ in ensureFullUnplayedCountsIfNeeded() }
         .onDisappear {
             summaryLoadTask?.cancel()
+            fullCountLoadTask?.cancel()
             directoryQueryTask?.cancel()
         }
         .refreshable { await syncSubscriptions() }
@@ -402,6 +420,11 @@ struct LibraryView: View {
             if snapshot.isEmpty {
                 LibraryDirectoryEmptyState(query: effectiveDirectoryQuery, scope: directoryScope)
             } else {
+                if isLoadingFullUnplayedCounts && directoryNeedsFullUnplayedCounts {
+                    TunerLabel(text: "● LOADING DIRECTORY COUNTS", color: .offscriptSignalYellow, size: 8)
+                        .padding(.top, 2)
+                }
+
                 LibraryAlphabetRail(
                     sections: snapshot.sections,
                     selectedSectionID: selectedDirectorySectionID
@@ -426,13 +449,13 @@ struct LibraryView: View {
                             .id(section.id)
 
                             ForEach(Array(section.podcasts.enumerated()), id: \.element.id) { idx, podcast in
-                                NavigationLink {
-                                    PodcastDetailView(podcast: podcast)
+                                Button {
+                                    selectedPodcast = podcast
                                 } label: {
                                     PodcastShelfRow(
                                         podcast: podcast,
                                         channelNumber: snapshot.numbersByPodcastID[podcast.id] ?? (idx + 1),
-                                        unplayedCount: freshCountsByPodcastID[podcast.id] ?? 0,
+                                        unplayedCount: directoryUnplayedCountsByPodcastID[podcast.id] ?? 0,
                                         inProgressCount: inProgressCountsByPodcastID[podcast.id] ?? 0,
                                         isCompact: isCompactDirectory
                                     )
@@ -466,11 +489,19 @@ struct LibraryView: View {
     @MainActor
     private func startLibraryEpisodeSummaryLoad(deferWhileImporting: Bool) {
         summaryLoadTask?.cancel()
+        fullCountLoadTask?.cancel()
+        fullUnplayedCountsByPodcastID = [:]
+        isLoadingFullUnplayedCounts = false
         let podcastIDs = subscribedPodcastIDs
         guard !podcastIDs.isEmpty else {
             freshEpisodes = []
+            inProgressEpisodes = []
+            inProgressEpisodeCount = 0
             unplayedEpisodeCount = 0
-            freshCountsByPodcastID = [:]
+            freshUnplayedCountsByPodcastID = [:]
+            fullUnplayedCountsByPodcastID = [:]
+            fullCountLoadTask?.cancel()
+            isLoadingFullUnplayedCounts = false
             return
         }
 
@@ -494,15 +525,63 @@ struct LibraryView: View {
                 sortBy: [SortDescriptor(\Episode.pubDate, order: .reverse)]
             )
             freshDescriptor.fetchLimit = 10
+            let inProgressDescriptor = FetchDescriptor<Episode>(
+                predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed && $0.playedPosition > 0 }
+            )
+            var inProgressPageDescriptor = FetchDescriptor<Episode>(
+                predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed && $0.playedPosition > 0 },
+                sortBy: [SortDescriptor(\Episode.lastPlayedAt, order: .reverse)]
+            )
+            inProgressPageDescriptor.fetchLimit = 8
 
             unplayedEpisodeCount = try modelContext.fetchCount(countDescriptor)
             freshEpisodes = try modelContext.fetch(freshDescriptor)
-            freshCountsByPodcastID = Dictionary(freshEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
+            inProgressEpisodeCount = try modelContext.fetchCount(inProgressDescriptor)
+            inProgressEpisodes = try modelContext.fetch(inProgressPageDescriptor)
+            freshUnplayedCountsByPodcastID = Dictionary(freshEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
+            if directoryNeedsFullUnplayedCounts {
+                startFullUnplayedCountLoad(podcastIDs: podcastIDs)
+            }
+        } catch {
+            freshEpisodes = []
+            inProgressEpisodes = []
+            inProgressEpisodeCount = 0
+            unplayedEpisodeCount = 0
+            freshUnplayedCountsByPodcastID = [:]
+            fullUnplayedCountsByPodcastID = [:]
+            libraryLogger.error("Library summary load failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
 
-            var counts = freshCountsByPodcastID
-            let chunkSize = 24
+    @MainActor
+    private func ensureFullUnplayedCountsIfNeeded() {
+        guard directoryNeedsFullUnplayedCounts else { return }
+        guard !subscribedPodcastIDs.isEmpty else { return }
+        guard fullUnplayedCountsByPodcastID.isEmpty else { return }
+        startFullUnplayedCountLoad(podcastIDs: subscribedPodcastIDs)
+    }
+
+    @MainActor
+    private func startFullUnplayedCountLoad(podcastIDs: [UUID]) {
+        fullCountLoadTask?.cancel()
+        isLoadingFullUnplayedCounts = true
+        fullUnplayedCountsByPodcastID = [:]
+        fullCountLoadTask = Task { @MainActor in
+            await refreshFullUnplayedCounts(podcastIDs: podcastIDs)
+        }
+    }
+
+    @MainActor
+    private func refreshFullUnplayedCounts(podcastIDs: [UUID]) async {
+        var counts: [UUID: Int] = [:]
+        let chunkSize = 24
+
+        do {
             for start in stride(from: 0, to: podcastIDs.count, by: chunkSize) {
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled else {
+                    isLoadingFullUnplayedCounts = false
+                    return
+                }
                 let chunk = podcastIDs[start..<min(start + chunkSize, podcastIDs.count)]
                 for podcastID in chunk {
                     let descriptor = FetchDescriptor<Episode>(
@@ -511,16 +590,23 @@ struct LibraryView: View {
                         }
                     )
                     let count = try modelContext.fetchCount(descriptor)
-                    counts[podcastID] = count
+                    if count > 0 {
+                        counts[podcastID] = count
+                    }
                 }
-                freshCountsByPodcastID = counts.filter { $0.value > 0 }
                 await Task.yield()
             }
+
+            guard !Task.isCancelled else {
+                isLoadingFullUnplayedCounts = false
+                return
+            }
+            fullUnplayedCountsByPodcastID = counts
+            isLoadingFullUnplayedCounts = false
         } catch {
-            freshEpisodes = []
-            unplayedEpisodeCount = 0
-            freshCountsByPodcastID = [:]
-            libraryLogger.error("Library summary load failed: \(error.localizedDescription, privacy: .public)")
+            fullUnplayedCountsByPodcastID = [:]
+            isLoadingFullUnplayedCounts = false
+            libraryLogger.error("Library per-show count load failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -75,6 +75,13 @@ nonisolated enum LibraryDirectoryOrganizer {
         scope == .unplayed || sort == .attention
     }
 
+    static func needsPerShowInProgressCounts(
+        scope: LibraryDirectoryScope,
+        sort: LibraryDirectorySort
+    ) -> Bool {
+        scope == .inProgress || sort == .attention
+    }
+
     static func snapshot(
         for podcasts: [Podcast],
         query: String,
@@ -231,11 +238,14 @@ struct LibraryView: View {
     @State private var selectedDirectorySectionID: String?
     @State private var inProgressEpisodes: [Episode] = []
     @State private var inProgressEpisodeCount = 0
+    @State private var freshInProgressCountsByPodcastID: [UUID: Int] = [:]
+    @State private var fullInProgressCountsByPodcastID: [UUID: Int] = [:]
     @State private var freshEpisodes: [Episode] = []
     @State private var unplayedEpisodeCount = 0
     @State private var freshUnplayedCountsByPodcastID: [UUID: Int] = [:]
     @State private var fullUnplayedCountsByPodcastID: [UUID: Int] = [:]
-    @State private var isLoadingFullUnplayedCounts = false
+    @State private var didLoadFullDirectoryCounts = false
+    @State private var isLoadingFullDirectoryCounts = false
     @State private var summaryLoadTask: Task<Void, Never>?
     @State private var fullCountLoadTask: Task<Void, Never>?
     @State private var directoryQueryTask: Task<Void, Never>?
@@ -252,7 +262,7 @@ struct LibraryView: View {
             scope: directoryScope,
             sort: directorySort,
             unplayedCounts: directoryUnplayedCountsByPodcastID,
-            inProgressCounts: inProgressCountsByPodcastID
+            inProgressCounts: directoryInProgressCountsByPodcastID
         )
     }
 
@@ -260,16 +270,24 @@ struct LibraryView: View {
         LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: directoryScope, sort: directorySort)
     }
 
+    private var directoryNeedsFullInProgressCounts: Bool {
+        LibraryDirectoryOrganizer.needsPerShowInProgressCounts(scope: directoryScope, sort: directorySort)
+    }
+
+    private var directoryNeedsFullCounts: Bool {
+        directoryNeedsFullUnplayedCounts || directoryNeedsFullInProgressCounts
+    }
+
     private var directoryUnplayedCountsByPodcastID: [UUID: Int] {
         directoryNeedsFullUnplayedCounts ? fullUnplayedCountsByPodcastID : freshUnplayedCountsByPodcastID
     }
 
-    private var isCompactDirectory: Bool {
-        directoryDensity == .compact || subscribedPodcasts.count >= 120
+    private var directoryInProgressCountsByPodcastID: [UUID: Int] {
+        directoryNeedsFullInProgressCounts ? fullInProgressCountsByPodcastID : freshInProgressCountsByPodcastID
     }
 
-    private var inProgressCountsByPodcastID: [UUID: Int] {
-        Dictionary(inProgressEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
+    private var isCompactDirectory: Bool {
+        directoryDensity == .compact || subscribedPodcasts.count >= 120
     }
 
     private var subscribedPodcastIDs: [UUID] {
@@ -357,8 +375,8 @@ struct LibraryView: View {
         .onAppear { effectiveDirectoryQuery = directoryQuery }
         .onChange(of: subscribedPodcastIDs) { _, _ in scheduleLibraryEpisodeSummaryLoad() }
         .onChange(of: directoryQuery) { _, newValue in scheduleDirectoryQuery(newValue) }
-        .onChange(of: directoryScope) { _, _ in ensureFullUnplayedCountsIfNeeded() }
-        .onChange(of: directorySort) { _, _ in ensureFullUnplayedCountsIfNeeded() }
+        .onChange(of: directoryScope) { _, _ in ensureFullDirectoryCountsIfNeeded() }
+        .onChange(of: directorySort) { _, _ in ensureFullDirectoryCountsIfNeeded() }
         .onDisappear {
             summaryLoadTask?.cancel()
             fullCountLoadTask?.cancel()
@@ -420,7 +438,7 @@ struct LibraryView: View {
             if snapshot.isEmpty {
                 LibraryDirectoryEmptyState(query: effectiveDirectoryQuery, scope: directoryScope)
             } else {
-                if isLoadingFullUnplayedCounts && directoryNeedsFullUnplayedCounts {
+                if isLoadingFullDirectoryCounts && directoryNeedsFullCounts {
                     TunerLabel(text: "● LOADING DIRECTORY COUNTS", color: .offscriptSignalYellow, size: 8)
                         .padding(.top, 2)
                 }
@@ -456,7 +474,7 @@ struct LibraryView: View {
                                         podcast: podcast,
                                         channelNumber: snapshot.numbersByPodcastID[podcast.id] ?? (idx + 1),
                                         unplayedCount: directoryUnplayedCountsByPodcastID[podcast.id] ?? 0,
-                                        inProgressCount: inProgressCountsByPodcastID[podcast.id] ?? 0,
+                                        inProgressCount: directoryInProgressCountsByPodcastID[podcast.id] ?? 0,
                                         isCompact: isCompactDirectory
                                     )
                                 }
@@ -491,17 +509,22 @@ struct LibraryView: View {
         summaryLoadTask?.cancel()
         fullCountLoadTask?.cancel()
         fullUnplayedCountsByPodcastID = [:]
-        isLoadingFullUnplayedCounts = false
+        fullInProgressCountsByPodcastID = [:]
+        didLoadFullDirectoryCounts = false
+        isLoadingFullDirectoryCounts = false
         let podcastIDs = subscribedPodcastIDs
         guard !podcastIDs.isEmpty else {
             freshEpisodes = []
             inProgressEpisodes = []
             inProgressEpisodeCount = 0
+            freshInProgressCountsByPodcastID = [:]
             unplayedEpisodeCount = 0
             freshUnplayedCountsByPodcastID = [:]
             fullUnplayedCountsByPodcastID = [:]
+            fullInProgressCountsByPodcastID = [:]
+            didLoadFullDirectoryCounts = false
             fullCountLoadTask?.cancel()
-            isLoadingFullUnplayedCounts = false
+            isLoadingFullDirectoryCounts = false
             return
         }
 
@@ -539,74 +562,95 @@ struct LibraryView: View {
             inProgressEpisodeCount = try modelContext.fetchCount(inProgressDescriptor)
             inProgressEpisodes = try modelContext.fetch(inProgressPageDescriptor)
             freshUnplayedCountsByPodcastID = Dictionary(freshEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
-            if directoryNeedsFullUnplayedCounts {
-                startFullUnplayedCountLoad(podcastIDs: podcastIDs)
+            freshInProgressCountsByPodcastID = Dictionary(inProgressEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
+            if directoryNeedsFullCounts {
+                startFullDirectoryCountLoad(podcastIDs: podcastIDs)
             }
         } catch {
             freshEpisodes = []
             inProgressEpisodes = []
             inProgressEpisodeCount = 0
+            freshInProgressCountsByPodcastID = [:]
             unplayedEpisodeCount = 0
             freshUnplayedCountsByPodcastID = [:]
             fullUnplayedCountsByPodcastID = [:]
+            fullInProgressCountsByPodcastID = [:]
+            didLoadFullDirectoryCounts = false
             libraryLogger.error("Library summary load failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 
     @MainActor
-    private func ensureFullUnplayedCountsIfNeeded() {
-        guard directoryNeedsFullUnplayedCounts else { return }
+    private func ensureFullDirectoryCountsIfNeeded() {
+        guard directoryNeedsFullCounts else { return }
         guard !subscribedPodcastIDs.isEmpty else { return }
-        guard fullUnplayedCountsByPodcastID.isEmpty else { return }
-        startFullUnplayedCountLoad(podcastIDs: subscribedPodcastIDs)
+        guard !didLoadFullDirectoryCounts else { return }
+        startFullDirectoryCountLoad(podcastIDs: subscribedPodcastIDs)
     }
 
     @MainActor
-    private func startFullUnplayedCountLoad(podcastIDs: [UUID]) {
+    private func startFullDirectoryCountLoad(podcastIDs: [UUID]) {
         fullCountLoadTask?.cancel()
-        isLoadingFullUnplayedCounts = true
+        isLoadingFullDirectoryCounts = true
+        didLoadFullDirectoryCounts = false
         fullUnplayedCountsByPodcastID = [:]
+        fullInProgressCountsByPodcastID = [:]
         fullCountLoadTask = Task { @MainActor in
-            await refreshFullUnplayedCounts(podcastIDs: podcastIDs)
+            await refreshFullDirectoryCounts(podcastIDs: podcastIDs)
         }
     }
 
     @MainActor
-    private func refreshFullUnplayedCounts(podcastIDs: [UUID]) async {
-        var counts: [UUID: Int] = [:]
+    private func refreshFullDirectoryCounts(podcastIDs: [UUID]) async {
+        var unplayedCounts: [UUID: Int] = [:]
+        var inProgressCounts: [UUID: Int] = [:]
         let chunkSize = 24
 
         do {
             for start in stride(from: 0, to: podcastIDs.count, by: chunkSize) {
                 guard !Task.isCancelled else {
-                    isLoadingFullUnplayedCounts = false
+                    isLoadingFullDirectoryCounts = false
                     return
                 }
                 let chunk = podcastIDs[start..<min(start + chunkSize, podcastIDs.count)]
                 for podcastID in chunk {
-                    let descriptor = FetchDescriptor<Episode>(
+                    let unplayedDescriptor = FetchDescriptor<Episode>(
                         predicate: #Predicate<Episode> {
                             $0.podcast.id == podcastID && $0.podcast.isSubscribed && !$0.isPlayed
                         }
                     )
-                    let count = try modelContext.fetchCount(descriptor)
-                    if count > 0 {
-                        counts[podcastID] = count
+                    let unplayedCount = try modelContext.fetchCount(unplayedDescriptor)
+                    if unplayedCount > 0 {
+                        unplayedCounts[podcastID] = unplayedCount
+                    }
+
+                    let inProgressDescriptor = FetchDescriptor<Episode>(
+                        predicate: #Predicate<Episode> {
+                            $0.podcast.id == podcastID && $0.podcast.isSubscribed && !$0.isPlayed && $0.playedPosition > 0
+                        }
+                    )
+                    let inProgressCount = try modelContext.fetchCount(inProgressDescriptor)
+                    if inProgressCount > 0 {
+                        inProgressCounts[podcastID] = inProgressCount
                     }
                 }
                 await Task.yield()
             }
 
             guard !Task.isCancelled else {
-                isLoadingFullUnplayedCounts = false
+                isLoadingFullDirectoryCounts = false
                 return
             }
-            fullUnplayedCountsByPodcastID = counts
-            isLoadingFullUnplayedCounts = false
+            fullUnplayedCountsByPodcastID = unplayedCounts
+            fullInProgressCountsByPodcastID = inProgressCounts
+            didLoadFullDirectoryCounts = true
+            isLoadingFullDirectoryCounts = false
         } catch {
             fullUnplayedCountsByPodcastID = [:]
-            isLoadingFullUnplayedCounts = false
-            libraryLogger.error("Library per-show count load failed: \(error.localizedDescription, privacy: .public)")
+            fullInProgressCountsByPodcastID = [:]
+            didLoadFullDirectoryCounts = false
+            isLoadingFullDirectoryCounts = false
+            libraryLogger.error("Library per-show directory count load failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -968,6 +968,14 @@ struct OffScriptTests {
     }
 
     @Test
+    func libraryDirectoryOrganizerLoadsPerShowCountsOnlyForCountDrivenModes() {
+        #expect(!LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: .all, sort: .title))
+        #expect(!LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: .needsSync, sort: .latest))
+        #expect(LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: .unplayed, sort: .title))
+        #expect(LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: .all, sort: .attention))
+    }
+
+    @Test
     @MainActor
     func tasteProfileRefreshAggregatesSignals() throws {
         let container = try makeContainer()

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -973,6 +973,11 @@ struct OffScriptTests {
         #expect(!LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: .needsSync, sort: .latest))
         #expect(LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: .unplayed, sort: .title))
         #expect(LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: .all, sort: .attention))
+
+        #expect(!LibraryDirectoryOrganizer.needsPerShowInProgressCounts(scope: .all, sort: .title))
+        #expect(!LibraryDirectoryOrganizer.needsPerShowInProgressCounts(scope: .needsSync, sort: .latest))
+        #expect(LibraryDirectoryOrganizer.needsPerShowInProgressCounts(scope: .inProgress, sort: .title))
+        #expect(LibraryDirectoryOrganizer.needsPerShowInProgressCounts(scope: .all, sort: .attention))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Remove the default Library open/scroll path that ran one per-show unplayed `fetchCount` for every subscribed podcast.
- Defer exact per-show unplayed counts until `UNPLAYED` scope or `ATTN` sort actually needs them.
- Bound the in-progress rail fetch to the rendered rail instead of using an unbounded `@Query`.
- Replace per-row podcast detail `NavigationLink` destinations with a single selection-based navigation destination.
- Update changelog and add a unit contract for count-driven directory modes.

## Validation
- Xcode MCP BuildProject: passed
- Xcode MCP RunSomeTests: Library organizer tests + 258-show UI smokes passed
- Xcode MCP RunAllTests: 61/61 passed
- `git diff --check`: passed

## Performance Notes
This targets the 250+ show scroll problem directly: the default Library directory no longer repaints while hundreds of main-actor per-show count queries finish in chunks, and SwiftUI does not carry a detail destination closure in every show row.