### PR TITLE
Replace remaining action menus with Tuner controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Discovery/search copy now names Apple Podcasts Search explicitly** and avoids implying the app is running a generic opaque algorithmic feed.
 - **Remaining app-controlled Liquid Glass controls were replaced with Tuner surfaces**: Settings toggles, Player scrubber, sign-out/unsubscribe confirmations, and sheet presentation chrome now use flat OLED panels, hairlines, and signal-yellow keys.
 - **Player speed, sleep timer, settings default-rate, and episode download controls no longer invoke system `Menu` chrome.** They now use direct Tuner keys or inline sharp option grids, keeping daily playback controls inside the OLED instrument-panel language.
+- **Home feedback, compact episode-card actions, and Queue reorder controls now use inline Tuner keys** instead of default `Menu`/long-press context surfaces, removing the remaining system action chrome from core playback and queue flows.
 - **Long recommendation reason tags now wrap inside Tuner cards** instead of forcing fixed-width mono pills that could run off Home cards.
 - **Library import is now an explicit `IMPORT` Tuner key** with an icon-only fallback when width is constrained, so the OPML/paste entry point is visible without guessing the glyph.
 - **The bottom Tuner tab indicator now slides between Home, Library, Queue, and Search** with selection haptics instead of appearing abruptly in each cell.

--- a/OffScript/CardComponents.swift
+++ b/OffScript/CardComponents.swift
@@ -179,17 +179,19 @@ struct EpisodeCompactCard: View {
     var showPodcastTitle: Bool = true
 
     @State private var navigateToDetail = false
+    @State private var showsActions = false
 
     var body: some View {
-        HStack(spacing: 12) {
-            if let rank {
-                Text(String(format: "%02d", rank))
-                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                    .tracking(0.6)
-                    .foregroundStyle(Color.offscriptSignalYellow)
-                    .monospacedDigit()
-                    .frame(width: 28, alignment: .leading)
-            }
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                if let rank {
+                    Text(String(format: "%02d", rank))
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .tracking(0.6)
+                        .foregroundStyle(Color.offscriptSignalYellow)
+                        .monospacedDigit()
+                        .frame(width: 28, alignment: .leading)
+                }
 
             Button {
                 if let onTap {
@@ -256,17 +258,9 @@ struct EpisodeCompactCard: View {
             .buttonStyle(.plain)
             .accessibilityLabel(isCurrentlyPlaying ? "Pause" : "Play \(episode.title)")
 
-            Menu {
-                Button(episode.isQueued ? "Already Queued" : "Add to Queue") {
-                    do { try QueueService.add(episode, in: modelContext) }
-                    catch { cardLogger.error("Queue add failed: \(error.localizedDescription, privacy: .public)") }
-                }
-                .disabled(episode.isQueued)
-
-                Divider()
-
-                Button(episode.isPlayed ? "Mark Unplayed" : "Mark Played") {
-                    togglePlayedState()
+            Button {
+                withAnimation(.easeInOut(duration: 0.16)) {
+                    showsActions.toggle()
                 }
             } label: {
                 Image(systemName: "ellipsis")
@@ -279,6 +273,7 @@ struct EpisodeCompactCard: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("More actions for \(episode.title)")
+            .accessibilityHint(showsActions ? "Double-tap to hide actions." : "Double-tap to show queue and played actions.")
 
             if let onRemove {
                 Button {
@@ -294,6 +289,31 @@ struct EpisodeCompactCard: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Remove \(episode.title)")
+            }
+            }
+
+            if showsActions {
+                HStack(spacing: 8) {
+                    tunerInlineAction(
+                        title: episode.isQueued ? "✓ QUEUED" : "+ QUEUE",
+                        color: episode.isQueued ? .offscriptSoftPaper : .offscriptPaperWhite,
+                        disabled: episode.isQueued
+                    ) {
+                        do { try QueueService.add(episode, in: modelContext) }
+                        catch { cardLogger.error("Queue add failed: \(error.localizedDescription, privacy: .public)") }
+                        withAnimation(.easeInOut(duration: 0.16)) { showsActions = false }
+                    }
+
+                    tunerInlineAction(
+                        title: episode.isPlayed ? "○ UNPLAYED" : "✓ PLAYED",
+                        color: .offscriptSignalYellow
+                    ) {
+                        togglePlayedState()
+                        withAnimation(.easeInOut(duration: 0.16)) { showsActions = false }
+                    }
+                }
+                .padding(.leading, rank == nil ? 64 : 92)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .padding(.horizontal, 12)
@@ -324,6 +344,23 @@ struct EpisodeCompactCard: View {
 
     private var playIcon: String {
         isCurrentlyPlaying ? "pause.fill" : "play.fill"
+    }
+
+    private func tunerInlineAction(
+        title: String,
+        color: Color,
+        disabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            TunerLabel(text: title, color: color.opacity(disabled ? 0.55 : 1), size: 9)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .frame(minHeight: 34)
+                .overlay(Rectangle().stroke(color.opacity(disabled ? 0.35 : 0.7), lineWidth: 1))
+        }
+        .disabled(disabled)
+        .buttonStyle(.plain)
     }
 
     private func togglePlayedState() {

--- a/OffScript/CardComponents.swift
+++ b/OffScript/CardComponents.swift
@@ -294,6 +294,11 @@ struct EpisodeCompactCard: View {
 
             if showsActions {
                 HStack(spacing: 8) {
+                    if rank != nil {
+                        Color.clear.frame(width: 28)
+                    }
+                    Color.clear.frame(width: 52)
+
                     tunerInlineAction(
                         title: episode.isQueued ? "✓ QUEUED" : "+ QUEUE",
                         color: episode.isQueued ? .offscriptSoftPaper : .offscriptPaperWhite,
@@ -311,8 +316,8 @@ struct EpisodeCompactCard: View {
                         togglePlayedState()
                         withAnimation(.easeInOut(duration: 0.16)) { showsActions = false }
                     }
+                    Spacer(minLength: 0)
                 }
-                .padding(.leading, rank == nil ? 64 : 92)
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
@@ -356,8 +361,9 @@ struct EpisodeCompactCard: View {
             TunerLabel(text: title, color: color.opacity(disabled ? 0.55 : 1), size: 9)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 7)
-                .frame(minHeight: 34)
+                .frame(minHeight: 44)
                 .overlay(Rectangle().stroke(color.opacity(disabled ? 0.35 : 0.7), lineWidth: 1))
+                .contentShape(Rectangle())
         }
         .disabled(disabled)
         .buttonStyle(.plain)

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -762,6 +762,9 @@ private struct HeroTunerCard: View {
         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("\(episode.title) from \(episode.podcast.title). \(displayReason)")
+        .onChange(of: episode.id) { _, _ in
+            showsFeedbackActions = false
+        }
         .onDisappear { feedbackClearTask?.cancel() }
     }
 
@@ -828,8 +831,9 @@ private struct HeroTunerCard: View {
             TunerLabel(text: title, color: color, size: 9)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 7)
-                .frame(minHeight: 34)
+                .frame(minHeight: 44)
                 .overlay(Rectangle().stroke(color.opacity(0.65), lineWidth: 1))
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -626,6 +626,7 @@ private struct HeroTunerCard: View {
     let signals: [RecommendationSignal]
     @State private var feedbackStatusMessage: String?
     @State private var feedbackClearTask: Task<Void, Never>?
+    @State private var showsFeedbackActions = false
 
     private var progressValue: Double {
         guard let duration = episode.duration, duration > 0 else { return 0 }
@@ -730,11 +731,10 @@ private struct HeroTunerCard: View {
 
                     Spacer()
 
-                    Menu {
-                        Button("Like") { register(.like) }
-                        Button("More like this") { register(.moreLikeThis) }
-                        Button("Less like this") { register(.lessLikeThis) }
-                        Button(role: .destructive) { register(.notInterested) } label: { Text("Not interested") }
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.16)) {
+                            showsFeedbackActions.toggle()
+                        }
                     } label: {
                         Image(systemName: "ellipsis")
                             .font(.system(size: 12, weight: .bold))
@@ -743,8 +743,19 @@ private struct HeroTunerCard: View {
                             .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                     }
                     .accessibilityLabel("More actions")
+                    .accessibilityHint(showsFeedbackActions ? "Double-tap to hide feedback actions." : "Double-tap to show feedback actions.")
                 }
                 .padding(.top, 4)
+
+                if showsFeedbackActions {
+                    HStack(spacing: 8) {
+                        preferenceKey("LIKE", color: .offscriptSignalYellow) { registerAndCollapse(.like) }
+                        preferenceKey("MORE", color: .offscriptFnInfo) { registerAndCollapse(.moreLikeThis) }
+                        preferenceKey("LESS", color: .offscriptSoftPaper) { registerAndCollapse(.lessLikeThis) }
+                        preferenceKey("HIDE", color: .offscriptFnRecord) { registerAndCollapse(.notInterested) }
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
             }
             .padding(14)
         }
@@ -803,6 +814,24 @@ private struct HeroTunerCard: View {
             }
             scheduleFeedbackStatusClear(delay: 3_000_000_000)
         }
+    }
+
+    private func registerAndCollapse(_ action: PreferenceSignal.Action) {
+        register(action)
+        withAnimation(.easeInOut(duration: 0.16)) {
+            showsFeedbackActions = false
+        }
+    }
+
+    private func preferenceKey(_ title: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            TunerLabel(text: title, color: color, size: 9)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .frame(minHeight: 34)
+                .overlay(Rectangle().stroke(color.opacity(0.65), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
     }
 
     private func statusMessage(for action: PreferenceSignal.Action) -> String {

--- a/OffScript/QueueView.swift
+++ b/OffScript/QueueView.swift
@@ -350,7 +350,7 @@ private struct QueueItemRow: View {
                 .foregroundStyle(color.opacity(disabled ? 0.35 : 1))
                 .frame(width: 24, height: 28)
                 .overlay(Rectangle().stroke(Color.offscriptHairline.opacity(disabled ? 0.35 : 1), lineWidth: 1))
-                .frame(width: 36, height: 44)
+                .frame(width: 44, height: 44)
                 .contentShape(Rectangle())
         }
         .disabled(disabled)

--- a/OffScript/QueueView.swift
+++ b/OffScript/QueueView.swift
@@ -113,6 +113,20 @@ struct QueueView: View {
                     QueueItemRow(
                         item: item,
                         rank: index + 1,
+                        canMoveUp: index > 0,
+                        canMoveDown: index < orderedItems.count - 1,
+                        onMoveUp: {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                do { try QueueService.move(from: IndexSet(integer: index), to: index - 1, in: modelContext) }
+                                catch { queueLogger.error("Failed to move queue item: \(error.localizedDescription, privacy: .public)") }
+                            }
+                        },
+                        onMoveDown: {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                do { try QueueService.move(from: IndexSet(integer: index), to: index + 2, in: modelContext) }
+                                catch { queueLogger.error("Failed to move queue item: \(error.localizedDescription, privacy: .public)") }
+                            }
+                        },
                         onRemove: {
                             withAnimation(.easeInOut(duration: 0.2)) {
                                 do { try QueueService.remove(item, in: modelContext) }
@@ -120,36 +134,6 @@ struct QueueView: View {
                             }
                         }
                     )
-                    .contextMenu {
-                        if index > 0 {
-                            Button {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    do { try QueueService.move(from: IndexSet(integer: index), to: index - 1, in: modelContext) }
-                                    catch { queueLogger.error("Failed to move queue item: \(error.localizedDescription, privacy: .public)") }
-                                }
-                            } label: {
-                                Label("Move Up", systemImage: "arrow.up")
-                            }
-                        }
-                        if index < orderedItems.count - 1 {
-                            Button {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    do { try QueueService.move(from: IndexSet(integer: index), to: index + 2, in: modelContext) }
-                                    catch { queueLogger.error("Failed to move queue item: \(error.localizedDescription, privacy: .public)") }
-                                }
-                            } label: {
-                                Label("Move Down", systemImage: "arrow.down")
-                            }
-                        }
-                        Button(role: .destructive) {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                do { try QueueService.remove(item, in: modelContext) }
-                                catch { queueLogger.error("Failed to remove queue item: \(error.localizedDescription, privacy: .public)") }
-                            }
-                        } label: {
-                            Label("Remove", systemImage: "trash")
-                        }
-                    }
                     if index < orderedItems.count - 1 {
                         Rectangle().fill(Color.offscriptHairline).frame(height: 1)
                     }
@@ -281,6 +265,10 @@ private struct QueueItemRow: View {
 
     let item: QueueItem
     let rank: Int
+    var canMoveUp = false
+    var canMoveDown = false
+    var onMoveUp: (() -> Void)? = nil
+    var onMoveDown: (() -> Void)? = nil
     var onRemove: (() -> Void)? = nil
 
     var body: some View {
@@ -326,6 +314,11 @@ private struct QueueItemRow: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Play \(item.episode.title)")
 
+            queueIconButton(systemName: "chevron.up", color: .offscriptSoftPaper, disabled: !canMoveUp, action: onMoveUp)
+                .accessibilityLabel("Move up")
+            queueIconButton(systemName: "chevron.down", color: .offscriptSoftPaper, disabled: !canMoveDown, action: onMoveDown)
+                .accessibilityLabel("Move down")
+
             if let onRemove {
                 Button(action: onRemove) {
                     Image(systemName: "xmark")
@@ -341,5 +334,26 @@ private struct QueueItemRow: View {
             }
         }
         .padding(.vertical, 10)
+    }
+
+    private func queueIconButton(
+        systemName: String,
+        color: Color,
+        disabled: Bool,
+        action: (() -> Void)?
+    ) -> some View {
+        Button {
+            action?()
+        } label: {
+            Image(systemName: systemName)
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(color.opacity(disabled ? 0.35 : 1))
+                .frame(width: 24, height: 28)
+                .overlay(Rectangle().stroke(Color.offscriptHairline.opacity(disabled ? 0.35 : 1), lineWidth: 1))
+                .frame(width: 36, height: 44)
+                .contentShape(Rectangle())
+        }
+        .disabled(disabled)
+        .buttonStyle(.plain)
     }
 }


### PR DESCRIPTION
## Summary
- Replace compact episode-card action Menus with inline Tuner action keys
- Replace Home headline feedback Menu with inline feedback keys
- Replace Queue row contextMenu controls with visible Tuner reorder/remove controls
- Update changelog and confirm no Menu/contextMenu call sites remain

## Verification
- rg -n "Menu \\{|contextMenu" OffScript
- git diff --check
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests

## Notes
- PR #38 remains separate and untouched until its signing-preflight passes.
