### PR TITLE
Improve recommendation signal ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home can render a Tuner-styled discovery rail** sourced from the existing taste profile, with trace rows explaining whether each new podcast came from genre, tag, show-affinity, or discovery signal. Discovery rows can be tuned into the library without leaving Home.
 
 ### Changed — taste profile quality
+- **Home recommendations now treat explicit Like / More Like This feedback as first-class signal** ahead of passive show completion, so the next Home surface follows what the listener deliberately asked for instead of drifting back toward generic fresh/feed picks.
+- **Home show-affinity recommendations now use current preference events immediately** instead of waiting on the cached taste profile refresh window, so a newly liked show can influence the next render right away.
+- **Player suggestions now let strong now-playing topic overlap beat unrelated same-show episodes**, making the player rail feel contextual to the current listen rather than a plain “more from this feed” list.
+- **“Shows You Finish” now means actual completed playback events** instead of grouping resumed or queue-advanced events into completion evidence.
 - **Home, Discovery, and Player recommendation cards now use authored local signal explanations** instead of raw algorithm fallback strings like `Matches your saved signal`, keeping WHY copy concrete even when Apple Intelligence is unavailable.
 - **Taste refresh now uses weighted, decayed evidence instead of equal counts.** Recent explicit `More like this` signals beat old passive completions, while `Less like this`, `Not interested`, quick skips, and abandons demote matching tags and shows.
 - **Recommendation modes now materially change Home ranking.** `SIGNAL` excludes genre-only candidates, while `BALANCED` and `DISCOVERY` can include a separate tuned-genre lane after local evidence.

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -165,8 +165,6 @@ final class RecommendationService {
             .filter { $0.podcast.isSubscribed }
         let recentEpisodes = try context.fetch(Self.recentCandidateDescriptor(limit: 360))
         let episodes = Self.uniqueEpisodes(queueItems.map(\.episode) + inProgressEpisodes + recentEpisodes)
-        let profiles = try context.fetch(FetchDescriptor<EpisodeProfile>())
-        let profileByEpisodeID = Dictionary(uniqueKeysWithValues: profiles.map { ($0.episodeID, $0) })
 
         // Only fetch preference signals from the last 90 days to avoid loading stale history
         let signalCutoff = Calendar.current.date(byAdding: .day, value: -90, to: Date()) ?? .distantPast
@@ -176,6 +174,11 @@ final class RecommendationService {
         let playbackEvents = try context.fetch(FetchDescriptor<PlaybackEvent>(
             predicate: #Predicate<PlaybackEvent> { $0.date >= signalCutoff }
         ))
+        var profileEpisodeIDs = Set(episodes.map(\.id))
+        profileEpisodeIDs.formUnion(preferences.map { $0.episode.id })
+        profileEpisodeIDs.formUnion(playbackEvents.compactMap { $0.episode?.id })
+        let profiles = try Self.profiles(for: profileEpisodeIDs, context: context)
+        let profileByEpisodeID = Self.profileMap(from: profiles)
         let tasteProfile = try? TasteProfileService.loadOrCreate(in: context)
         let dislikedEpisodeIDs: Set<UUID> = Set(preferences.filter { $0.action == .notInterested || $0.action == .lessLikeThis }.compactMap { (signal: PreferenceSignal) -> UUID? in signal.episode.id })
         let negativePreferences = preferences.filter { $0.action == .notInterested || $0.action == .lessLikeThis }
@@ -555,7 +558,6 @@ final class RecommendationService {
             predicate: #Predicate<Episode> { $0.podcast.isSubscribed == true && $0.id != currentEpisodeID && $0.isPlayed == false }
         ))
 
-        let profiles = try context.fetch(FetchDescriptor<EpisodeProfile>())
         let signalCutoff = Calendar.current.date(byAdding: .day, value: -90, to: Date()) ?? .distantPast
         let preferences = try context.fetch(FetchDescriptor<PreferenceSignal>(
             predicate: #Predicate<PreferenceSignal> { $0.date >= signalCutoff }
@@ -570,12 +572,20 @@ final class RecommendationService {
         let tasteProfile = try? TasteProfileService.loadOrCreate(in: context)
         let likedEpisodeIDs: Set<UUID> = Set(preferences.filter { $0.action == .like || $0.action == .moreLikeThis }.compactMap { (signal: PreferenceSignal) -> UUID? in signal.episode.id })
         let negativePreferences = preferences.filter { $0.action == .notInterested || $0.action == .lessLikeThis }
-        let profileByEpisodeID = Dictionary(uniqueKeysWithValues: profiles.map { ($0.episodeID, $0) })
-        let likedTags = Self.normalizedTags(profiles.lazy.filter { likedEpisodeIDs.contains($0.episodeID) }.flatMap(\.tags))
+        var profileEpisodeIDs = Set(episodes.map(\.id))
+        profileEpisodeIDs.insert(currentEpisode.id)
+        profileEpisodeIDs.formUnion(preferences.map { $0.episode.id })
+        profileEpisodeIDs.formUnion(negativePlaybackEvents.compactMap { $0.episode?.id })
+        let profiles = try Self.profiles(for: profileEpisodeIDs, context: context)
+        let profileByEpisodeID = Self.profileMap(from: profiles)
+        let likedTags = Self.normalizedTags(likedEpisodeIDs.flatMap { profileByEpisodeID[$0]?.tags ?? [] })
         let dislikedTags = Self.normalizedTags(
-            negativePreferences.lazy.flatMap { $0.episode.profile?.tags ?? [] }
+            negativePreferences.lazy.flatMap { profileByEpisodeID[$0.episode.id]?.tags ?? $0.episode.profile?.tags ?? [] }
         ).union(Self.normalizedTags(
-            negativePlaybackEvents.lazy.flatMap { $0.episode?.profile?.tags ?? [] }
+            negativePlaybackEvents.lazy.flatMap { event -> [String] in
+                guard let episode = event.episode else { return [] }
+                return profileByEpisodeID[episode.id]?.tags ?? episode.profile?.tags ?? []
+            }
         ))
         let penalizedShows = Set(
             negativePreferences.map { $0.episode.podcast.title }
@@ -719,6 +729,18 @@ final class RecommendationService {
 
     private static func normalizedTags<S: Sequence>(_ tags: S) -> Set<String> where S.Element == String {
         Set(tags.map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }.filter { !$0.isEmpty })
+    }
+
+    private static func profileMap(from profiles: [EpisodeProfile]) -> [UUID: EpisodeProfile] {
+        Dictionary(profiles.map { ($0.episodeID, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    private static func profiles(for episodeIDs: Set<UUID>, context: ModelContext) throws -> [EpisodeProfile] {
+        guard !episodeIDs.isEmpty else { return [] }
+        let ids = Array(episodeIDs)
+        return try context.fetch(FetchDescriptor<EpisodeProfile>(
+            predicate: #Predicate<EpisodeProfile> { ids.contains($0.episodeID) }
+        ))
     }
 
     private static func recentCandidateDescriptor(limit: Int) -> FetchDescriptor<Episode> {

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -73,10 +73,12 @@ final class RecommendationService {
         let profileByEpisodeID: [UUID: EpisodeProfile]
         let likedTags: Set<String>
         let completedTags: Set<String>
+        let explicitPositiveTags: Set<String>
         let tasteProfile: UserTasteProfile?
         let topTags: Set<String>
         let showAffinity: Set<String>
         let completedShowCounts: [String: Int]
+        let explicitPositiveShowCounts: [String: Int]
         let queuedPositionByEpisodeID: [UUID: Int]
         let preferredGenres: Set<String>
         let dislikedTags: Set<String>
@@ -163,6 +165,8 @@ final class RecommendationService {
             .filter { $0.podcast.isSubscribed }
         let recentEpisodes = try context.fetch(Self.recentCandidateDescriptor(limit: 360))
         let episodes = Self.uniqueEpisodes(queueItems.map(\.episode) + inProgressEpisodes + recentEpisodes)
+        let profiles = try context.fetch(FetchDescriptor<EpisodeProfile>())
+        let profileByEpisodeID = Dictionary(uniqueKeysWithValues: profiles.map { ($0.episodeID, $0) })
 
         // Only fetch preference signals from the last 90 days to avoid loading stale history
         let signalCutoff = Calendar.current.date(byAdding: .day, value: -90, to: Date()) ?? .distantPast
@@ -176,23 +180,32 @@ final class RecommendationService {
         let dislikedEpisodeIDs: Set<UUID> = Set(preferences.filter { $0.action == .notInterested || $0.action == .lessLikeThis }.compactMap { (signal: PreferenceSignal) -> UUID? in signal.episode.id })
         let negativePreferences = preferences.filter { $0.action == .notInterested || $0.action == .lessLikeThis }
         let negativePlaybackEvents = playbackEvents.filter { $0.kind == .skippedQuickly || $0.kind == .abandoned }
-        let profileByEpisodeID = Dictionary(uniqueKeysWithValues: episodes.compactMap { episode in
-            episode.profile.map { (episode.id, $0) }
-        })
         let likedTags = Self.normalizedTags(preferences.lazy
             .filter { $0.action == .like || $0.action == .moreLikeThis }
-            .flatMap { $0.episode.profile?.tags ?? [] })
+            .flatMap { profileByEpisodeID[$0.episode.id]?.tags ?? $0.episode.profile?.tags ?? [] })
         let completedTags = Self.normalizedTags(playbackEvents.lazy
             .filter { $0.kind == .completed }
-            .flatMap { $0.episode?.profile?.tags ?? [] })
+            .flatMap { event -> [String] in
+                guard let episode = event.episode else { return [] }
+                return profileByEpisodeID[episode.id]?.tags ?? episode.profile?.tags ?? []
+            })
+        let explicitPositivePreferences = preferences.filter { $0.action == .like || $0.action == .moreLikeThis }
+        let explicitPositiveTags = Self.normalizedTags(explicitPositivePreferences.lazy.flatMap {
+            profileByEpisodeID[$0.episode.id]?.tags ?? $0.episode.profile?.tags ?? []
+        })
         let completedShows = playbackEvents
-            .filter { $0.kind == .completed || $0.kind == .advancedFromQueue || $0.kind == .resumed }
+            .filter { $0.kind == .completed }
             .compactMap { $0.episode?.podcast.title }
         let completedShowCounts = Dictionary(completedShows.map { ($0, 1) }, uniquingKeysWith: +)
+        let explicitPositiveShows = explicitPositivePreferences.map { $0.episode.podcast.title }
+        let explicitPositiveShowCounts = Dictionary(explicitPositiveShows.map { ($0, 1) }, uniquingKeysWith: +)
         let dislikedTags = Self.normalizedTags(
-            negativePreferences.lazy.flatMap { $0.episode.profile?.tags ?? [] }
+            negativePreferences.lazy.flatMap { profileByEpisodeID[$0.episode.id]?.tags ?? $0.episode.profile?.tags ?? [] }
         ).union(Self.normalizedTags(
-            negativePlaybackEvents.lazy.flatMap { $0.episode?.profile?.tags ?? [] }
+            negativePlaybackEvents.lazy.flatMap { event -> [String] in
+                guard let episode = event.episode else { return [] }
+                return profileByEpisodeID[episode.id]?.tags ?? episode.profile?.tags ?? []
+            }
         ))
         let penalizedShows = Set(
             negativePreferences.map { $0.episode.podcast.title }
@@ -203,10 +216,12 @@ final class RecommendationService {
             profileByEpisodeID: profileByEpisodeID,
             likedTags: likedTags,
             completedTags: completedTags,
+            explicitPositiveTags: explicitPositiveTags,
             tasteProfile: tasteProfile,
             topTags: Self.normalizedTags(tasteProfile?.topTags ?? []),
             showAffinity: Set(tasteProfile?.showAffinity ?? []),
             completedShowCounts: completedShowCounts,
+            explicitPositiveShowCounts: explicitPositiveShowCounts,
             queuedPositionByEpisodeID: queuedPositionByEpisodeID,
             preferredGenres: Set((tasteProfile?.preferredGenres ?? AppSettings.preferredGenres.map(\.title)).map { $0.lowercased() }),
             dislikedTags: dislikedTags,
@@ -245,6 +260,7 @@ final class RecommendationService {
             scoredEpisodes.filter {
                 scoringContext.completedShowCounts[$0.episode.podcast.title, default: 0] > 0
                     || scoringContext.showAffinity.contains($0.episode.podcast.title)
+                    || scoringContext.explicitPositiveShowCounts[$0.episode.podcast.title, default: 0] > 0
             },
             limit: limit,
             excluding: &usedEpisodeIDs
@@ -288,6 +304,7 @@ final class RecommendationService {
     ) -> (score: Double, explanation: String, signalTrace: [RecommendationSignal])? {
         let profile = context.profileByEpisodeID[episode.id]
         let profileTags = Self.normalizedTags(profile?.tags ?? [])
+        let matchingExplicitTags = profileTags.intersection(context.explicitPositiveTags)
         let matchingLikedTags = profileTags.intersection(context.likedTags)
         let matchingCompletedTags = profileTags.intersection(context.completedTags)
         let matchingTopTags = profileTags.intersection(context.topTags)
@@ -329,6 +346,31 @@ final class RecommendationService {
 
         if Self.isSuppressedByNegativeSignal(episode, profileTags: profileTags, context: context) {
             return nil
+        }
+
+        if !matchingExplicitTags.isEmpty {
+            let sample = matchingExplicitTags.sorted().prefix(2).joined(separator: ", ")
+            return (
+                360 + Double(min(matchingExplicitTags.count, 4)) * 22 + freshnessTieBreak + qualityTieBreak,
+                "Matches what you asked for: \(sample)",
+                [
+                    RecommendationSignal(label: "source", value: "explicit signal"),
+                    RecommendationSignal(label: "tags", value: sample)
+                ]
+            )
+        }
+
+        let explicitShowCount = context.explicitPositiveShowCounts[episode.podcast.title, default: 0]
+        if explicitShowCount > 0 {
+            return (
+                380 + Double(min(explicitShowCount, 4)) * 20 + freshnessTieBreak + qualityTieBreak,
+                "You asked for more from \(episode.podcast.title)",
+                [
+                    RecommendationSignal(label: "source", value: "show intent"),
+                    RecommendationSignal(label: "show", value: episode.podcast.title),
+                    RecommendationSignal(label: "signals", value: "\(explicitShowCount)")
+                ]
+            )
         }
 
         let completedShowCount = context.completedShowCounts[episode.podcast.title, default: 0]
@@ -543,10 +585,12 @@ final class RecommendationService {
             profileByEpisodeID: profileByEpisodeID,
             likedTags: likedTags,
             completedTags: [],
+            explicitPositiveTags: likedTags,
             tasteProfile: tasteProfile,
             topTags: Self.normalizedTags(tasteProfile?.topTags ?? []),
             showAffinity: Set(tasteProfile?.showAffinity ?? []),
             completedShowCounts: [:],
+            explicitPositiveShowCounts: [:],
             queuedPositionByEpisodeID: [:],
             preferredGenres: Set((tasteProfile?.preferredGenres ?? AppSettings.preferredGenres.map(\.title)).map { $0.lowercased() }),
             dislikedTags: dislikedTags,
@@ -556,7 +600,7 @@ final class RecommendationService {
         // Also boost episodes from the same podcast
         let currentPodcastID = currentEpisode.podcast.id
         let currentProfile = profileByEpisodeID[currentEpisode.id]
-        let currentTags = Set(currentProfile?.tags ?? [])
+        let currentTags = Self.normalizedTags(currentProfile?.tags ?? [])
 
         return episodes
             .filter { episode in
@@ -585,10 +629,10 @@ final class RecommendationService {
 
                 // Boost episodes with overlapping tags to current episode
                 let episodeProfile = profileByEpisodeID[episode.id]
-                let episodeTags = Set(episodeProfile?.tags ?? [])
+                let episodeTags = Self.normalizedTags(episodeProfile?.tags ?? [])
                 let currentOverlap = episodeTags.intersection(currentTags)
                 if !currentOverlap.isEmpty {
-                    score += Double(currentOverlap.count) * 0.05
+                    score += Double(min(currentOverlap.count, 4)) * 0.12
                     if episode.podcast.id != currentPodcastID {
                         let tag = currentOverlap.first ?? ""
                         result = (

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -489,6 +489,113 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func homeRecommendationsPreferExplicitMoreLikeThisOverPassiveShowAffinity() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let originalGenres = AppSettings.preferredGenres
+        AppSettings.preferredGenres = []
+        defer { AppSettings.preferredGenres = originalGenres }
+
+        let likedShow = Podcast(title: "Liked Topic", feedURL: URL(string: "https://example.com/liked-topic.xml")!)
+        let affinityShow = Podcast(title: "Finished Show", feedURL: URL(string: "https://example.com/passive-finished.xml")!)
+        let seed = Episode(
+            title: "Seed You Asked For",
+            pubDate: Date().addingTimeInterval(-9 * 86_400),
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/seed-like.mp3")!,
+            podcast: likedShow
+        )
+        let explicitMatch = Episode(
+            title: "Older Explicit Match",
+            pubDate: Date().addingTimeInterval(-8 * 86_400),
+            duration: 2_100,
+            audioURL: URL(string: "https://example.com/explicit-match.mp3")!,
+            podcast: likedShow
+        )
+        let completed = Episode(
+            title: "Completed Passive",
+            pubDate: Date().addingTimeInterval(-4 * 86_400),
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/passive-completed.mp3")!,
+            podcast: affinityShow
+        )
+        let passiveAffinity = Episode(
+            title: "Newer Passive Affinity",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/passive-affinity.mp3")!,
+            podcast: affinityShow
+        )
+        let seedProfile = EpisodeProfile(episodeID: seed.id)
+        seedProfile.tags = ["indie interviews"]
+        let matchProfile = EpisodeProfile(episodeID: explicitMatch.id)
+        matchProfile.tags = ["indie interviews"]
+
+        completed.isPlayed = true
+        context.insert(likedShow)
+        context.insert(affinityShow)
+        context.insert(seed)
+        context.insert(explicitMatch)
+        context.insert(completed)
+        context.insert(passiveAffinity)
+        context.insert(seedProfile)
+        context.insert(matchProfile)
+        context.insert(PreferenceSignal(action: .moreLikeThis, episode: seed))
+        context.insert(PlaybackEvent(kind: .completed, position: 1_800, episode: completed))
+        try context.save()
+
+        let sections = try RecommendationService().homeSections(context: context, limit: 3)
+        let firstEpisode = try #require(sections.first?.episodes.first)
+
+        #expect(firstEpisode.id == explicitMatch.id)
+        #expect(sections.first?.signalTrace(for: explicitMatch).contains(RecommendationSignal(label: "source", value: "explicit signal")) == true)
+    }
+
+    @Test
+    @MainActor
+    func homeRecommendationsUseCurrentLikedShowSignalWithoutCachedProfileRefresh() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let originalGenres = AppSettings.preferredGenres
+        AppSettings.preferredGenres = []
+        defer { AppSettings.preferredGenres = originalGenres }
+
+        let tasteProfile = UserTasteProfile()
+        tasteProfile.showAffinity = []
+        tasteProfile.topTags = []
+        tasteProfile.lastUpdatedAt = .now
+        let show = Podcast(title: "Freshly Liked Show", feedURL: URL(string: "https://example.com/freshly-liked.xml")!)
+        let liked = Episode(
+            title: "Liked Episode",
+            pubDate: Date().addingTimeInterval(-7 * 86_400),
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/freshly-liked-seed.mp3")!,
+            podcast: show
+        )
+        let next = Episode(
+            title: "Same Show Next",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/freshly-liked-next.mp3")!,
+            podcast: show
+        )
+
+        context.insert(tasteProfile)
+        context.insert(show)
+        context.insert(liked)
+        context.insert(next)
+        context.insert(PreferenceSignal(action: .like, episode: liked))
+        try context.save()
+
+        let sections = try RecommendationService().homeSections(context: context, limit: 3)
+        let firstEpisode = try #require(sections.first?.episodes.first)
+
+        #expect(firstEpisode.id == next.id)
+        #expect(sections.first?.signalTrace(for: next).contains(RecommendationSignal(label: "source", value: "show intent")) == true)
+    }
+
+    @Test
+    @MainActor
     func homeRecommendationsDoNotReturnRecencyOnlyCandidates() throws {
         let container = try makeContainer()
         let context = container.mainContext
@@ -758,6 +865,63 @@ struct OffScriptTests {
         #expect(scored.explanation == "Also covers \"audio craft\"")
         #expect(scored.signalTrace.contains(RecommendationSignal(label: "source", value: "now playing")))
         #expect(scored.signalTrace.contains(RecommendationSignal(label: "tag", value: "audio craft")))
+    }
+
+    @Test
+    @MainActor
+    func playerSuggestionsPreferStrongNowPlayingOverlapOverSameShow() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let currentPodcast = Podcast(title: "Current Show", feedURL: URL(string: "https://example.com/current-player.xml")!)
+        let relatedPodcast = Podcast(title: "Deep Related", feedURL: URL(string: "https://example.com/deep-related.xml")!)
+        let current = Episode(
+            title: "Current Context",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/current-context.mp3")!,
+            podcast: currentPodcast
+        )
+        let sameShow = Episode(
+            title: "Same Feed But Unrelated",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/same-feed.mp3")!,
+            podcast: currentPodcast
+        )
+        let deepMatch = Episode(
+            title: "Cross Show Deep Match",
+            pubDate: Date().addingTimeInterval(-2 * 86_400),
+            duration: 2_400,
+            audioURL: URL(string: "https://example.com/deep-match.mp3")!,
+            podcast: relatedPodcast
+        )
+        let currentProfile = EpisodeProfile(episodeID: current.id)
+        currentProfile.tags = ["editing", "field recording", "interviews"]
+        let sameProfile = EpisodeProfile(episodeID: sameShow.id)
+        sameProfile.tags = ["news"]
+        let deepProfile = EpisodeProfile(episodeID: deepMatch.id)
+        deepProfile.tags = ["editing", "field recording", "interviews"]
+
+        context.insert(currentPodcast)
+        context.insert(relatedPodcast)
+        context.insert(current)
+        context.insert(sameShow)
+        context.insert(deepMatch)
+        context.insert(currentProfile)
+        context.insert(sameProfile)
+        context.insert(deepProfile)
+        try context.save()
+
+        let suggestions = try RecommendationService().playerSuggestions(
+            currentEpisode: current,
+            context: context,
+            limit: 3
+        )
+        let scored = try #require(suggestions.first)
+
+        #expect(scored.episode.id == deepMatch.id)
+        #expect(scored.signalTrace.contains(RecommendationSignal(label: "source", value: "now playing")))
     }
 
     @Test

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -561,8 +561,8 @@ struct OffScriptTests {
         defer { AppSettings.preferredGenres = originalGenres }
 
         let tasteProfile = UserTasteProfile()
+        tasteProfile.topTags = ["already tuned"]
         tasteProfile.showAffinity = []
-        tasteProfile.topTags = []
         tasteProfile.lastUpdatedAt = .now
         let show = Podcast(title: "Freshly Liked Show", feedURL: URL(string: "https://example.com/freshly-liked.xml")!)
         let liked = Episode(


### PR DESCRIPTION
## Summary
- prioritize explicit Like / More Like This tags and show intent ahead of passive completion affinity on Home
- make Home use current preference signals immediately instead of waiting for cached taste-profile refresh
- strengthen player suggestions so strong now-playing topic overlap can beat unrelated same-show episodes
- document the recommendation-quality changes in the Unreleased changelog

## Verification
- Xcode MCP RunSomeTests: 13 recommendation/taste-profile tests passed
- Xcode MCP RunAllTests: 65 passed, 1 UI timing failure in testLargeLibraryAlphabetRailJumpsToSelectedLetter
- Xcode MCP rerun testLargeLibraryAlphabetRailJumpsToSelectedLetter: passed