### PR TITLE
Replace system playback menus with Tuner panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Compact Tuner keys now keep their visual size but expose 44pt hit targets** across Library, Player, Queue, Search, downloads, and episode detail actions.
 - **Discovery/search copy now names Apple Podcasts Search explicitly** and avoids implying the app is running a generic opaque algorithmic feed.
 - **Remaining app-controlled Liquid Glass controls were replaced with Tuner surfaces**: Settings toggles, Player scrubber, sign-out/unsubscribe confirmations, and sheet presentation chrome now use flat OLED panels, hairlines, and signal-yellow keys.
+- **Player speed, sleep timer, settings default-rate, and episode download controls no longer invoke system `Menu` chrome.** They now use direct Tuner keys or inline sharp option grids, keeping daily playback controls inside the OLED instrument-panel language.
 - **Long recommendation reason tags now wrap inside Tuner cards** instead of forcing fixed-width mono pills that could run off Home cards.
 - **Library import is now an explicit `IMPORT` Tuner key** with an icon-only fallback when width is constrained, so the OPML/paste entry point is visible without guessing the glyph.
 - **The bottom Tuner tab indicator now slides between Home, Library, Queue, and Search** with selection haptics instead of appearing abruptly in each cell.

--- a/OffScript/AppTheme.swift
+++ b/OffScript/AppTheme.swift
@@ -564,6 +564,44 @@ struct TunerLabel: View {
     }
 }
 
+struct TunerRatePicker: View {
+    let rates: [Float]
+    let selectedRate: Float
+    var accessibilityActionPrefix = "Set playback rate to"
+    let onSelect: (Float) -> Void
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 74), spacing: 8)], spacing: 8) {
+            ForEach(rates, id: \.self) { rate in
+                let isSelected = abs(selectedRate - rate) < 0.001
+                Button {
+                    onSelect(rate)
+                } label: {
+                    HStack(spacing: 6) {
+                        TunerLabel(
+                            text: String(format: "%.2g×", rate),
+                            color: isSelected ? .offscriptStudioBlack : .offscriptPaperWhite,
+                            size: 10
+                        )
+                        if isSelected {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(Color.offscriptStudioBlack)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 34)
+                    .background(isSelected ? Color.offscriptSignalYellow : Color.clear)
+                    .overlay(Rectangle().stroke(isSelected ? Color.offscriptSignalYellow : Color.offscriptHairline, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("\(accessibilityActionPrefix) \(String(format: "%.2g×", rate))")
+                .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+            }
+        }
+    }
+}
+
 /// Cassette/cartridge artwork tile — flat fill with a hairline border, corner
 // (TunerArtworkTile removed — placeholder cassette tile was never composed
 // into any view; OffScriptArtworkPlaceholder + OffScriptArtworkView fill

--- a/OffScript/DownloadButton.swift
+++ b/OffScript/DownloadButton.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DownloadButton: View {
     @ObservedObject private var downloadService = DownloadService.shared
+    @State private var isRemoveArmed = false
     let episode: Episode
 
     var body: some View {
@@ -25,16 +26,26 @@ struct DownloadButton: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(downloadAccessibilityLabel)
+        .accessibilityHint(downloadAccessibilityHint)
     }
 
     private func performPrimaryDownloadAction() {
         switch episode.downloadState {
         case .notDownloaded, .failed:
+            isRemoveArmed = false
             downloadService.startDownload(for: episode)
         case .downloading, .queued:
+            isRemoveArmed = false
             downloadService.cancelDownload(for: episode)
         case .downloaded:
-            downloadService.deleteDownload(for: episode)
+            if isRemoveArmed {
+                downloadService.deleteDownload(for: episode)
+                isRemoveArmed = false
+            } else {
+                withAnimation(.easeInOut(duration: 0.16)) {
+                    isRemoveArmed = true
+                }
+            }
         }
     }
 
@@ -45,6 +56,7 @@ struct DownloadButton: View {
         case .queued, .downloading:
             return .offscriptSignalYellow
         case .downloaded:
+            if isRemoveArmed { return .offscriptFnRecord }
             return .offscriptFnMode
         case .failed:
             return .offscriptFnRecord
@@ -60,6 +72,7 @@ struct DownloadButton: View {
         case .downloading:
             return "\(Int((episode.downloadProgress * 100).rounded()))%"
         case .downloaded:
+            if isRemoveArmed { return "Remove?" }
             return "Offline"
         case .failed:
             return "Retry"
@@ -75,6 +88,7 @@ struct DownloadButton: View {
         case .downloading:
             return "arrow.down.circle.fill"
         case .downloaded:
+            if isRemoveArmed { return "trash" }
             return "checkmark.circle.fill"
         case .failed:
             return "exclamationmark.arrow.trianglehead.2.clockwise"
@@ -93,6 +107,23 @@ struct DownloadButton: View {
             return "\(episode.title) is downloaded"
         case .failed:
             return "Retry download for \(episode.title)"
+        }
+    }
+
+    private var downloadAccessibilityHint: String {
+        switch episode.downloadState {
+        case .notDownloaded:
+            return "Double-tap to download this episode."
+        case .queued:
+            return "Double-tap to cancel the queued download."
+        case .downloading:
+            return "Double-tap to cancel the download."
+        case .downloaded:
+            return isRemoveArmed
+                ? "Double-tap again to remove the downloaded file."
+                : "Double-tap to arm removal of the downloaded file."
+        case .failed:
+            return "Double-tap to retry the download."
         }
     }
 }

--- a/OffScript/DownloadButton.swift
+++ b/OffScript/DownloadButton.swift
@@ -8,21 +8,8 @@ struct DownloadButton: View {
         // Tuner-direction download key — sharp hairline rectangle with mono
         // status text. Function-coded color (signal yellow for actionable
         // states, mode-green when downloaded, record-red on failure).
-        Menu {
-            switch episode.downloadState {
-            case .notDownloaded, .failed:
-                Button("Download") {
-                    downloadService.startDownload(for: episode)
-                }
-            case .downloading, .queued:
-                Button("Cancel Download", role: .destructive) {
-                    downloadService.cancelDownload(for: episode)
-                }
-            case .downloaded:
-                Button("Remove Download", role: .destructive) {
-                    downloadService.deleteDownload(for: episode)
-                }
-            }
+        Button {
+            performPrimaryDownloadAction()
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: downloadIcon)
@@ -38,6 +25,17 @@ struct DownloadButton: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(downloadAccessibilityLabel)
+    }
+
+    private func performPrimaryDownloadAction() {
+        switch episode.downloadState {
+        case .notDownloaded, .failed:
+            downloadService.startDownload(for: episode)
+        case .downloading, .queued:
+            downloadService.cancelDownload(for: episode)
+        case .downloaded:
+            downloadService.deleteDownload(for: episode)
+        }
     }
 
     private var downloadColor: Color {

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -23,6 +23,8 @@ struct PlayerView: View {
     @Environment(\.modelContext) private var modelContext
     @ObservedObject private var player = PlaybackController.shared
     @Query private var queueItems: [QueueItem]
+    @State private var isSpeedPickerExpanded = false
+    @State private var isSleepPickerExpanded = false
 
     private var orderedQueueItems: [QueueItem] {
         queueItems.sorted { lhs, rhs in
@@ -392,89 +394,76 @@ struct PlayerView: View {
         VStack(alignment: .leading, spacing: 8) {
             TunerLabel(text: "CONTROLS · TRANSPORT", color: .offscriptSignalYellow)
 
-            HStack(spacing: 8) {
-                Menu {
-                    Section("Speed for \(episode.podcast.title)") {
-                        ForEach([("1.0×", Float(1.0)),
-                                 ("1.1×", Float(1.1)),
-                                 ("1.25×", Float(1.25)),
-                                 ("1.5×", Float(1.5)),
-                                 ("1.75×", Float(1.75)),
-                                 ("2.0×", Float(2.0)),
-                                 ("2.5×", Float(2.5))], id: \.0) { label, rate in
-                            Button {
-                                player.setPlaybackRate(rate)
-                            } label: {
-                                HStack {
-                                    Text(label)
-                                    if abs(player.playbackRate - rate) < 0.001 {
-                                        Image(systemName: "checkmark")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } label: {
-                    tunerControlLabel(text: "SPEED  \(String(format: "%.2g", player.playbackRate))×",
-                                      color: hasCustomRate(for: episode) ? .offscriptSignalYellow : .offscriptPaperWhite)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Playback speed")
-                .accessibilityHint("Pick a speed for this podcast")
-
-                if !episode.isQueued {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
                     Button {
-                        do { try QueueService.add(episode, in: modelContext) }
-                        catch { playerLogger.error("Queue add failed: \(error.localizedDescription, privacy: .public)") }
+                        withAnimation(.easeInOut(duration: 0.16)) {
+                            isSpeedPickerExpanded.toggle()
+                            if isSpeedPickerExpanded { isSleepPickerExpanded = false }
+                        }
                     } label: {
-                        tunerControlLabel(text: "+ QUEUE NEXT", color: .offscriptPaperWhite)
+                        tunerControlLabel(text: "SPEED  \(String(format: "%.2g", player.playbackRate))×",
+                                          color: hasCustomRate(for: episode) ? .offscriptSignalYellow : .offscriptPaperWhite)
                     }
                     .buttonStyle(.plain)
-                }
+                    .accessibilityLabel("Playback speed")
+                    .accessibilityHint("Pick a speed for this podcast")
 
-                Button {
-                    episode.isPlayed = true
-                    episode.playedPosition = player.duration
-                    do { try modelContext.save() }
-                    catch { playerLogger.error("Mark-played save failed: \(error.localizedDescription, privacy: .public)") }
-                } label: {
-                    tunerControlLabel(text: "✓ MARK PLAYED", color: .offscriptSignalYellow)
-                }
-                .buttonStyle(.plain)
-
-                // Sleep timer — Menu with the standard podcast app intervals.
-                // Active timer shows live countdown in mm:ss as the SLEEP key
-                // label; tapping reveals the menu so the user can extend or
-                // cancel without leaving the player.
-                Menu {
-                    if player.sleepTimerEndDate != nil {
-                        Button(role: .destructive) {
-                            player.cancelSleepTimer()
-                        } label: {
-                            Label("Cancel Timer", systemImage: "xmark")
-                        }
-                        Divider()
-                    }
-                    ForEach([5, 15, 30, 45, 60], id: \.self) { minutes in
+                    if !episode.isQueued {
                         Button {
-                            player.setSleepTimer(minutes: minutes)
+                            do { try QueueService.add(episode, in: modelContext) }
+                            catch { playerLogger.error("Queue add failed: \(error.localizedDescription, privacy: .public)") }
                         } label: {
-                            Text("\(minutes) min")
+                            tunerControlLabel(text: "+ QUEUE NEXT", color: .offscriptPaperWhite)
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    Button {
+                        episode.isPlayed = true
+                        episode.playedPosition = player.duration
+                        do { try modelContext.save() }
+                        catch { playerLogger.error("Mark-played save failed: \(error.localizedDescription, privacy: .public)") }
+                    } label: {
+                        tunerControlLabel(text: "✓ MARK PLAYED", color: .offscriptSignalYellow)
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.16)) {
+                            isSleepPickerExpanded.toggle()
+                            if isSleepPickerExpanded { isSpeedPickerExpanded = false }
+                        }
+                    } label: {
+                        tunerControlLabel(text: sleepTimerLabel,
+                                          color: player.sleepTimerEndDate != nil
+                                            ? .offscriptSignalYellow
+                                            : .offscriptPaperWhite)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Sleep timer")
+                    .accessibilityHint(player.sleepTimerEndDate != nil
+                        ? "Active. Pick a new duration or cancel."
+                        : "Pick a duration to pause playback.")
+
+                    Spacer()
+                }
+
+                if isSpeedPickerExpanded {
+                    tunerRatePicker(
+                        rates: [Float(1.0), 1.1, 1.25, 1.5, 1.75, 2.0, 2.5],
+                        selectedRate: player.playbackRate
+                    ) { rate in
+                        player.setPlaybackRate(rate)
+                        withAnimation(.easeInOut(duration: 0.16)) {
+                            isSpeedPickerExpanded = false
                         }
                     }
-                } label: {
-                    tunerControlLabel(text: sleepTimerLabel,
-                                      color: player.sleepTimerEndDate != nil
-                                        ? .offscriptSignalYellow
-                                        : .offscriptPaperWhite)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Sleep timer")
-                .accessibilityHint(player.sleepTimerEndDate != nil
-                    ? "Active. Pick a new duration or cancel."
-                    : "Pick a duration to pause playback.")
 
-                Spacer()
+                if isSleepPickerExpanded {
+                    tunerSleepPicker
+                }
             }
         }
         .padding(.vertical, 12)
@@ -493,6 +482,70 @@ struct PlayerView: View {
             .overlay(Rectangle().stroke(color.opacity(0.7), lineWidth: 1))
             .frame(minHeight: 44)
             .contentShape(Rectangle())
+    }
+
+    private func tunerRatePicker(
+        rates: [Float],
+        selectedRate: Float,
+        onSelect: @escaping (Float) -> Void
+    ) -> some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 74), spacing: 8)], spacing: 8) {
+            ForEach(rates, id: \.self) { rate in
+                let isSelected = abs(selectedRate - rate) < 0.001
+                Button {
+                    onSelect(rate)
+                } label: {
+                    HStack(spacing: 6) {
+                        TunerLabel(
+                            text: String(format: "%.2g×", rate),
+                            color: isSelected ? .offscriptStudioBlack : .offscriptPaperWhite,
+                            size: 10
+                        )
+                        if isSelected {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(Color.offscriptStudioBlack)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 34)
+                    .background(isSelected ? Color.offscriptSignalYellow : Color.clear)
+                    .overlay(Rectangle().stroke(isSelected ? Color.offscriptSignalYellow : Color.offscriptHairline, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var tunerSleepPicker: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 88), spacing: 8)], spacing: 8) {
+            if player.sleepTimerEndDate != nil {
+                Button {
+                    player.cancelSleepTimer()
+                    withAnimation(.easeInOut(duration: 0.16)) {
+                        isSleepPickerExpanded = false
+                    }
+                } label: {
+                    TunerLabel(text: "× CANCEL", color: .offscriptFnRecord, size: 10)
+                        .frame(maxWidth: .infinity, minHeight: 34)
+                        .overlay(Rectangle().stroke(Color.offscriptFnRecord.opacity(0.7), lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+            }
+
+            ForEach([5, 15, 30, 45, 60], id: \.self) { minutes in
+                Button {
+                    player.setSleepTimer(minutes: minutes)
+                    withAnimation(.easeInOut(duration: 0.16)) {
+                        isSleepPickerExpanded = false
+                    }
+                } label: {
+                    TunerLabel(text: "\(minutes) MIN", color: .offscriptPaperWhite, size: 10)
+                        .frame(maxWidth: .infinity, minHeight: 34)
+                        .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+            }
+        }
     }
 
     // MARK: empty

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -450,9 +450,10 @@ struct PlayerView: View {
                 }
 
                 if isSpeedPickerExpanded {
-                    tunerRatePicker(
+                    TunerRatePicker(
                         rates: [Float(1.0), 1.1, 1.25, 1.5, 1.75, 2.0, 2.5],
-                        selectedRate: player.playbackRate
+                        selectedRate: player.playbackRate,
+                        accessibilityActionPrefix: "Set playback speed to"
                     ) { rate in
                         player.setPlaybackRate(rate)
                         withAnimation(.easeInOut(duration: 0.16)) {
@@ -482,38 +483,6 @@ struct PlayerView: View {
             .overlay(Rectangle().stroke(color.opacity(0.7), lineWidth: 1))
             .frame(minHeight: 44)
             .contentShape(Rectangle())
-    }
-
-    private func tunerRatePicker(
-        rates: [Float],
-        selectedRate: Float,
-        onSelect: @escaping (Float) -> Void
-    ) -> some View {
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 74), spacing: 8)], spacing: 8) {
-            ForEach(rates, id: \.self) { rate in
-                let isSelected = abs(selectedRate - rate) < 0.001
-                Button {
-                    onSelect(rate)
-                } label: {
-                    HStack(spacing: 6) {
-                        TunerLabel(
-                            text: String(format: "%.2g×", rate),
-                            color: isSelected ? .offscriptStudioBlack : .offscriptPaperWhite,
-                            size: 10
-                        )
-                        if isSelected {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 9, weight: .bold))
-                                .foregroundStyle(Color.offscriptStudioBlack)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 34)
-                    .background(isSelected ? Color.offscriptSignalYellow : Color.clear)
-                    .overlay(Rectangle().stroke(isSelected ? Color.offscriptSignalYellow : Color.offscriptHairline, lineWidth: 1))
-                }
-                .buttonStyle(.plain)
-            }
-        }
     }
 
     private var tunerSleepPicker: some View {

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -220,14 +220,19 @@ struct SettingsView: View {
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                 }
                 .buttonStyle(.plain)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Default playback rate")
+                .accessibilityValue(String(format: "%.2g×", currentDefaultRate))
+                .accessibilityHint(isDefaultRatePickerExpanded ? "Double-tap to collapse rate options." : "Double-tap to expand rate options.")
             }
             .padding(.top, 10)
             .padding(.bottom, isDefaultRatePickerExpanded ? 8 : 10)
 
             if isDefaultRatePickerExpanded {
-                tunerRatePicker(
+                TunerRatePicker(
                     rates: [Float(1.0), 1.1, 1.25, 1.5, 1.75, 2.0, 2.5],
-                    selectedRate: currentDefaultRate
+                    selectedRate: currentDefaultRate,
+                    accessibilityActionPrefix: "Set default playback rate to"
                 ) { rate in
                     PodcastPlaybackPreferences.setGlobalDefault(rate)
                     defaultRateRefresh = UUID()  // force re-read of static
@@ -321,42 +326,6 @@ struct SettingsView: View {
         .accessibilityValue(isOn.wrappedValue ? "On" : "Off")
         .accessibilityAddTraits(isOn.wrappedValue ? [.isButton, .isSelected] : .isButton)
         .padding(.vertical, 10)
-    }
-
-    private func tunerRatePicker(
-        rates: [Float],
-        selectedRate: Float,
-        onSelect: @escaping (Float) -> Void
-    ) -> some View {
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 74), spacing: 8)], spacing: 8) {
-            ForEach(rates, id: \.self) { rate in
-                let isSelected = abs(selectedRate - rate) < 0.001
-                Button {
-                    onSelect(rate)
-                } label: {
-                    HStack(spacing: 6) {
-                        TunerLabel(
-                            text: String(format: "%.2g×", rate),
-                            color: isSelected ? .offscriptStudioBlack : .offscriptPaperWhite,
-                            size: 10
-                        )
-                        if isSelected {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 9, weight: .bold))
-                                .foregroundStyle(Color.offscriptStudioBlack)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 34)
-                    .background(isSelected ? Color.offscriptSignalYellow : Color.clear)
-                    .overlay(
-                        Rectangle()
-                            .stroke(isSelected ? Color.offscriptSignalYellow : Color.offscriptHairline, lineWidth: 1)
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Set default playback rate to \(String(format: "%.2g×", rate))")
-            }
-        }
     }
 
     // MARK: signal profile

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
     @State private var cloudKitAvailability: CloudKitAccountAvailability = .couldNotDetermine
     @State private var showSignOutConfirmation = false
     @State private var signInMessage: String?
+    @State private var isDefaultRatePickerExpanded = false
 
     @State private var episodeCount: Int = 0
     @State private var unplayedCount: Int = 0
@@ -186,45 +187,57 @@ struct SettingsView: View {
     /// from the player win over this. Stored in
     /// `PodcastPlaybackPreferences.globalDefault`.
     private var defaultRateRow: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Default playback rate")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(Color.offscriptPaperWhite)
-                Text("New podcasts inherit this rate. Per-podcast picks from the player override it.")
-                    .font(.system(size: 12.5))
-                    .foregroundStyle(Color.offscriptPaperWhite.opacity(0.75))
-                    .fixedSize(horizontal: false, vertical: true)
-                    .lineSpacing(2)
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Default playback rate")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.offscriptPaperWhite)
+                    Text("New podcasts inherit this rate. Per-podcast picks from the player override it.")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(Color.offscriptPaperWhite.opacity(0.75))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .lineSpacing(2)
+                }
+                Spacer(minLength: 12)
+                Button {
+                    withAnimation(.easeInOut(duration: 0.16)) {
+                        isDefaultRatePickerExpanded.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        TunerLabel(
+                            text: String(format: "%.2g×", currentDefaultRate),
+                            color: .offscriptSignalYellow,
+                            size: 11
+                        )
+                        Image(systemName: isDefaultRatePickerExpanded ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(Color.offscriptSignalYellow)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
             }
-            Spacer(minLength: 12)
-            Menu {
-                ForEach([Float(1.0), 1.1, 1.25, 1.5, 1.75, 2.0, 2.5], id: \.self) { rate in
-                    Button {
-                        PodcastPlaybackPreferences.setGlobalDefault(rate)
-                        defaultRateRefresh = UUID()  // force re-read of static
-                    } label: {
-                        HStack {
-                            Text(String(format: "%.2g×", rate))
-                            if abs(currentDefaultRate - rate) < 0.001 {
-                                Image(systemName: "checkmark")
-                            }
-                        }
+            .padding(.top, 10)
+            .padding(.bottom, isDefaultRatePickerExpanded ? 8 : 10)
+
+            if isDefaultRatePickerExpanded {
+                tunerRatePicker(
+                    rates: [Float(1.0), 1.1, 1.25, 1.5, 1.75, 2.0, 2.5],
+                    selectedRate: currentDefaultRate
+                ) { rate in
+                    PodcastPlaybackPreferences.setGlobalDefault(rate)
+                    defaultRateRefresh = UUID()  // force re-read of static
+                    withAnimation(.easeInOut(duration: 0.16)) {
+                        isDefaultRatePickerExpanded = false
                     }
                 }
-            } label: {
-                TunerLabel(
-                    text: String(format: "%.2g×", currentDefaultRate),
-                    color: .offscriptSignalYellow,
-                    size: 11
-                )
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                .padding(.bottom, 10)
             }
-            .buttonStyle(.plain)
         }
-        .padding(.vertical, 10)
     }
 
     /// Wipe every per-podcast playback-rate override so all shows
@@ -308,6 +321,42 @@ struct SettingsView: View {
         .accessibilityValue(isOn.wrappedValue ? "On" : "Off")
         .accessibilityAddTraits(isOn.wrappedValue ? [.isButton, .isSelected] : .isButton)
         .padding(.vertical, 10)
+    }
+
+    private func tunerRatePicker(
+        rates: [Float],
+        selectedRate: Float,
+        onSelect: @escaping (Float) -> Void
+    ) -> some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 74), spacing: 8)], spacing: 8) {
+            ForEach(rates, id: \.self) { rate in
+                let isSelected = abs(selectedRate - rate) < 0.001
+                Button {
+                    onSelect(rate)
+                } label: {
+                    HStack(spacing: 6) {
+                        TunerLabel(
+                            text: String(format: "%.2g×", rate),
+                            color: isSelected ? .offscriptStudioBlack : .offscriptPaperWhite,
+                            size: 10
+                        )
+                        if isSelected {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(Color.offscriptStudioBlack)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 34)
+                    .background(isSelected ? Color.offscriptSignalYellow : Color.clear)
+                    .overlay(
+                        Rectangle()
+                            .stroke(isSelected ? Color.offscriptSignalYellow : Color.offscriptHairline, lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Set default playback rate to \(String(format: "%.2g×", rate))")
+            }
+        }
     }
 
     // MARK: signal profile


### PR DESCRIPTION
## Summary
- Replace the episode download Menu with a direct Tuner-styled primary action
- Replace player speed and sleep timer Menus with inline Tuner option grids
- Replace the settings default playback rate Menu with an inline Tuner rate picker

## Verification
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- Xcode MCP BuildProject on windowtab1

## Notes
- PR #38 remains separate and untouched until its CloudKit signing preflight passes.
