### PR TITLE
Weight explicit recommendation intent higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Large Library sections now render as flattened lazy headers, rows, and separators** so a 250+ show directory does not build an entire oversized letter section as one SwiftUI child.
 - **The Library directory now renders from value snapshots instead of live SwiftData podcast models** so 250+ show scrolling does less model work and only resolves a show when a row is opened.
 
+### Changed — recommendation quality
+- **Explicit “more like this” and like signals now carry substantially more weight than passive completions** so recommendations follow intentional user feedback instead of feeling like generic completion-based ranking.
+
 ### Fixed — onboarding, import, and sync UI honesty
 - **Settings and Sign in with Apple now log identity, iCloud, signal-profile, and Keychain OSStatus breadcrumbs** so TestFlight Settings crashes and Apple sign-in failures can be correlated to the failing subsystem.
 - **Large OPML bootstrap imports now fetch feeds concurrently but apply SwiftData changes serially** and cap bootstrap RSS parsing to the small starter window, reducing 250+ show import stalls without changing normal full-feed sync.

--- a/OffScript/TasteProfileService.swift
+++ b/OffScript/TasteProfileService.swift
@@ -103,8 +103,8 @@ enum TasteProfileService {
 
     private static func preferenceWeight(_ action: PreferenceSignal.Action) -> Double {
         switch action {
-        case .moreLikeThis: 4.0
-        case .like: 2.5
+        case .moreLikeThis: 8.0
+        case .like: 5.0
         case .lessLikeThis: -3.5
         case .notInterested: -5.0
         }

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1485,6 +1485,53 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func tasteProfileRefreshLetsOneExplicitIntentBeatSeveralPassiveCompletions() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let passiveShow = Podcast(title: "Passive Show", feedURL: URL(string: "https://example.com/passive-signals.xml")!)
+        let chosenShow = Podcast(title: "Chosen Show", feedURL: URL(string: "https://example.com/chosen-signals.xml")!)
+        let chosen = Episode(
+            title: "Explicit Choice",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/chosen-signals.mp3")!,
+            podcast: chosenShow
+        )
+        let chosenProfile = EpisodeProfile(episodeID: chosen.id)
+        chosenProfile.tags = ["chosen"]
+
+        context.insert(passiveShow)
+        context.insert(chosenShow)
+        context.insert(chosen)
+        context.insert(chosenProfile)
+        context.insert(PreferenceSignal(action: .moreLikeThis, episode: chosen))
+
+        for index in 1...4 {
+            let passive = Episode(
+                title: "Passive Completion \(index)",
+                pubDate: .now,
+                duration: 1_800,
+                audioURL: URL(string: "https://example.com/passive-signals-\(index).mp3")!,
+                podcast: passiveShow
+            )
+            let passiveProfile = EpisodeProfile(episodeID: passive.id)
+            passiveProfile.tags = ["passive"]
+            context.insert(passive)
+            context.insert(passiveProfile)
+            context.insert(PlaybackEvent(kind: .completed, position: 1_800, episode: passive))
+        }
+        try context.save()
+
+        try TasteProfileService.refresh(in: context, force: true)
+        let tasteProfile = try #require(try context.fetch(FetchDescriptor<UserTasteProfile>()).first)
+
+        #expect(tasteProfile.topTags.first == "chosen")
+        #expect(tasteProfile.showAffinity.first == "Chosen Show")
+    }
+
+    @Test
+    @MainActor
     func tasteProfileRefreshDemotesNegativePreferenceSignals() throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- increase explicit like/more-like-this taste-profile weights so intentional feedback beats passive completion history
- add a regression test proving one explicit intent outranks several passive completions for tags and show affinity
- update the changelog under recommendation quality

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- Xcode MCP BuildProject windowtab1