### PR TITLE
Parallelize onboarding feed hydration

### DIFF
--- a/OffScript/ImportProgressView.swift
+++ b/OffScript/ImportProgressView.swift
@@ -206,27 +206,27 @@ struct ImportProgressView: View {
     private func syncStagedPodcastsInBackground(_ podcasts: [Podcast]) async {
         guard !podcasts.isEmpty else { return }
 
-        for podcast in podcasts {
-            do {
-                try await syncService.sync(
-                    podcast: podcast,
-                    in: modelContext,
-                    options: .onboardingBootstrap()
-                )
-                if let newestEpisode = podcast.episodes
+        let results = await syncService.sync(
+            podcasts: podcasts,
+            in: modelContext,
+            options: .onboardingBootstrap()
+        )
+        for result in results {
+            if result.isSuccess {
+                if let newestEpisode = result.podcast.episodes
                     .sorted(by: { $0.pubDate > $1.pubDate })
                     .first {
                     modelContext.insert(PreferenceSignal(action: .like, episode: newestEpisode))
                     modelContext.saveOrLog("OnboardingPreferenceSignal")
                 }
-            } catch {
-                let failureCount = podcast.syncFailureCount + 1
-                podcast.syncStatus = "failed"
-                podcast.syncFailureCount = failureCount
-                podcast.syncErrorMessage = error.localizedDescription
-                podcast.nextRetryAt = FeedSyncRetryPolicy.nextRetryDate(afterFailureCount: failureCount)
+            } else if let error = result.error {
+                let failureCount = result.podcast.syncFailureCount + 1
+                result.podcast.syncStatus = "failed"
+                result.podcast.syncFailureCount = failureCount
+                result.podcast.syncErrorMessage = error.localizedDescription
+                result.podcast.nextRetryAt = FeedSyncRetryPolicy.nextRetryDate(afterFailureCount: failureCount)
                 modelContext.saveOrLog("OnboardingBackgroundSync")
-                importLogger.error("Onboarding background sync failed for \(podcast.feedURL, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                importLogger.error("Onboarding background sync failed for \(result.podcast.feedURL, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/OffScript/Models.swift
+++ b/OffScript/Models.swift
@@ -449,7 +449,7 @@ final class TelemetryEvent {
     }
 }
 
-struct EpisodeChapter: Identifiable, Hashable, Codable {
+struct EpisodeChapter: Identifiable, Hashable, Codable, Sendable {
     let title: String
     let startTime: TimeInterval
 
@@ -463,7 +463,7 @@ struct EpisodeChapter: Identifiable, Hashable, Codable {
     }
 }
 
-struct EpisodeTranscriptReference: Identifiable, Hashable, Codable {
+struct EpisodeTranscriptReference: Identifiable, Hashable, Codable, Sendable {
     let url: URL
     let mimeType: String?
     let language: String?

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -267,7 +267,12 @@ final class FeedSyncService {
 
     private struct FeedSyncFetchOutcome: Sendable {
         let feedURL: URL
-        let result: Result<FeedFetchResult, Error>
+        let result: FeedSyncFetchResult
+    }
+
+    private enum FeedSyncFetchResult: Sendable {
+        case success(FeedFetchResult)
+        case failure(String)
     }
 
     @MainActor
@@ -460,11 +465,16 @@ final class FeedSyncService {
                 lastModified: $0.feedLastModified
             )
         }
-        try? context.save()
+        context.saveOrLog("FeedSyncService.batchSyncStarted")
 
         var syncResults: [PodcastSyncResult] = []
         await withTaskGroup(of: FeedSyncFetchOutcome.self) { group in
-            for request in requests {
+            let maxConcurrentFetches = 3
+            var iterator = requests.makeIterator()
+            var inFlight = 0
+
+            func addFetch(_ request: FeedSyncRequest) {
+                inFlight += 1
                 group.addTask {
                     do {
                         let fetched = try await Self.fetchParsedFeed(
@@ -474,12 +484,17 @@ final class FeedSyncService {
                         )
                         return FeedSyncFetchOutcome(feedURL: request.feedURL, result: .success(fetched))
                     } catch {
-                        return FeedSyncFetchOutcome(feedURL: request.feedURL, result: .failure(error))
+                        return FeedSyncFetchOutcome(feedURL: request.feedURL, result: .failure(error.localizedDescription))
                     }
                 }
             }
 
+            while inFlight < maxConcurrentFetches, let request = iterator.next() {
+                addFetch(request)
+            }
+
             while let outcome = await group.next() {
+                inFlight -= 1
                 guard let podcast = podcastByFeedURL[outcome.feedURL] else { continue }
                 switch outcome.result {
                 case .success(.notModified):
@@ -491,6 +506,10 @@ final class FeedSyncService {
                         try context.save()
                         syncResults.append(PodcastSyncResult(podcast: podcast, error: nil))
                     } catch {
+                        context.rollback()
+                        podcast.syncStatus = "failed"
+                        podcast.syncErrorMessage = error.localizedDescription
+                        context.saveOrLog("FeedSyncService.batchNotModifiedSaveFailure")
                         syncResults.append(PodcastSyncResult(podcast: podcast, error: error))
                     }
                 case let .success(.feed(parsed, httpResponse)):
@@ -500,14 +519,21 @@ final class FeedSyncService {
                     } catch {
                         podcast.syncStatus = "failed"
                         podcast.syncErrorMessage = error.localizedDescription
-                        try? context.save()
+                        context.saveOrLog("FeedSyncService.batchApplyFailure")
                         syncResults.append(PodcastSyncResult(podcast: podcast, error: error))
                     }
-                case let .failure(error):
+                case let .failure(errorMessage):
                     podcast.syncStatus = "failed"
-                    podcast.syncErrorMessage = error.localizedDescription
-                    try? context.save()
-                    syncResults.append(PodcastSyncResult(podcast: podcast, error: error))
+                    podcast.syncErrorMessage = errorMessage
+                    context.saveOrLog("FeedSyncService.batchFetchFailure")
+                    syncResults.append(PodcastSyncResult(
+                        podcast: podcast,
+                        error: PodcastImportError.feedFetchFailed(errorMessage)
+                    ))
+                }
+
+                if let nextRequest = iterator.next() {
+                    addFetch(nextRequest)
                 }
             }
         }
@@ -890,7 +916,7 @@ nonisolated private struct ItunesPodcast: Decodable {
     }
 }
 
-struct ParsedFeed {
+struct ParsedFeed: Sendable {
     var title: String?
     var author: String?
     var summary: String?
@@ -900,7 +926,7 @@ struct ParsedFeed {
     var items: [ParsedFeedItem] = []
 }
 
-struct ParsedFeedItem {
+struct ParsedFeedItem: Sendable {
     var guid: String?
     var title: String
     var summary: String?

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -250,6 +250,26 @@ enum FeedSyncRetryPolicy {
 final class FeedSyncService {
     private let topicExtractionService = TopicExtractionService()
 
+    struct PodcastSyncResult {
+        let podcast: Podcast
+        let error: Error?
+
+        var isSuccess: Bool {
+            error == nil
+        }
+    }
+
+    private struct FeedSyncRequest: Sendable {
+        let feedURL: URL
+        let eTag: String?
+        let lastModified: String?
+    }
+
+    private struct FeedSyncFetchOutcome: Sendable {
+        let feedURL: URL
+        let result: Result<FeedFetchResult, Error>
+    }
+
     @MainActor
     func importPodcast(from result: PodcastSearchResult, into context: ModelContext, episodeLimit: Int? = nil) async throws -> Podcast {
         let podcast = try upsertPodcast(from: result, into: context)
@@ -420,6 +440,79 @@ final class FeedSyncService {
             try? context.save()
             throw error
         }
+    }
+
+    @MainActor
+    func sync(podcasts: [Podcast], in context: ModelContext, options: FeedSyncOptions) async -> [PodcastSyncResult] {
+        guard !podcasts.isEmpty else { return [] }
+
+        let podcastByFeedURL = Dictionary(
+            podcasts.map { ($0.feedURL, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let requests = podcasts.map {
+            $0.syncStatus = "syncing"
+            $0.lastSyncAttemptAt = .now
+            $0.syncErrorMessage = nil
+            return FeedSyncRequest(
+                feedURL: $0.feedURL,
+                eTag: $0.feedETag,
+                lastModified: $0.feedLastModified
+            )
+        }
+        try? context.save()
+
+        var syncResults: [PodcastSyncResult] = []
+        await withTaskGroup(of: FeedSyncFetchOutcome.self) { group in
+            for request in requests {
+                group.addTask {
+                    do {
+                        let fetched = try await Self.fetchParsedFeed(
+                            feedURL: request.feedURL,
+                            eTag: request.eTag,
+                            lastModified: request.lastModified
+                        )
+                        return FeedSyncFetchOutcome(feedURL: request.feedURL, result: .success(fetched))
+                    } catch {
+                        return FeedSyncFetchOutcome(feedURL: request.feedURL, result: .failure(error))
+                    }
+                }
+            }
+
+            while let outcome = await group.next() {
+                guard let podcast = podcastByFeedURL[outcome.feedURL] else { continue }
+                switch outcome.result {
+                case .success(.notModified):
+                    podcast.lastSyncAt = Date()
+                    podcast.syncStatus = "idle"
+                    podcast.syncFailureCount = 0
+                    podcast.nextRetryAt = nil
+                    do {
+                        try context.save()
+                        syncResults.append(PodcastSyncResult(podcast: podcast, error: nil))
+                    } catch {
+                        syncResults.append(PodcastSyncResult(podcast: podcast, error: error))
+                    }
+                case let .success(.feed(parsed, httpResponse)):
+                    do {
+                        try await apply(parsed: parsed, httpResponse: httpResponse, to: podcast, in: context, options: options)
+                        syncResults.append(PodcastSyncResult(podcast: podcast, error: nil))
+                    } catch {
+                        podcast.syncStatus = "failed"
+                        podcast.syncErrorMessage = error.localizedDescription
+                        try? context.save()
+                        syncResults.append(PodcastSyncResult(podcast: podcast, error: error))
+                    }
+                case let .failure(error):
+                    podcast.syncStatus = "failed"
+                    podcast.syncErrorMessage = error.localizedDescription
+                    try? context.save()
+                    syncResults.append(PodcastSyncResult(podcast: podcast, error: error))
+                }
+            }
+        }
+
+        return syncResults
     }
 
     @MainActor
@@ -598,7 +691,7 @@ final class FeedSyncService {
         ))
     }
 
-    private enum FeedFetchResult {
+    private enum FeedFetchResult: Sendable {
         case notModified(HTTPURLResponse)
         case feed(ParsedFeed, HTTPURLResponse)
     }


### PR DESCRIPTION
## Summary
- fetch and parse staged onboarding feeds concurrently after the user enters the app
- keep SwiftData apply/save work serialized on the main/model actor
- preserve per-podcast failure handling and starter preference signal creation

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
  - passed 65 tests, 0 failures

@copilot review