### PR TITLE
Speed up OPML bootstrap imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Fixed — onboarding, import, and sync UI honesty
 - **Settings and Sign in with Apple now log identity, iCloud, signal-profile, and Keychain OSStatus breadcrumbs** so TestFlight Settings crashes and Apple sign-in failures can be correlated to the failing subsystem.
+- **Large OPML bootstrap imports now fetch feeds concurrently but apply SwiftData changes serially** and cap bootstrap RSS parsing to the small starter window, reducing 250+ show import stalls without changing normal full-feed sync.
 - **Large OPML and onboarding bootstrap imports now use shorter feed request timeouts** so dead feeds release bounded import slots faster while normal subscribed-feed sync keeps its more patient timeout.
 - **Onboarding Sign in with Apple now presents from the actual button window when available** and no longer uses the old crash-prone missing-scene path for the normal sign-in flow.
 - **Onboarding starter subscriptions now commit immediately and hydrate in the background** using the same lightweight bootstrap profile as large imports, so picking three podcasts no longer waits on serial feed parsing, full episode enrichment, or external chapter lookups before entering the app.

--- a/OffScript/BatchImportService.swift
+++ b/OffScript/BatchImportService.swift
@@ -57,6 +57,11 @@ final class BatchImportService: ObservableObject {
     private var task: Task<Void, Never>?
     private var activeModelContext: ModelContext?
 
+    private struct FetchOutcome: Sendable {
+        let entry: OPMLFeedEntry
+        let result: Result<FeedSyncService.ParsedFeedFetch, Error>
+    }
+
     private init() {}
 
     /// Kick off a batch import and return immediately. Caller is free to
@@ -122,37 +127,29 @@ final class BatchImportService: ObservableObject {
     // MARK: - Internals
 
     private func runBatch(entries: [OPMLFeedEntry], modelContext: ModelContext) async {
-        // Bounded parallelism — 6 in flight is enough to overlap the
-        // slow rows without tripping rate limits or hammering the device.
+        // Bounded parallelism overlaps slow feed hosts, but completed feeds
+        // are applied back into SwiftData serially on the main actor.
         let concurrency = 6
-        await withTaskGroup(of: (URL, ImportRowStatus).self) { group in
+        await withTaskGroup(of: FetchOutcome.self) { group in
             var iterator = entries.makeIterator()
             var inFlight = 0
 
             while !Task.isCancelled, inFlight < concurrency, let entry = iterator.next() {
                 progress[entry.feedURL] = .importing
                 inFlight += 1
-                group.addTask { [syncService] in
-                    await Self.runOne(entry: entry,
-                                      syncService: syncService,
-                                      modelContext: modelContext)
-                }
+                Self.addFetchTask(for: entry, to: &group)
             }
 
-            while let (feedURL, status) = await group.next() {
+            while let outcome = await group.next() {
                 if Task.isCancelled {
                     group.cancelAll()
                     markUnfinishedRowsCancelled()
                     break
                 }
-                progress[feedURL] = status
+                progress[outcome.entry.feedURL] = await apply(outcome: outcome, modelContext: modelContext)
                 if !Task.isCancelled, let nextEntry = iterator.next() {
                     progress[nextEntry.feedURL] = .importing
-                    group.addTask { [syncService] in
-                        await Self.runOne(entry: nextEntry,
-                                          syncService: syncService,
-                                          modelContext: modelContext)
-                    }
+                    Self.addFetchTask(for: nextEntry, to: &group)
                 }
             }
         }
@@ -167,31 +164,59 @@ final class BatchImportService: ObservableObject {
         activeModelContext = nil
     }
 
+    private static func addFetchTask(for entry: OPMLFeedEntry, to group: inout TaskGroup<FetchOutcome>) {
+        group.addTask {
+            do {
+                try Task.checkCancellation()
+                let fetched = try await FeedSyncService.fetchParsedOPMLFeed(
+                    for: entry,
+                    options: .opmlBootstrap()
+                )
+                return FetchOutcome(entry: entry, result: .success(fetched))
+            } catch {
+                return FetchOutcome(entry: entry, result: .failure(error))
+            }
+        }
+    }
+
+    private func apply(outcome: FetchOutcome, modelContext: ModelContext) async -> ImportRowStatus {
+        switch outcome.result {
+        case let .success(fetched):
+            do {
+                try Task.checkCancellation()
+                _ = try await syncService.importPodcast(
+                    from: outcome.entry,
+                    parsedFeed: fetched.parsed,
+                    httpResponse: fetched.httpResponse,
+                    into: modelContext,
+                    options: .opmlBootstrap()
+                )
+                try Task.checkCancellation()
+                return .added
+            } catch is CancellationError {
+                Self.markStagedSubscriptionCancelled(entry: outcome.entry, in: modelContext)
+                return .cancelled
+            } catch {
+                Self.markStagedSubscriptionFailed(entry: outcome.entry, error: error, in: modelContext)
+                batchImportLogger.error("OPML row apply failed for \(outcome.entry.feedURL.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return .failed
+            }
+        case let .failure(error):
+            if error is CancellationError {
+                Self.markStagedSubscriptionCancelled(entry: outcome.entry, in: modelContext)
+                return .cancelled
+            }
+            Self.markStagedSubscriptionFailed(entry: outcome.entry, error: error, in: modelContext)
+            batchImportLogger.error("OPML row fetch failed for \(outcome.entry.feedURL.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return .failed
+        }
+    }
+
     private func markUnfinishedRowsCancelled() {
         for (feedURL, status) in progress {
             if status == .pending || status == .importing {
                 progress[feedURL] = .cancelled
             }
-        }
-    }
-
-    private static func runOne(entry: OPMLFeedEntry,
-                               syncService: FeedSyncService,
-                               modelContext: ModelContext) async -> (URL, ImportRowStatus) {
-        do {
-            try Task.checkCancellation()
-            _ = try await syncService.importPodcast(from: entry,
-                                                    into: modelContext,
-                                                    options: .opmlBootstrap())
-            try Task.checkCancellation()
-            return (entry.feedURL, .added)
-        } catch is CancellationError {
-            markStagedSubscriptionCancelled(entry: entry, in: modelContext)
-            return (entry.feedURL, .cancelled)
-        } catch {
-            markStagedSubscriptionFailed(entry: entry, error: error, in: modelContext)
-            batchImportLogger.error("OPML row failed for \(entry.feedURL.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
-            return (entry.feedURL, .failed)
         }
     }
 

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -205,6 +205,7 @@ enum EpisodeEnrichmentMode {
 
 struct FeedSyncOptions {
     let episodeLimit: Int?
+    let feedParseItemLimit: Int?
     let enrichmentMode: EpisodeEnrichmentMode
     let resolveExternalChapters: Bool
     let feedRequestTimeout: TimeInterval
@@ -212,6 +213,7 @@ struct FeedSyncOptions {
     static func standard(episodeLimit: Int? = nil) -> FeedSyncOptions {
         FeedSyncOptions(
             episodeLimit: episodeLimit,
+            feedParseItemLimit: nil,
             enrichmentMode: .full,
             resolveExternalChapters: true,
             feedRequestTimeout: 20
@@ -221,6 +223,7 @@ struct FeedSyncOptions {
     static func fastBatchImport(episodeLimit: Int? = nil) -> FeedSyncOptions {
         FeedSyncOptions(
             episodeLimit: episodeLimit,
+            feedParseItemLimit: nil,
             enrichmentMode: .heuristic,
             resolveExternalChapters: false,
             feedRequestTimeout: 12
@@ -230,6 +233,7 @@ struct FeedSyncOptions {
     static func opmlBootstrap(episodeLimit: Int? = 3) -> FeedSyncOptions {
         FeedSyncOptions(
             episodeLimit: episodeLimit,
+            feedParseItemLimit: episodeLimit.map { max($0 * 3, 10) },
             enrichmentMode: .skip,
             resolveExternalChapters: false,
             feedRequestTimeout: 8
@@ -263,6 +267,11 @@ final class FeedSyncService {
         }
     }
 
+    struct ParsedFeedFetch: Sendable {
+        let parsed: ParsedFeed
+        let httpResponse: HTTPURLResponse
+    }
+
     private struct FeedSyncRequest: Sendable {
         let feedURL: URL
         let eTag: String?
@@ -294,13 +303,27 @@ final class FeedSyncService {
 
     @MainActor
     func importPodcast(from opmlEntry: OPMLFeedEntry, into context: ModelContext, options: FeedSyncOptions) async throws -> Podcast {
-        let fetched = try await Self.fetchParsedFeed(
-            feedURL: opmlEntry.feedURL,
-            timeout: options.feedRequestTimeout
+        let fetched = try await Self.fetchParsedOPMLFeed(
+            for: opmlEntry,
+            options: options
         )
-        guard case let .feed(parsed, httpResponse) = fetched else {
-            throw PodcastImportError.feedParseFailed
-        }
+        return try await importPodcast(
+            from: opmlEntry,
+            parsedFeed: fetched.parsed,
+            httpResponse: fetched.httpResponse,
+            into: context,
+            options: options
+        )
+    }
+
+    @MainActor
+    func importPodcast(
+        from opmlEntry: OPMLFeedEntry,
+        parsedFeed parsed: ParsedFeed,
+        httpResponse: HTTPURLResponse? = nil,
+        into context: ModelContext,
+        options: FeedSyncOptions
+    ) async throws -> Podcast {
         let result = try PodcastImportService.searchResult(opmlEntry: opmlEntry, parsedFeed: parsed)
         let podcast = try upsertPodcast(from: result, into: context)
         podcast.syncStatus = "syncing"
@@ -308,6 +331,18 @@ final class FeedSyncService {
         podcast.syncErrorMessage = nil
         try await apply(parsed: parsed, httpResponse: httpResponse, to: podcast, in: context, options: options)
         return podcast
+    }
+
+    static func fetchParsedOPMLFeed(for entry: OPMLFeedEntry, options: FeedSyncOptions) async throws -> ParsedFeedFetch {
+        let fetched = try await Self.fetchParsedFeed(
+            feedURL: entry.feedURL,
+            timeout: options.feedRequestTimeout,
+            itemLimit: options.feedParseItemLimit
+        )
+        guard case let .feed(parsed, httpResponse) = fetched else {
+            throw PodcastImportError.feedParseFailed
+        }
+        return ParsedFeedFetch(parsed: parsed, httpResponse: httpResponse)
     }
 
     @MainActor
@@ -434,7 +469,8 @@ final class FeedSyncService {
                 feedURL: podcast.feedURL,
                 eTag: podcast.feedETag,
                 lastModified: podcast.feedLastModified,
-                timeout: options.feedRequestTimeout
+                timeout: options.feedRequestTimeout,
+                itemLimit: options.feedParseItemLimit
             )
             switch fetched {
             case .notModified:
@@ -489,7 +525,8 @@ final class FeedSyncService {
                             feedURL: request.feedURL,
                             eTag: request.eTag,
                             lastModified: request.lastModified,
-                            timeout: options.feedRequestTimeout
+                            timeout: options.feedRequestTimeout,
+                            itemLimit: options.feedParseItemLimit
                         )
                         return FeedSyncFetchOutcome(feedURL: request.feedURL, result: .success(fetched))
                     } catch {
@@ -735,7 +772,8 @@ final class FeedSyncService {
         feedURL: URL,
         eTag: String? = nil,
         lastModified: String? = nil,
-        timeout: TimeInterval = 20
+        timeout: TimeInterval = 20,
+        itemLimit: Int? = nil
     ) async throws -> FeedFetchResult {
         var request = URLRequest(url: feedURL)
         request.timeoutInterval = timeout
@@ -766,7 +804,7 @@ final class FeedSyncService {
             throw PodcastImportError.feedParseFailed
         }
 
-        let parsed = try RSSFeedParser().parse(data: data)
+        let parsed = try RSSFeedParser().parse(data: data, itemLimit: itemLimit)
         return .feed(parsed, httpResponse)
     }
 
@@ -961,17 +999,24 @@ final class RSSFeedParser: NSObject, XMLParserDelegate {
     private var currentElement = ""
     private var currentText = ""
     private var insideItem = false
+    private var itemLimit: Int?
+    private var reachedItemLimit = false
 
-    func parse(data: Data) throws -> ParsedFeed {
+    func parse(data: Data, itemLimit: Int? = nil) throws -> ParsedFeed {
         feed = ParsedFeed()
         currentItem = nil
         currentElement = ""
         currentText = ""
         insideItem = false
+        self.itemLimit = itemLimit
+        reachedItemLimit = false
 
         let parser = XMLParser(data: data)
         parser.delegate = self
         guard parser.parse() else {
+            if reachedItemLimit {
+                return feed
+            }
             throw parser.parserError ?? URLError(.cannotParseResponse)
         }
         return feed
@@ -1073,6 +1118,10 @@ final class RSSFeedParser: NSObject, XMLParserDelegate {
                 insideItem = false
                 if let item = currentItem, item.title.isEmpty == false, item.audioURL.absoluteString.contains("unset") == false {
                     feed.items.append(item)
+                    if let itemLimit, feed.items.count >= itemLimit {
+                        reachedItemLimit = true
+                        parser.abortParsing()
+                    }
                 }
                 currentItem = nil
             default:

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -81,6 +81,72 @@ struct OffScriptTests {
     }
 
     @Test
+    func rssParserStopsAfterItemLimitButKeepsChannelMetadata() throws {
+        let items = (1...12).map { index in
+            """
+            <item>
+              <title>Episode \(index)</title>
+              <guid>episode-\(index)</guid>
+              <enclosure url="https://example.com/episode-\(index).mp3" type="audio/mpeg" />
+            </item>
+            """
+        }.joined(separator: "\n")
+        let xml = """
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+          <channel>
+            <title>Large Back Catalog</title>
+            <itunes:author>OffScript Studio</itunes:author>
+            <description>Hundreds of episodes, capped during bootstrap.</description>
+            <itunes:image href="https://example.com/show.jpg" />
+            \(items)
+          </channel>
+        </rss>
+        """
+
+        let parsed = try RSSFeedParser().parse(data: Data(xml.utf8), itemLimit: 3)
+
+        #expect(parsed.title == "Large Back Catalog")
+        #expect(parsed.author == "OffScript Studio")
+        #expect(parsed.artworkURL?.absoluteString == "https://example.com/show.jpg")
+        #expect(parsed.items.map(\.guid) == ["episode-1", "episode-2", "episode-3"])
+    }
+
+    @Test
+    func rssParserUnlimitedModeStillParsesAllItems() throws {
+        let items = (1...12).map { index in
+            """
+            <item>
+              <title>Episode \(index)</title>
+              <guid>episode-\(index)</guid>
+              <enclosure url="https://example.com/episode-\(index).mp3" type="audio/mpeg" />
+            </item>
+            """
+        }.joined(separator: "\n")
+        let xml = """
+        <rss version="2.0">
+          <channel>
+            <title>Full Sync Feed</title>
+            \(items)
+          </channel>
+        </rss>
+        """
+
+        let parsed = try RSSFeedParser().parse(data: Data(xml.utf8))
+
+        #expect(parsed.items.count == 12)
+        #expect(parsed.items.last?.guid == "episode-12")
+    }
+
+    @Test
+    func opmlBootstrapConfigCapsFeedParseItems() {
+        #expect(FeedSyncOptions.standard().feedParseItemLimit == nil)
+        #expect(FeedSyncOptions.fastBatchImport().feedParseItemLimit == nil)
+        #expect(FeedSyncOptions.opmlBootstrap().feedParseItemLimit == 10)
+        #expect(FeedSyncOptions.onboardingBootstrap().feedParseItemLimit == 10)
+        #expect(FeedSyncOptions.opmlBootstrap(episodeLimit: 12).feedParseItemLimit == 36)
+    }
+
+    @Test
     func opmlImportDedupesFeedsPreservingFirstSeenOrder() throws {
         let opml = """
         <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- split OPML batch work so feed fetch/parse remains bounded-concurrent while SwiftData apply runs serially on the main actor
- add a bootstrap feed parse cap so OPML/onboarding imports do not parse huge back catalogs before keeping the starter episode window
- add parser/config tests and update the changelog

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- Xcode MCP BuildProject windowtab1