### PR TITLE
Harden onboarding Apple sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Fixed — onboarding, import, and sync UI honesty
 - **Settings and Sign in with Apple now log identity, iCloud, signal-profile, and Keychain OSStatus breadcrumbs** so TestFlight Settings crashes and Apple sign-in failures can be correlated to the failing subsystem.
+- **Onboarding Sign in with Apple no longer has an iOS 26 missing-window precondition crash path** and now logs Keychain OSStatus details when credential persistence fails.
 - **Large OPML bootstrap imports now fetch feeds concurrently but apply SwiftData changes serially** and cap bootstrap RSS parsing to the small starter window, reducing 250+ show import stalls without changing normal full-feed sync.
 - **Large OPML and onboarding bootstrap imports now use shorter feed request timeouts** so dead feeds release bounded import slots faster while normal subscribed-feed sync keeps its more patient timeout.
 - **Onboarding Sign in with Apple now presents from the actual button window when available** and no longer uses the old crash-prone missing-scene path for the normal sign-in flow.

--- a/OffScript/OnboardingFlowView.swift
+++ b/OffScript/OnboardingFlowView.swift
@@ -278,16 +278,9 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
                     ?? active.windows.first
                     ?? UIWindow(windowScene: active)
             }
-            assertionFailure("Sign in with Apple requires an active window scene")
-            if #unavailable(iOS 26.0) {
-                return detachedFallbackAnchor()
-            }
-            preconditionFailure("Sign in with Apple requires an active window scene")
-        }
-
-        @available(iOS, deprecated: 26.0)
-        private func detachedFallbackAnchor() -> ASPresentationAnchor {
-            ASPresentationAnchor(frame: .zero)
+            let logger = Logger(subsystem: "com.offscript", category: "AppleSignin")
+            logger.error("Sign in with Apple requested without an active window scene; using detached fallback anchor")
+            return ASPresentationAnchor(frame: .zero)
         }
 
         func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
@@ -313,7 +306,11 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
                 }
             } catch {
                 let logger = Logger(subsystem: "com.offscript", category: "AppleSignin")
-                logger.error("Failed to persist Apple credential: \(error.localizedDescription, privacy: .public)")
+                if let keychainError = error as? UserProfileService.KeychainError {
+                    logger.error("Failed to persist Apple credential: \(keychainError.localizedDescription, privacy: .public), osStatus=\(keychainError.osStatus, privacy: .public)")
+                } else {
+                    logger.error("Failed to persist Apple credential: \(error.localizedDescription, privacy: .public)")
+                }
                 inFlightController = nil
                 onFailure("SIGN-IN COULD NOT BE SAVED. TRY AGAIN.")
             }


### PR DESCRIPTION
## Summary
- remove the iOS 26 missing-window precondition crash path from onboarding Sign in with Apple
- log Keychain LocalizedError and OSStatus details when onboarding credential persistence fails
- update the changelog for the onboarding identity hardening

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests\n- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testOnboardingFirstScreenSmoke\n- Xcode MCP BuildProject windowtab1