### PR TITLE
Flatten Library directory rows for large libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Library import is now an explicit `IMPORT` Tuner key** with an icon-only fallback when width is constrained, so the OPML/paste entry point is visible without guessing the glyph.
 - **The bottom Tuner tab indicator now slides between Home, Library, Queue, and Search** with selection haptics instead of appearing abruptly in each cell.
 - **Root page headers sit tighter to the safe area** to reclaim top-of-app space while keeping the iOS status/Dynamic Island safe region intact.
+- **Large Library sections now render as flattened lazy headers, rows, and separators** so a 250+ show directory does not build an entire oversized letter section as one SwiftUI child.
 
 ### Fixed — onboarding, import, and sync UI honesty
 - **Large OPML and onboarding bootstrap imports now use shorter feed request timeouts** so dead feeds release bounded import slots faster while normal subscribed-feed sync keeps its more patient timeout.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -86,6 +86,26 @@ nonisolated struct LibraryDirectorySnapshot {
     var isEmpty: Bool { podcasts.isEmpty }
 }
 
+nonisolated enum LibraryDirectoryListItem: Identifiable {
+    case sectionHeader(LibraryDirectorySection)
+    case row(LibraryDirectoryRow)
+    case sectionSeparator(String)
+    case rowSeparator(String)
+
+    var id: String {
+        switch self {
+        case let .sectionHeader(section):
+            return "header-\(section.id)"
+        case let .row(row):
+            return "row-\(row.id)"
+        case let .sectionSeparator(sectionID):
+            return "section-separator-\(sectionID)"
+        case let .rowSeparator(rowID):
+            return "row-separator-\(rowID)"
+        }
+    }
+}
+
 private struct LibraryPodcastFingerprint: Equatable {
     let id: UUID
     let title: String
@@ -211,6 +231,20 @@ nonisolated enum LibraryDirectoryOrganizer {
             return next.id
         }
         return sortedSections.last?.id
+    }
+
+    static func listItems(for sections: [LibraryDirectorySection]) -> [LibraryDirectoryListItem] {
+        sections.flatMap { section -> [LibraryDirectoryListItem] in
+            var items: [LibraryDirectoryListItem] = [.sectionHeader(section)]
+            for row in section.rows {
+                items.append(.row(row))
+                if !row.isLastInSection {
+                    items.append(.rowSeparator(row.id.uuidString))
+                }
+            }
+            items.append(.sectionSeparator(section.id))
+            return items
+        }
     }
 
     static func sections(
@@ -574,9 +608,11 @@ struct LibraryView: View {
                     }
                 }
 
+                let directoryItems = LibraryDirectoryOrganizer.listItems(for: snapshot.sections)
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(snapshot.sections) { section in
-                        VStack(alignment: .leading, spacing: 0) {
+                    ForEach(directoryItems) { item in
+                        switch item {
+                        case let .sectionHeader(section):
                             HStack {
                                 TunerLabel(text: section.title, color: .offscriptSignalYellow, size: 10)
                                     .accessibilityIdentifier("LibrarySectionHeader\(section.title)")
@@ -587,27 +623,23 @@ struct LibraryView: View {
                             .padding(.bottom, 6)
                             .id(section.id)
 
-                            ForEach(section.rows) { row in
-                                Button {
-                                    selectedPodcast = row.podcast
-                                } label: {
-                                    PodcastShelfRow(
-                                        podcast: row.podcast,
-                                        channelNumber: row.channelNumber,
-                                        unplayedCount: row.unplayedCount,
-                                        inProgressCount: row.inProgressCount,
-                                        isCompact: isCompactDirectory
-                                    )
-                                }
-                                .buttonStyle(.plain)
-
-                                if !row.isLastInSection {
-                                    Rectangle().fill(Color.offscriptHairline).frame(height: 1)
-                                }
+                        case let .row(row):
+                            Button {
+                                selectedPodcast = row.podcast
+                            } label: {
+                                PodcastShelfRow(
+                                    podcast: row.podcast,
+                                    channelNumber: row.channelNumber,
+                                    unplayedCount: row.unplayedCount,
+                                    inProgressCount: row.inProgressCount,
+                                    isCompact: isCompactDirectory
+                                )
                             }
-                        }
+                            .buttonStyle(.plain)
 
-                        Rectangle().fill(Color.offscriptHairline).frame(height: 1)
+                        case .rowSeparator, .sectionSeparator:
+                            Rectangle().fill(Color.offscriptHairline).frame(height: 1)
+                        }
                     }
                 }
                 .padding(.top, 2)

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1244,6 +1244,29 @@ struct OffScriptTests {
     }
 
     @Test
+    @MainActor
+    func libraryDirectoryListItemsFlattenSectionRowsForLazyRendering() {
+        let alpha = Podcast(title: "Audio Craft", feedURL: URL(string: "https://example.com/audio-flat.xml")!)
+        let another = Podcast(title: "Another Audio", feedURL: URL(string: "https://example.com/another-flat.xml")!)
+        let beta = Podcast(title: "Beta Feed", feedURL: URL(string: "https://example.com/beta-flat.xml")!)
+        let sections = LibraryDirectoryOrganizer.sections(for: [alpha, another, beta])
+
+        let items = LibraryDirectoryOrganizer.listItems(for: sections)
+        let ids = items.map(\.id)
+
+        #expect(ids == [
+            "header-library-section-A",
+            "row-\(alpha.id)",
+            "row-separator-\(alpha.id.uuidString)",
+            "row-\(another.id)",
+            "section-separator-library-section-A",
+            "header-library-section-B",
+            "row-\(beta.id)",
+            "section-separator-library-section-B"
+        ])
+    }
+
+    @Test
     func libraryDirectoryOrganizerLoadsPerShowCountsOnlyForCountDrivenModes() {
         #expect(!LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: .all, sort: .title))
         #expect(!LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: .needsSync, sort: .latest))


### PR DESCRIPTION
## Summary\n- flatten Library directory rendering into lazy section-header, row, and separator items\n- keep the existing Tuner visual layout while avoiding section-level eager row construction for 250+ show libraries\n- add unit coverage for flattened item order\n- update the changelog under Unreleased\n\n## Verification\n- git diff --check\n- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests -> 69 tests passed\n- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testLargeLibraryAlphabetRailJumpsToSelectedLetter -> passed\n- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testLargeLibrarySeedSmoke -> passed\n- Xcode MCP BuildProject on windowtab1