### PR TITLE
Shorten bootstrap feed timeouts for large imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Root page headers sit tighter to the safe area** to reclaim top-of-app space while keeping the iOS status/Dynamic Island safe region intact.
 
 ### Fixed — onboarding, import, and sync UI honesty
+- **Large OPML and onboarding bootstrap imports now use shorter feed request timeouts** so dead feeds release bounded import slots faster while normal subscribed-feed sync keeps its more patient timeout.
 - **Onboarding Sign in with Apple now presents from the actual button window when available** and no longer uses the old crash-prone missing-scene path for the normal sign-in flow.
 - **Onboarding starter subscriptions now commit immediately and hydrate in the background** using the same lightweight bootstrap profile as large imports, so picking three podcasts no longer waits on serial feed parsing, full episode enrichment, or external chapter lookups before entering the app.
 - **Onboarding import no longer auto-completes through failed feeds.** Failed starter channels stay visible with retry and continue actions.

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -207,12 +207,14 @@ struct FeedSyncOptions {
     let episodeLimit: Int?
     let enrichmentMode: EpisodeEnrichmentMode
     let resolveExternalChapters: Bool
+    let feedRequestTimeout: TimeInterval
 
     static func standard(episodeLimit: Int? = nil) -> FeedSyncOptions {
         FeedSyncOptions(
             episodeLimit: episodeLimit,
             enrichmentMode: .full,
-            resolveExternalChapters: true
+            resolveExternalChapters: true,
+            feedRequestTimeout: 20
         )
     }
 
@@ -220,7 +222,8 @@ struct FeedSyncOptions {
         FeedSyncOptions(
             episodeLimit: episodeLimit,
             enrichmentMode: .heuristic,
-            resolveExternalChapters: false
+            resolveExternalChapters: false,
+            feedRequestTimeout: 12
         )
     }
 
@@ -228,7 +231,8 @@ struct FeedSyncOptions {
         FeedSyncOptions(
             episodeLimit: episodeLimit,
             enrichmentMode: .skip,
-            resolveExternalChapters: false
+            resolveExternalChapters: false,
+            feedRequestTimeout: 8
         )
     }
 
@@ -290,7 +294,10 @@ final class FeedSyncService {
 
     @MainActor
     func importPodcast(from opmlEntry: OPMLFeedEntry, into context: ModelContext, options: FeedSyncOptions) async throws -> Podcast {
-        let fetched = try await Self.fetchParsedFeed(feedURL: opmlEntry.feedURL)
+        let fetched = try await Self.fetchParsedFeed(
+            feedURL: opmlEntry.feedURL,
+            timeout: options.feedRequestTimeout
+        )
         guard case let .feed(parsed, httpResponse) = fetched else {
             throw PodcastImportError.feedParseFailed
         }
@@ -426,7 +433,8 @@ final class FeedSyncService {
             let fetched = try await Self.fetchParsedFeed(
                 feedURL: podcast.feedURL,
                 eTag: podcast.feedETag,
-                lastModified: podcast.feedLastModified
+                lastModified: podcast.feedLastModified,
+                timeout: options.feedRequestTimeout
             )
             switch fetched {
             case .notModified:
@@ -480,7 +488,8 @@ final class FeedSyncService {
                         let fetched = try await Self.fetchParsedFeed(
                             feedURL: request.feedURL,
                             eTag: request.eTag,
-                            lastModified: request.lastModified
+                            lastModified: request.lastModified,
+                            timeout: options.feedRequestTimeout
                         )
                         return FeedSyncFetchOutcome(feedURL: request.feedURL, result: .success(fetched))
                     } catch {
@@ -722,9 +731,14 @@ final class FeedSyncService {
         case feed(ParsedFeed, HTTPURLResponse)
     }
 
-    private static func fetchParsedFeed(feedURL: URL, eTag: String? = nil, lastModified: String? = nil) async throws -> FeedFetchResult {
+    private static func fetchParsedFeed(
+        feedURL: URL,
+        eTag: String? = nil,
+        lastModified: String? = nil,
+        timeout: TimeInterval = 20
+    ) async throws -> FeedFetchResult {
         var request = URLRequest(url: feedURL)
-        request.timeoutInterval = 20
+        request.timeoutInterval = timeout
         request.setValue("application/rss+xml,application/xml,text/xml;q=0.9,*/*;q=0.8",
                          forHTTPHeaderField: "Accept")
         if let eTag {

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -153,6 +153,14 @@ struct OffScriptTests {
     }
 
     @Test
+    func opmlBootstrapUsesShorterFeedTimeoutThanStandardSync() {
+        #expect(FeedSyncOptions.standard().feedRequestTimeout == 20)
+        #expect(FeedSyncOptions.fastBatchImport().feedRequestTimeout == 12)
+        #expect(FeedSyncOptions.opmlBootstrap().feedRequestTimeout == 8)
+        #expect(FeedSyncOptions.onboardingBootstrap().feedRequestTimeout == 8)
+    }
+
+    @Test
     @MainActor
     func opmlBatchStagingResubscribesExistingNormalizedFeeds() throws {
         let container = try makeContainer()


### PR DESCRIPTION
## Summary\n- add feed-request timeout tuning to FeedSyncOptions\n- keep normal subscribed feed sync at 20s while using shorter 12s fast-batch and 8s OPML/onboarding bootstrap timeouts\n- route OPML and batch sync fetches through the configured timeout\n- add timeout coverage and changelog entry\n\n## Verification\n- git diff --check\n- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests -> 68 tests passed\n- Xcode MCP BuildProject on windowtab1