### PR TITLE
Split explicit show-intent recommendations into their own lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Large-library UI smoke coverage now seeds a deterministic 258-show library** and launches directly into Library, giving the 250+ show scrolling case a repeatable simulator test instead of a manual-only complaint.
 - **Debug large-library seeding now resets stale simulator data when an explicit library size is requested**, so visual audits and UI tests are not polluted by previous sample stores.
 - **Large-library UI coverage now verifies alphabet directory jumps** by tapping the `Z` key in a 258-show Library and asserting the list scrolls to the `Z` section.
+- **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
 - **Shared Tuner labels, tags, and readouts now scale through Dynamic Type metrics** while preserving the mono instrument-panel vocabulary.

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -259,11 +259,17 @@ final class RecommendationService {
             limit: limit,
             excluding: &usedEpisodeIDs
         )
+        let explicitShowIntent = Self.diversified(
+            scoredEpisodes.filter {
+                scoringContext.explicitPositiveShowCounts[$0.episode.podcast.title, default: 0] > 0
+            },
+            limit: limit,
+            excluding: &usedEpisodeIDs
+        )
         let showAffinity = Self.diversified(
             scoredEpisodes.filter {
                 scoringContext.completedShowCounts[$0.episode.podcast.title, default: 0] > 0
                     || scoringContext.showAffinity.contains($0.episode.podcast.title)
-                    || scoringContext.explicitPositiveShowCounts[$0.episode.podcast.title, default: 0] > 0
             },
             limit: limit,
             excluding: &usedEpisodeIDs
@@ -287,6 +293,7 @@ final class RecommendationService {
         var allSections = [
             HomeFeedSection(title: "Signal Lock", subtitle: "The next listen is driven by something you actually did.", scoredEpisodes: signalLock),
             HomeFeedSection(title: "Resume Thread", subtitle: "Partially heard episodes with meaningful time left.", scoredEpisodes: resumeThread),
+            HomeFeedSection(title: "More From Shows You Chose", subtitle: "Follow-ups from shows you explicitly liked or asked for more of.", scoredEpisodes: explicitShowIntent),
             HomeFeedSection(title: "Shows You Finish", subtitle: "Newer episodes from channels with completion signal.", scoredEpisodes: showAffinity),
             HomeFeedSection(title: "Topic Continuation", subtitle: "Shared tags from completed or explicitly liked listens.", scoredEpisodes: topicContinuation)
         ]

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -591,7 +591,69 @@ struct OffScriptTests {
         let firstEpisode = try #require(sections.first?.episodes.first)
 
         #expect(firstEpisode.id == next.id)
+        #expect(sections.first?.title == "More From Shows You Chose")
         #expect(sections.first?.signalTrace(for: next).contains(RecommendationSignal(label: "source", value: "show intent")) == true)
+    }
+
+    @Test
+    @MainActor
+    func homeRecommendationsSeparateExplicitShowIntentFromCompletionAffinity() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let originalGenres = AppSettings.preferredGenres
+        AppSettings.preferredGenres = []
+        defer { AppSettings.preferredGenres = originalGenres }
+
+        let likedShow = Podcast(title: "Chosen Show", feedURL: URL(string: "https://example.com/chosen-show.xml")!)
+        let finishedShow = Podcast(title: "Finished Show", feedURL: URL(string: "https://example.com/finished-lane.xml")!)
+        let likedSeed = Episode(
+            title: "Liked Seed",
+            pubDate: Date().addingTimeInterval(-6 * 86_400),
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/liked-seed.mp3")!,
+            podcast: likedShow
+        )
+        let chosenNext = Episode(
+            title: "Chosen Follow Up",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/chosen-next.mp3")!,
+            podcast: likedShow
+        )
+        let completed = Episode(
+            title: "Completed Seed",
+            pubDate: Date().addingTimeInterval(-5 * 86_400),
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/completed-lane.mp3")!,
+            podcast: finishedShow
+        )
+        let finishedNext = Episode(
+            title: "Finished Follow Up",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/finished-next.mp3")!,
+            podcast: finishedShow
+        )
+
+        completed.isPlayed = true
+        context.insert(likedShow)
+        context.insert(finishedShow)
+        context.insert(likedSeed)
+        context.insert(chosenNext)
+        context.insert(completed)
+        context.insert(finishedNext)
+        context.insert(PreferenceSignal(action: .moreLikeThis, episode: likedSeed))
+        context.insert(PlaybackEvent(kind: .completed, position: 1_800, episode: completed))
+        try context.save()
+
+        let sections = try RecommendationService().homeSections(context: context, limit: 3)
+        let intentSection = try #require(sections.first(where: { $0.title == "More From Shows You Chose" }))
+        let finishSection = try #require(sections.first(where: { $0.title == "Shows You Finish" }))
+
+        #expect(intentSection.episodes.map(\.id).contains(chosenNext.id))
+        #expect(!intentSection.episodes.map(\.id).contains(finishedNext.id))
+        #expect(finishSection.episodes.map(\.id).contains(finishedNext.id))
+        #expect(!finishSection.episodes.map(\.id).contains(chosenNext.id))
     }
 
     @Test


### PR DESCRIPTION
## Summary\n- add a dedicated Home recommendation lane for explicit liked/more-like-this show intent\n- stop grouping explicit show intent under the passive completion-affinity lane\n- add coverage that explicit show intent and completion affinity stay separated\n- update the changelog under Unreleased\n\n## Verification\n- git diff --check\n- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests -> 67 tests passed\n- Xcode MCP BuildProject on windowtab1