### PR TITLE
Replace native refresh with Tuner controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Root page headers sit tighter to the safe area** to reclaim top-of-app space while keeping the iOS status/Dynamic Island safe region intact.
 - **Large Library sections now render as flattened lazy headers, rows, and separators** so a 250+ show directory does not build an entire oversized letter section as one SwiftUI child.
 - **The Library directory now renders from value snapshots instead of live SwiftData podcast models** so 250+ show scrolling does less model work and only resolves a show when a row is opened.
+- **Home retune and Library sync now use explicit Tuner header keys instead of native pull-to-refresh chrome**, removing another app-controlled Liquid Glass surface while keeping refresh actions discoverable.
 
 ### Changed — recommendation quality
 - **Explicit “more like this” and like signals now carry substantially more weight than passive completions** so recommendations follow intentional user feedback instead of feeling like generic completion-based ranking.

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -23,6 +23,7 @@ struct HomeView: View {
     @State private var errorMessage: String?
     @State private var isLoading = true
     @State private var isLoadingDiscovery = false
+    @State private var isRetuning = false
     @State private var loadGeneration = 0
     @State private var feedbackRetuneTask: Task<Void, Never>?
     let onOpenSettings: () -> Void
@@ -32,7 +33,13 @@ struct HomeView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                HomeTunerHeader(onOpenSettings: onOpenSettings)
+                HomeTunerHeader(
+                    isRetuning: isRetuning,
+                    onRetune: {
+                        Task { await loadSections(manual: true) }
+                    },
+                    onOpenSettings: onOpenSettings
+                )
 
                 if let errorMessage {
                     HomeErrorRow(message: errorMessage)
@@ -97,7 +104,6 @@ struct HomeView: View {
         // saw in the screenshot. The settings affordance is rendered inline
         // in HomeTunerHeader instead, where we have full control.
         .task(id: recommendationModeRaw) { await loadSections() }
-        .refreshable { await loadSections() }
         .onReceive(NotificationCenter.default.publisher(for: .offscriptRecommendationFeedbackChanged)) { _ in
             feedbackRetuneTask?.cancel()
             feedbackRetuneTask = Task {
@@ -114,10 +120,19 @@ struct HomeView: View {
     }
 
     @MainActor
-    private func loadSections() async {
+    private func loadSections(manual: Bool = false) async {
+        if manual {
+            guard !isRetuning else { return }
+            isRetuning = true
+        }
         loadGeneration += 1
         let generation = loadGeneration
         isLoadingDiscovery = false
+        defer {
+            if manual, generation == loadGeneration {
+                isRetuning = false
+            }
+        }
         do {
             let mode = AppSettings.recommendationMode
             let loaded = try recommendationService.homeSections(context: modelContext, mode: mode)
@@ -180,6 +195,8 @@ struct HomeView: View {
 // MARK: - Header
 
 private struct HomeTunerHeader: View {
+    let isRetuning: Bool
+    let onRetune: () -> Void
     let onOpenSettings: () -> Void
 
     private var dayString: String {
@@ -209,6 +226,19 @@ private struct HomeTunerHeader: View {
                     .foregroundStyle(Color.offscriptPaperWhite)
 
                 Spacer()
+
+                Button(action: onRetune) {
+                    Image(systemName: isRetuning ? "waveform.path" : "arrow.clockwise")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(isRetuning ? Color.offscriptFnInfo : Color.offscriptSignalYellow)
+                        .frame(width: 36, height: 30)
+                        .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(isRetuning)
+                .accessibilityLabel(isRetuning ? "Retuning recommendations" : "Retune recommendations")
 
                 // Tuner config button — sharp hairline rectangle, signal-yellow
                 // glyph. Replaces the toolbar gear which iOS 26 was wrapping in

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -466,6 +466,7 @@ struct LibraryView: View {
     @State private var selectedPodcastID: UUID?
     @State private var cachedDirectorySnapshot = LibraryDirectorySnapshot.empty
     @State private var didBuildDirectorySnapshot = false
+    @State private var isSyncingLibrary = false
 
     private var subscribedPodcasts: [Podcast] {
         podcasts
@@ -525,6 +526,10 @@ struct LibraryView: View {
                         unplayedCount: unplayedEpisodeCount,
                         inProgressCount: inProgressEpisodeCount,
                         onOpenImport: { isImportPresented = true },
+                        isSyncing: isSyncingLibrary,
+                        onSync: {
+                            Task { await syncSubscriptions() }
+                        },
                         onOpenSettings: onOpenSettings
                     )
 
@@ -625,7 +630,6 @@ struct LibraryView: View {
             fullCountLoadTask?.cancel()
             directoryQueryTask?.cancel()
         }
-        .refreshable { await syncSubscriptions() }
         // Settings + Import buttons render inline in LibraryTunerHeader, not
         // as toolbar items — iOS 26 wraps toolbar buttons in glass chrome.
         .sheet(isPresented: $isImportPresented) {
@@ -950,6 +954,9 @@ struct LibraryView: View {
 
     @MainActor
     private func syncSubscriptions() async {
+        guard !isSyncingLibrary else { return }
+        isSyncingLibrary = true
+        defer { isSyncingLibrary = false }
         for podcast in subscribedPodcasts {
             do {
                 try await syncService.sync(podcast: podcast, in: modelContext)
@@ -969,6 +976,8 @@ private struct LibraryTunerHeader: View {
     let unplayedCount: Int
     let inProgressCount: Int
     let onOpenImport: () -> Void
+    let isSyncing: Bool
+    let onSync: () -> Void
     let onOpenSettings: () -> Void
 
     var body: some View {
@@ -1009,6 +1018,19 @@ private struct LibraryTunerHeader: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Import podcasts")
+
+                Button(action: onSync) {
+                    Image(systemName: isSyncing ? "waveform.path" : "arrow.clockwise")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(isSyncing ? Color.offscriptFnInfo : Color.offscriptSignalYellow)
+                        .frame(width: 36, height: 30)
+                        .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(isSyncing)
+                .accessibilityLabel(isSyncing ? "Syncing library" : "Sync library")
 
                 Button(action: onOpenSettings) {
                     Image(systemName: "slider.horizontal.3")


### PR DESCRIPTION
## Summary
- remove native SwiftUI pull-to-refresh surfaces from Home and Library
- add explicit Tuner header keys for Home retune and Library sync with in-progress disabled states
- update the changelog for the remaining app-controlled Liquid Glass cleanup

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testSettingsPanelOpensFromHome -only-testing:OffScriptUITests/OffScriptUITests/testLargeLibrarySeedSmoke
- Xcode MCP BuildProject windowtab1