### PR TITLE
Make Library alphabet rail target every key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Remaining app-controlled Liquid Glass controls were replaced with Tuner surfaces**: Settings toggles, Player scrubber, sign-out/unsubscribe confirmations, and sheet presentation chrome now use flat OLED panels, hairlines, and signal-yellow keys.
 - **Player speed, sleep timer, settings default-rate, and episode download controls no longer invoke system `Menu` chrome.** They now use direct Tuner keys or inline sharp option grids, keeping daily playback controls inside the OLED instrument-panel language.
 - **Home feedback, compact episode-card actions, and Queue reorder controls now use inline Tuner keys** instead of default `Menu`/long-press context surfaces, removing the remaining system action chrome from core playback and queue flows.
+- **The Library `#-Z` carousel now targets the nearest available section for every key**, so sparse or filtered directories still respond when a letter does not currently have an exact section.
 - **Long recommendation reason tags now wrap inside Tuner cards** instead of forcing fixed-width mono pills that could run off Home cards.
 - **Library import is now an explicit `IMPORT` Tuner key** with an icon-only fallback when width is constrained, so the OPML/paste entry point is visible without guessing the glyph.
 - **The bottom Tuner tab indicator now slides between Home, Library, Queue, and Search** with selection haptics instead of appearing abruptly in each cell.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -197,6 +197,22 @@ nonisolated enum LibraryDirectoryOrganizer {
         sections(for: podcasts, numbersByPodcastID: [:], unplayedCounts: [:], inProgressCounts: [:])
     }
 
+    static func sectionIDForAlphabetKey(_ key: String, sections: [LibraryDirectorySection]) -> String? {
+        guard !sections.isEmpty else { return nil }
+        if let exact = sections.first(where: { $0.title == key }) {
+            return exact.id
+        }
+
+        let sortedSections = sections.sorted { sectionSort($0.title, $1.title) }
+        if key == "#" {
+            return sortedSections.first?.id
+        }
+        if let next = sortedSections.first(where: { sectionSort(key, $0.title) }) {
+            return next.id
+        }
+        return sortedSections.last?.id
+    }
+
     static func sections(
         for podcasts: [Podcast],
         numbersByPodcastID: [UUID: Int],
@@ -1037,18 +1053,19 @@ private struct LibraryAlphabetRail: View {
                 HStack(spacing: 4) {
                     ForEach(keys, id: \.self) { key in
                         let section = sectionsByTitle[key]
+                        let targetSectionID = LibraryDirectoryOrganizer.sectionIDForAlphabetKey(key, sections: sections)
                         let isSelected = selectedSectionID == section?.id
 
-                        if let section {
+                        if let targetSectionID {
                             Button {
-                                onSelect(section.id)
+                                onSelect(targetSectionID)
                             } label: {
-                                letterKey(key, isSelected: isSelected, isDisabled: false)
+                                letterKey(key, isSelected: isSelected, isDisabled: section == nil)
                             }
                             .id(key)
                             .buttonStyle(.plain)
                             .accessibilityElement(children: .ignore)
-                            .accessibilityLabel("Jump to \(key)")
+                            .accessibilityLabel(section == nil ? "Jump near \(key)" : "Jump to \(key)")
                             .accessibilityIdentifier("LibraryJumpLetter\(key)")
                             .accessibilityAddTraits(isSelected ? .isSelected : [])
                         } else {

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1133,6 +1133,21 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func libraryAlphabetRailTargetsNearestAvailableSection() {
+        let alpha = Podcast(title: "Audio Craft", feedURL: URL(string: "https://example.com/audio-nearest.xml")!)
+        let delta = Podcast(title: "Delta Feed", feedURL: URL(string: "https://example.com/delta-nearest.xml")!)
+        let zeta = Podcast(title: "Zeta Waves", feedURL: URL(string: "https://example.com/zeta-nearest.xml")!)
+        let sections = LibraryDirectoryOrganizer.sections(for: [zeta, alpha, delta])
+
+        #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("A", sections: sections) == "library-section-A")
+        #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("B", sections: sections) == "library-section-D")
+        #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("Y", sections: sections) == "library-section-Z")
+        #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("#", sections: sections) == "library-section-A")
+        #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("M", sections: []) == nil)
+    }
+
+    @Test
+    @MainActor
     func libraryDirectorySnapshotBuildsRowsWithCountsAndNumbers() {
         let alpha = Podcast(title: "Audio Craft", feedURL: URL(string: "https://example.com/audio-row.xml")!)
         let beta = Podcast(title: "Beta Feed", feedURL: URL(string: "https://example.com/beta-row.xml")!)


### PR DESCRIPTION
## Summary\n- make the Library #-Z carousel resolve every key to an exact or nearest available section\n- keep sparse/filtered directories responsive instead of leaving missing letters inert\n- add unit coverage for exact, nearest, # fallback, and empty-section behavior\n- update the changelog under Unreleased\n\n## Verification\n- git diff --check\n- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests\n- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testLargeLibraryAlphabetRailJumpsToSelectedLetter\n- Xcode MCP BuildProject on windowtab1