### PR TITLE
Add Settings identity diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Added — UI QA swarm coverage
 - **Large-library UI smoke coverage now seeds a deterministic 258-show library** and launches directly into Library, giving the 250+ show scrolling case a repeatable simulator test instead of a manual-only complaint.
+- **Settings UI coverage now opens the config panel against a deterministic 258-show library** and verifies simulator iCloud status stays recoverable instead of crashing.
 - **Debug large-library seeding now resets stale simulator data when an explicit library size is requested**, so visual audits and UI tests are not polluted by previous sample stores.
 - **Large-library UI coverage now verifies alphabet directory jumps** by tapping the `Z` key in a 258-show Library and asserting the list scrolls to the `Z` section.
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
@@ -25,6 +26,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Large Library sections now render as flattened lazy headers, rows, and separators** so a 250+ show directory does not build an entire oversized letter section as one SwiftUI child.
 
 ### Fixed — onboarding, import, and sync UI honesty
+- **Settings and Sign in with Apple now log identity, iCloud, signal-profile, and Keychain OSStatus breadcrumbs** so TestFlight Settings crashes and Apple sign-in failures can be correlated to the failing subsystem.
 - **Large OPML and onboarding bootstrap imports now use shorter feed request timeouts** so dead feeds release bounded import slots faster while normal subscribed-feed sync keeps its more patient timeout.
 - **Onboarding Sign in with Apple now presents from the actual button window when available** and no longer uses the old crash-prone missing-scene path for the normal sign-in flow.
 - **Onboarding starter subscriptions now commit immediately and hydrate in the background** using the same lightweight bootstrap profile as large imports, so picking three podcasts no longer waits on serial feed parsing, full episode enrichment, or external chapter lookups before entering the app.

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -66,10 +66,12 @@ struct SettingsView: View {
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarColorScheme(.dark, for: .navigationBar)
             .task {
+                settingsLogger.info("Settings task started")
                 refreshCounts()
                 refreshSignInState()
                 refreshSignalProfile()
                 await refreshIdentityStatus()
+                settingsLogger.info("Settings task completed: episodes=\(episodeCount, privacy: .public), queued=\(queuedCount, privacy: .public), signedIn=\(isSignedIn, privacy: .public), apple=\(appleCredentialState.displayText, privacy: .public), iCloud=\(cloudKitAvailability.displayText, privacy: .public)")
             }
             // No `.toolbar` ToolbarItem — iOS 26 wraps toolbar buttons in
             // glass-capsule chrome that ignores .plain styling. DONE key
@@ -596,7 +598,11 @@ struct SettingsView: View {
                 withAnimation { signInMessage = "Signed in. Checking iCloud availability." }
                 settingsLogger.info("Sign in with Apple succeeded for user \(credential.user, privacy: .private)")
             } catch {
-                settingsLogger.error("Failed to persist Apple credential: \(error.localizedDescription, privacy: .public)")
+                if let keychainError = error as? UserProfileService.KeychainError {
+                    settingsLogger.error("Failed to persist Apple credential: \(keychainError.localizedDescription, privacy: .public), osStatus=\(keychainError.osStatus, privacy: .public)")
+                } else {
+                    settingsLogger.error("Failed to persist Apple credential: \(error.localizedDescription, privacy: .public)")
+                }
                 withAnimation { signInMessage = "Sign-in could not be saved. Please try again." }
             }
         case .failure(let error):
@@ -655,6 +661,7 @@ struct SettingsView: View {
 
     @MainActor
     private func refreshIdentityStatus(enableSyncWhenAvailable: Bool = false) async {
+        settingsLogger.info("Settings identity refresh started: enableSyncWhenAvailable=\(enableSyncWhenAvailable, privacy: .public)")
         appleCredentialState = await AppleIdentityService.validateStoredCredential()
         cloudKitAvailability = await CloudKitAccountService.currentStatus()
         refreshSignInState()
@@ -665,6 +672,7 @@ struct SettingsView: View {
                 ? "Signed in. Sync activates on next launch."
                 : "Signed in. iCloud is not available on this device right now."
         }
+        settingsLogger.info("Settings identity refresh completed: signedIn=\(isSignedIn, privacy: .public), apple=\(appleCredentialState.displayText, privacy: .public), iCloud=\(cloudKitAvailability.displayText, privacy: .public), cloudSyncEnabled=\(cloudSyncEnabled, privacy: .public), runtime=\(String(describing: AppSettings.cloudSyncRuntimeState), privacy: .public)")
     }
 
     private func refreshSignInState() {
@@ -706,6 +714,7 @@ struct SettingsView: View {
         completedSignalCount = (try? modelContext.fetchCount(FetchDescriptor<PlaybackEvent>(
             predicate: #Predicate<PlaybackEvent> { $0.kindRawValue == completedRawValue }
         ))) ?? 0
+        settingsLogger.info("Settings signal profile refreshed: tags=\(signalTags.count, privacy: .public), shows=\(signalShows.count, privacy: .public), explicitSignals=\(explicitSignalCount, privacy: .public), completedSignals=\(completedSignalCount, privacy: .public)")
     }
 
     private func rebuildSignalProfile() {
@@ -728,5 +737,6 @@ struct SettingsView: View {
         queuedCount   = (try? modelContext.fetchCount(
             FetchDescriptor<Episode>(predicate: #Predicate<Episode> { $0.isQueued })
         )) ?? 0
+        settingsLogger.info("Settings counts refreshed: episodes=\(episodeCount, privacy: .public), unplayed=\(unplayedCount, privacy: .public), queued=\(queuedCount, privacy: .public)")
     }
 }

--- a/OffScript/UserProfileService.swift
+++ b/OffScript/UserProfileService.swift
@@ -95,7 +95,21 @@ enum UserProfileService {
         SecItemDelete(query as CFDictionary)
     }
 
-    enum KeychainError: Error {
+    enum KeychainError: LocalizedError {
         case unhandled(OSStatus)
+
+        var errorDescription: String? {
+            switch self {
+            case let .unhandled(status):
+                return "Keychain write failed with OSStatus \(status)."
+            }
+        }
+
+        var osStatus: OSStatus {
+            switch self {
+            case let .unhandled(status):
+                return status
+            }
+        }
     }
 }

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -56,6 +56,21 @@ final class OffScriptUITests: XCTestCase {
     }
 
     @MainActor
+    func testSettingsPanelOpensWithLargeLibrarySeed() throws {
+        let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 258, debugEpisodesPerShow: 3)
+        app.launch()
+
+        XCTAssertTrue(app.screen("HomeScreen").waitForExistence(timeout: 12))
+        app.buttons["Open settings"].tap()
+
+        let settingsLabel = app.staticTexts["SETTINGS · CONFIG PANEL"]
+        XCTAssertTrue(settingsLabel.waitForExistence(timeout: 12), "Settings panel did not appear. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.staticTexts.containing(labelContaining: "258").waitForExistence(timeout: 12), "Settings counts did not reflect seeded library. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.staticTexts["ICLOUD · NOT CONFIGURED"].waitForExistence(timeout: 8), "Simulator Settings should report missing iCloud entitlements without crashing. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.buttons["Close settings"].waitForExistence(timeout: 5))
+    }
+
+    @MainActor
     func testLargeLibrarySeedSmoke() throws {
         let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 258, debugEpisodesPerShow: 3, debugLaunchTab: 1)
         app.launch()


### PR DESCRIPTION
## Summary
- add Settings panel breadcrumbs for counts, signal profile, Apple identity, iCloud availability, and CloudKit runtime state
- surface Keychain OSStatus in persisted Apple credential failures
- add a 258-show Settings UI smoke test and changelog entry for the Settings crash/sign-in diagnostics path

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testSettingsPanelOpensWithLargeLibrarySeed
- Xcode MCP BuildProject windowtab1