### PR TITLE
Limit capped feed duplicate lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Library directory rendering now builds one snapshot per render pass** for filtered shows, alphabet sections, and row numbers, with debounced search input so typing does not repeatedly sort/group the whole library.
 - **Library no longer observes every OPML progress tick at the root page level.** The import strip repaints during batch progress, and the expensive directory snapshot refreshes when the batch reaches a terminal state.
 - **Bulk OPML import now skips already-subscribed feed URLs before network fetch/parse work** using the same normalized feed-key logic as OPML dedupe, so re-importing a large library does not waste rows on feeds that are already tuned.
+- **Capped feed imports now only look up existing episodes that can match the processed feed window** instead of fetching a show's entire historical episode table before an OPML/onboarding bootstrap slice.
 - **Library summary loading now avoids hydrating the full unplayed back catalog on open.** The header count and fresh rail load from count/limited fetches first, while per-show unplayed counts fill in incrementally in small chunks.
 
 ### Added — recommendation tuner and signal discovery

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -416,18 +416,17 @@ final class FeedSyncService {
         podcast.syncFailureCount = 0
         podcast.nextRetryAt = nil
 
-        // Use the podcast's stable UUID (a stored property) for the predicate
-        // instead of persistentModelID, which SwiftData cannot always translate
-        // into a reliable SQLite query.
-        let podcastID = podcast.id
-        let existingEpisodes = try context.fetch(FetchDescriptor<Episode>(
-            predicate: #Predicate<Episode> { $0.podcast.id == podcastID }
-        ))
-        let existingByGUID = Dictionary(existingEpisodes.map { ($0.guid, $0) }, uniquingKeysWith: { first, _ in first })
-        let existingByAudioURL = Dictionary(existingEpisodes.map { ($0.audioURL, $0) }, uniquingKeysWith: { first, _ in first })
-
         let sortedItems = parsed.items.sorted { ($0.pubDate ?? .distantPast) > ($1.pubDate ?? .distantPast) }
         let itemsToProcess = options.episodeLimit.map { Array(sortedItems.prefix($0)) } ?? sortedItems
+        let podcastID = podcast.id
+        let lookupKeys = Self.episodeLookupKeys(for: itemsToProcess)
+        let existingEpisodes = try Self.fetchExistingEpisodes(
+            for: podcastID,
+            lookupKeys: lookupKeys,
+            in: context
+        )
+        let existingByGUID = Dictionary(existingEpisodes.map { ($0.guid, $0) }, uniquingKeysWith: { first, _ in first })
+        let existingByAudioURL = Dictionary(existingEpisodes.map { ($0.audioURL, $0) }, uniquingKeysWith: { first, _ in first })
 
         for item in itemsToProcess {
             let guid = item.guid ?? item.audioURL.absoluteString
@@ -470,6 +469,34 @@ final class FeedSyncService {
         }
 
         try context.save()
+    }
+
+    private struct EpisodeLookupKeys {
+        let guids: Set<String>
+        let audioURLs: Set<URL>
+    }
+
+    private static func episodeLookupKeys(for items: [ParsedFeedItem]) -> EpisodeLookupKeys {
+        EpisodeLookupKeys(
+            guids: Set(items.map { $0.guid ?? $0.audioURL.absoluteString }),
+            audioURLs: Set(items.map(\.audioURL))
+        )
+    }
+
+    @MainActor
+    private static func fetchExistingEpisodes(
+        for podcastID: UUID,
+        lookupKeys: EpisodeLookupKeys,
+        in context: ModelContext
+    ) throws -> [Episode] {
+        guard !lookupKeys.guids.isEmpty || !lookupKeys.audioURLs.isEmpty else { return [] }
+        let guids = lookupKeys.guids
+        let audioURLs = lookupKeys.audioURLs
+        return try context.fetch(FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> {
+                $0.podcast.id == podcastID && (guids.contains($0.guid) || audioURLs.contains($0.audioURL))
+            }
+        ))
     }
 
     private enum FeedFetchResult {

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -472,8 +472,14 @@ final class FeedSyncService {
     }
 
     private struct EpisodeLookupKeys {
+        static let maxPredicateKeyCount = 800
+
         let guids: Set<String>
         let audioURLs: Set<URL>
+
+        var count: Int {
+            guids.count + audioURLs.count
+        }
     }
 
     private static func episodeLookupKeys(for items: [ParsedFeedItem]) -> EpisodeLookupKeys {
@@ -490,6 +496,13 @@ final class FeedSyncService {
         in context: ModelContext
     ) throws -> [Episode] {
         guard !lookupKeys.guids.isEmpty || !lookupKeys.audioURLs.isEmpty else { return [] }
+        if lookupKeys.count > EpisodeLookupKeys.maxPredicateKeyCount {
+            return try context.fetch(FetchDescriptor<Episode>(
+                predicate: #Predicate<Episode> {
+                    $0.podcast.id == podcastID
+                }
+            ))
+        }
         let guids = lookupKeys.guids
         let audioURLs = lookupKeys.audioURLs
         return try context.fetch(FetchDescriptor<Episode>(

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1637,7 +1637,7 @@ struct OffScriptTests {
             feedURL: URL(string: "https://example.com/large-back-catalog.xml")!
         )
         let inWindow = Episode(
-            guid: "large-1",
+            guid: "stale-guid-1",
             title: "Old Title",
             pubDate: .distantPast,
             audioURL: URL(string: "https://example.com/large-1.mp3")!,
@@ -1663,6 +1663,17 @@ struct OffScriptTests {
             websiteURL: nil,
             summary: nil
         )
+        let baseDate = Date()
+        let parsedItems = (1...5).map { index in
+            ParsedFeedItem(
+                guid: "large-\(index)",
+                title: "Updated Episode \(index)",
+                summary: nil,
+                pubDate: baseDate.addingTimeInterval(TimeInterval(-index)),
+                duration: 1_800,
+                audioURL: URL(string: "https://example.com/large-\(index).mp3")!
+            )
+        }
         let parsed = ParsedFeed(
             title: "Large Back Catalog",
             author: nil,
@@ -1670,16 +1681,7 @@ struct OffScriptTests {
             websiteURL: nil,
             artworkURL: nil,
             categories: [],
-            items: (1...5).map { index in
-                ParsedFeedItem(
-                    guid: "large-\(index)",
-                    title: "Updated Episode \(index)",
-                    summary: nil,
-                    pubDate: Date().addingTimeInterval(TimeInterval(-index)),
-                    duration: 1_800,
-                    audioURL: URL(string: "https://example.com/large-\(index).mp3")!
-                )
-            }
+            items: parsedItems
         )
 
         _ = try await FeedSyncService().importPodcast(
@@ -1692,6 +1694,7 @@ struct OffScriptTests {
         let episodes = try context.fetch(FetchDescriptor<Episode>())
         #expect(episodes.count == 4)
         #expect(inWindow.title == "Updated Episode 1")
+        #expect(inWindow.guid == "stale-guid-1")
         #expect(outsideWindow.title == "Preserved Title")
         #expect(episodes.contains { $0.guid == "large-2" })
         #expect(episodes.contains { $0.guid == "large-3" })

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1629,6 +1629,77 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func feedSyncCappedImportOnlyMatchesExistingEpisodesInProcessedWindow() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let podcast = Podcast(
+            title: "Large Back Catalog",
+            feedURL: URL(string: "https://example.com/large-back-catalog.xml")!
+        )
+        let inWindow = Episode(
+            guid: "large-1",
+            title: "Old Title",
+            pubDate: .distantPast,
+            audioURL: URL(string: "https://example.com/large-1.mp3")!,
+            podcast: podcast
+        )
+        let outsideWindow = Episode(
+            guid: "large-5",
+            title: "Preserved Title",
+            pubDate: .distantPast,
+            audioURL: URL(string: "https://example.com/large-5.mp3")!,
+            podcast: podcast
+        )
+        context.insert(podcast)
+        context.insert(inWindow)
+        context.insert(outsideWindow)
+        try context.save()
+
+        let result = PodcastSearchResult(
+            title: "Large Back Catalog",
+            author: "",
+            feedURL: podcast.feedURL,
+            artworkURL: nil,
+            websiteURL: nil,
+            summary: nil
+        )
+        let parsed = ParsedFeed(
+            title: "Large Back Catalog",
+            author: nil,
+            summary: nil,
+            websiteURL: nil,
+            artworkURL: nil,
+            categories: [],
+            items: (1...5).map { index in
+                ParsedFeedItem(
+                    guid: "large-\(index)",
+                    title: "Updated Episode \(index)",
+                    summary: nil,
+                    pubDate: Date().addingTimeInterval(TimeInterval(-index)),
+                    duration: 1_800,
+                    audioURL: URL(string: "https://example.com/large-\(index).mp3")!
+                )
+            }
+        )
+
+        _ = try await FeedSyncService().importPodcast(
+            from: result,
+            parsedFeed: parsed,
+            into: context,
+            options: .opmlBootstrap()
+        )
+
+        let episodes = try context.fetch(FetchDescriptor<Episode>())
+        #expect(episodes.count == 4)
+        #expect(inWindow.title == "Updated Episode 1")
+        #expect(outsideWindow.title == "Preserved Title")
+        #expect(episodes.contains { $0.guid == "large-2" })
+        #expect(episodes.contains { $0.guid == "large-3" })
+        #expect(!episodes.contains { $0.guid == "large-4" })
+    }
+
+    @Test
+    @MainActor
     func feedSyncStagesSearchSubscriptionBeforeNetworkWork() throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- limit existing-episode duplicate fetches to GUID/audio keys from the processed feed window
- avoid hydrating an entire historical episode table before capped OPML/onboarding bootstrap imports
- document the import performance change in the changelog

## Verification
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- git diff --check