### PR TITLE
Speed up onboarding feed staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Changed — Library performance
 - **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.
+- **Onboarding now stages selected starter shows in one SwiftData batch** instead of saving each selected podcast independently, making the three-podcast starter flow a single local commit before background hydration.
+- **Capped feed bootstrap now selects the newest episode slice without sorting full back catalogs**, so OPML and onboarding bootstrap paths do not pay full-feed sort cost when they only need the first few newest episodes.
 - **OPML batch hydration now uses a lightweight bootstrap pass** that imports only a small first slice of episodes and skips episode profile enrichment, avoiding thousands of episode/profile writes during the initial import.
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**
 - **Large-library scrolling no longer waits on per-show unplayed count churn by default.** Library now loads the aggregate unplayed count, fresh rail, and bounded in-progress rail first; exact per-show counts are deferred until `UNPLAYED` or `ATTN` directory modes need them.

--- a/OffScript/ImportProgressView.swift
+++ b/OffScript/ImportProgressView.swift
@@ -174,14 +174,16 @@ struct ImportProgressView: View {
             statuses[podcast.feedURL] = .importing
         }
 
-        var stagedPodcasts: [Podcast] = []
-        for podcast in selectedPodcasts {
-            do {
-                let staged = try syncService.stagePodcastSubscription(from: podcast, into: modelContext)
-                stagedPodcasts.append(staged)
+        let stagedPodcasts: [Podcast]
+        do {
+            stagedPodcasts = try syncService.stagePodcastSubscriptions(from: selectedPodcasts, into: modelContext)
+            for podcast in selectedPodcasts {
                 statuses[podcast.feedURL] = .done
-            } catch {
-                importLogger.error("Onboarding subscription staging failed for \(podcast.feedURL, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        } catch {
+            importLogger.error("Onboarding subscription staging failed: \(error.localizedDescription, privacy: .public)")
+            stagedPodcasts = []
+            for podcast in selectedPodcasts {
                 statuses[podcast.feedURL] = .failed
             }
         }

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -327,6 +327,58 @@ final class FeedSyncService {
     }
 
     @MainActor
+    func stagePodcastSubscriptions(from results: [PodcastSearchResult], into context: ModelContext) throws -> [Podcast] {
+        guard !results.isEmpty else { return [] }
+
+        let existingPodcasts = try context.fetch(FetchDescriptor<Podcast>())
+        var podcastByFeedKey = Dictionary(
+            existingPodcasts.map { ($0.feedURL.normalizedFeedKey, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let now = Date()
+        var stagedPodcasts: [Podcast] = []
+
+        for result in results {
+            let key = result.feedURL.normalizedFeedKey
+            let podcast: Podcast
+            if let existing = podcastByFeedKey[key] {
+                podcast = existing
+                podcast.isSubscribed = true
+                podcast.title = result.title
+                podcast.author = result.author
+                podcast.feedURL = result.feedURL
+                podcast.artworkURL = result.artworkURL
+                podcast.websiteURL = result.websiteURL
+                podcast.summary = result.summary
+                if podcast.subscribedAt == nil {
+                    podcast.subscribedAt = now
+                }
+            } else {
+                podcast = Podcast(
+                    title: result.title,
+                    author: result.author,
+                    summary: result.summary,
+                    feedURL: result.feedURL,
+                    websiteURL: result.websiteURL,
+                    artworkURL: result.artworkURL,
+                    isSubscribed: true
+                )
+                podcast.subscribedAt = now
+                context.insert(podcast)
+                podcastByFeedKey[key] = podcast
+            }
+
+            podcast.syncStatus = "idle"
+            podcast.lastSyncAttemptAt = now
+            podcast.syncErrorMessage = nil
+            stagedPodcasts.append(podcast)
+        }
+
+        try context.save()
+        return stagedPodcasts
+    }
+
+    @MainActor
     func sync(podcast: Podcast, in context: ModelContext, episodeLimit: Int? = nil) async throws {
         try await sync(podcast: podcast, in: context, options: .standard(episodeLimit: episodeLimit))
     }
@@ -416,8 +468,7 @@ final class FeedSyncService {
         podcast.syncFailureCount = 0
         podcast.nextRetryAt = nil
 
-        let sortedItems = parsed.items.sorted { ($0.pubDate ?? .distantPast) > ($1.pubDate ?? .distantPast) }
-        let itemsToProcess = options.episodeLimit.map { Array(sortedItems.prefix($0)) } ?? sortedItems
+        let itemsToProcess = Self.itemsToProcess(from: parsed.items, limit: options.episodeLimit)
         let podcastID = podcast.id
         let lookupKeys = Self.episodeLookupKeys(for: itemsToProcess)
         let existingEpisodes = try Self.fetchExistingEpisodes(
@@ -480,6 +531,34 @@ final class FeedSyncService {
         var count: Int {
             guids.count + audioURLs.count
         }
+    }
+
+    static func itemsToProcess(from items: [ParsedFeedItem], limit: Int?) -> [ParsedFeedItem] {
+        guard let limit else {
+            return items.sorted { ($0.pubDate ?? .distantPast) > ($1.pubDate ?? .distantPast) }
+        }
+        guard limit > 0 else { return [] }
+
+        var newestItems: [ParsedFeedItem] = []
+        newestItems.reserveCapacity(min(limit, items.count))
+
+        for item in items {
+            let itemDate = item.pubDate ?? .distantPast
+            let insertionIndex = newestItems.firstIndex {
+                itemDate > ($0.pubDate ?? .distantPast)
+            } ?? newestItems.endIndex
+
+            if insertionIndex < limit {
+                newestItems.insert(item, at: insertionIndex)
+                if newestItems.count > limit {
+                    newestItems.removeLast()
+                }
+            } else if newestItems.count < limit {
+                newestItems.append(item)
+            }
+        }
+
+        return newestItems
     }
 
     private static func episodeLookupKeys(for items: [ParsedFeedItem]) -> EpisodeLookupKeys {

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -330,18 +330,22 @@ final class FeedSyncService {
     func stagePodcastSubscriptions(from results: [PodcastSearchResult], into context: ModelContext) throws -> [Podcast] {
         guard !results.isEmpty else { return [] }
 
-        let existingPodcasts = try context.fetch(FetchDescriptor<Podcast>())
+        let feedURLs = Set(results.map(\.feedURL))
+        let existingPodcasts = try context.fetch(FetchDescriptor<Podcast>(
+            predicate: #Predicate<Podcast> {
+                feedURLs.contains($0.feedURL)
+            }
+        ))
         var podcastByFeedKey = Dictionary(
-            existingPodcasts.map { ($0.feedURL.normalizedFeedKey, $0) },
+            existingPodcasts.map { ($0.feedURL, $0) },
             uniquingKeysWith: { first, _ in first }
         )
         let now = Date()
         var stagedPodcasts: [Podcast] = []
 
         for result in results {
-            let key = result.feedURL.normalizedFeedKey
             let podcast: Podcast
-            if let existing = podcastByFeedKey[key] {
+            if let existing = podcastByFeedKey[result.feedURL] {
                 podcast = existing
                 podcast.isSubscribed = true
                 podcast.title = result.title
@@ -365,7 +369,7 @@ final class FeedSyncService {
                 )
                 podcast.subscribedAt = now
                 context.insert(podcast)
-                podcastByFeedKey[key] = podcast
+                podcastByFeedKey[result.feedURL] = podcast
             }
 
             podcast.syncStatus = "idle"
@@ -374,7 +378,12 @@ final class FeedSyncService {
             stagedPodcasts.append(podcast)
         }
 
-        try context.save()
+        do {
+            try context.save()
+        } catch {
+            context.rollback()
+            throw error
+        }
         return stagedPodcasts
     }
 
@@ -553,8 +562,6 @@ final class FeedSyncService {
                 if newestItems.count > limit {
                     newestItems.removeLast()
                 }
-            } else if newestItems.count < limit {
-                newestItems.append(item)
             }
         }
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1733,6 +1733,60 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func feedSyncStagesMultipleOnboardingSubscriptionsInOneBatch() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let existing = Podcast(
+            title: "Old Starter",
+            author: "Old Author",
+            feedURL: URL(string: "https://example.com/old-starter.xml")!,
+            isSubscribed: false
+        )
+        context.insert(existing)
+        try context.save()
+
+        let results = [
+            PodcastSearchResult(
+                title: "Starter One",
+                author: "Starter Author",
+                feedURL: existing.feedURL,
+                artworkURL: URL(string: "https://example.com/starter-one.jpg")!,
+                websiteURL: URL(string: "https://example.com/one")!,
+                summary: "A staged starter show."
+            ),
+            PodcastSearchResult(
+                title: "Starter Two",
+                author: "Second Author",
+                feedURL: URL(string: "https://example.com/starter-two.xml")!,
+                artworkURL: nil,
+                websiteURL: nil,
+                summary: nil
+            ),
+            PodcastSearchResult(
+                title: "Starter Three",
+                author: "Third Author",
+                feedURL: URL(string: "https://example.com/starter-three.xml")!,
+                artworkURL: nil,
+                websiteURL: nil,
+                summary: nil
+            )
+        ]
+
+        let staged = try FeedSyncService().stagePodcastSubscriptions(from: results, into: context)
+
+        let podcasts = try context.fetch(FetchDescriptor<Podcast>())
+        #expect(staged.map(\.title) == ["Starter One", "Starter Two", "Starter Three"])
+        #expect(podcasts.count == 3)
+        #expect(existing.isSubscribed)
+        #expect(existing.title == "Starter One")
+        #expect(existing.feedURL == results[0].feedURL)
+        #expect(podcasts.allSatisfy { $0.isSubscribed })
+        #expect(podcasts.allSatisfy { $0.syncStatus == "idle" })
+        #expect(podcasts.allSatisfy { $0.lastSyncAttemptAt != nil })
+    }
+
+    @Test
+    @MainActor
     func feedSyncOnboardingBootstrapCapsEpisodesAndSkipsExpensiveEnrichment() async throws {
         let container = try makeContainer()
         let context = container.mainContext
@@ -1777,6 +1831,41 @@ struct OffScriptTests {
         #expect(episodes.allSatisfy { $0.chapters.isEmpty })
         #expect(profiles.isEmpty)
         #expect(podcast.syncStatus == "idle")
+    }
+
+    @Test
+    func feedSyncSelectsLatestCappedItemsWithoutFullFeedSort() {
+        let baseDate = Date()
+        let items = [
+            ParsedFeedItem(
+                guid: "old",
+                title: "Old",
+                summary: nil,
+                pubDate: baseDate.addingTimeInterval(-5),
+                duration: nil,
+                audioURL: URL(string: "https://example.com/old.mp3")!
+            ),
+            ParsedFeedItem(
+                guid: "newest",
+                title: "Newest",
+                summary: nil,
+                pubDate: baseDate,
+                duration: nil,
+                audioURL: URL(string: "https://example.com/newest.mp3")!
+            ),
+            ParsedFeedItem(
+                guid: "middle",
+                title: "Middle",
+                summary: nil,
+                pubDate: baseDate.addingTimeInterval(-2),
+                duration: nil,
+                audioURL: URL(string: "https://example.com/middle.mp3")!
+            )
+        ]
+
+        let capped = FeedSyncService.itemsToProcess(from: items, limit: 2)
+
+        #expect(capped.map(\.guid) == ["newest", "middle"])
     }
 
     @Test


### PR DESCRIPTION
## Summary
- stage all selected onboarding starter podcasts in one SwiftData batch/save before entering the app
- keep background hydration behavior but avoid per-podcast staging saves
- select capped bootstrap episodes with a bounded top-N scan instead of sorting full back catalogs
- document the onboarding/import performance changes in the changelog

## Verification
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
  - passed 65 tests, 0 failures

@copilot review