### PR TITLE
Speed up single-show subscription adds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Changed — Library performance
 - **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.
+- **Single-show adds from Home, Search, and pasted feed URLs now save the subscription before feed hydration**, then use a capped bootstrap sync in the background instead of blocking the UI on a full catalog import.
 - **Onboarding now stages selected starter shows in one SwiftData batch** instead of saving each selected podcast independently, making the three-podcast starter flow a single local commit before background hydration.
 - **Capped feed bootstrap now selects the newest episode slice without sorting full back catalogs**, so OPML and onboarding bootstrap paths do not pay full-feed sort cost when they only need the first few newest episodes.
 - **OPML batch hydration now uses a lightweight bootstrap pass** that imports only a small first slice of episodes and skips episode profile enrichment, avoiding thousands of episode/profile writes during the initial import.

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -430,9 +430,11 @@ private struct HomeStarterRail: View {
 
         do {
             let result = StarterRailService.searchResult(for: pick)
-            _ = try await syncService.importPodcast(from: result,
-                                                    into: modelContext,
-                                                    episodeLimit: 25)
+            _ = try syncService.subscribeThenHydrate(
+                from: result,
+                into: modelContext,
+                episodeLimit: 25
+            )
             addedIDs.insert(pick.id)
         } catch {
             homeLogger.error("Starter add failed for \(pick.title, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -637,7 +639,7 @@ private struct TunerDiscoveryRail: View {
         errorMessage = nil
 
         do {
-            _ = try await syncService.importPodcast(from: result, into: modelContext, episodeLimit: 25)
+            _ = try syncService.subscribeThenHydrate(from: result, into: modelContext, episodeLimit: 25)
             addedIDs.insert(key)
         } catch {
             homeLogger.error("Discovery add failed for \(result.title, privacy: .public): \(error.localizedDescription, privacy: .public)")

--- a/OffScript/LibraryImportSheet.swift
+++ b/OffScript/LibraryImportSheet.swift
@@ -429,7 +429,7 @@ struct LibraryImportSheet: View {
 
         do {
             let result = try await PodcastImportService.resolve(urlString: trimmed)
-            let podcast = try await syncService.importPodcast(from: result, into: modelContext)
+            let podcast = try syncService.subscribeThenHydrate(from: result, into: modelContext)
             importedTitle = podcast.title
             urlInput = ""
         } catch {

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -243,6 +243,10 @@ struct FeedSyncOptions {
     static func onboardingBootstrap(episodeLimit: Int? = 3) -> FeedSyncOptions {
         opmlBootstrap(episodeLimit: episodeLimit)
     }
+
+    static func singleAddBootstrap(episodeLimit: Int? = 12) -> FeedSyncOptions {
+        opmlBootstrap(episodeLimit: episodeLimit)
+    }
 }
 
 enum FeedSyncRetryPolicy {
@@ -390,6 +394,28 @@ final class FeedSyncService {
         podcast.lastSyncAttemptAt = .now
         podcast.syncErrorMessage = nil
         try context.save()
+        return podcast
+    }
+
+    @MainActor
+    @discardableResult
+    func subscribeThenHydrate(
+        from result: PodcastSearchResult,
+        into context: ModelContext,
+        episodeLimit: Int? = 12,
+        startHydration: Bool = true
+    ) throws -> Podcast {
+        let podcast = try stagePodcastSubscription(from: result, into: context)
+        guard startHydration else { return podcast }
+
+        Task { @MainActor in
+            try? await sync(
+                podcast: podcast,
+                in: context,
+                options: .singleAddBootstrap(episodeLimit: episodeLimit)
+            )
+        }
+
         return podcast
     }
 

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -235,7 +235,7 @@ struct SearchView: View {
         defer { importingID = nil }
 
         do {
-            _ = try await syncService.importPodcast(from: result, into: modelContext)
+            _ = try syncService.subscribeThenHydrate(from: result, into: modelContext)
             errorMessage = nil
             storeRecentSearch(result.title)
         } catch {

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -143,6 +143,7 @@ struct OffScriptTests {
         #expect(FeedSyncOptions.fastBatchImport().feedParseItemLimit == nil)
         #expect(FeedSyncOptions.opmlBootstrap().feedParseItemLimit == 10)
         #expect(FeedSyncOptions.onboardingBootstrap().feedParseItemLimit == 10)
+        #expect(FeedSyncOptions.singleAddBootstrap().feedParseItemLimit == 36)
         #expect(FeedSyncOptions.opmlBootstrap(episodeLimit: 12).feedParseItemLimit == 36)
     }
 
@@ -224,6 +225,7 @@ struct OffScriptTests {
         #expect(FeedSyncOptions.fastBatchImport().feedRequestTimeout == 12)
         #expect(FeedSyncOptions.opmlBootstrap().feedRequestTimeout == 8)
         #expect(FeedSyncOptions.onboardingBootstrap().feedRequestTimeout == 8)
+        #expect(FeedSyncOptions.singleAddBootstrap().feedRequestTimeout == 8)
     }
 
     @Test
@@ -2067,6 +2069,34 @@ struct OffScriptTests {
         #expect(podcast.subscribedAt != nil)
         #expect(podcast.syncStatus == "idle")
         #expect(podcast.lastSyncAttemptAt != nil)
+        #expect(podcast.syncErrorMessage == nil)
+    }
+
+    @Test
+    @MainActor
+    func feedSyncSubscribeThenHydrateCanReturnBeforeNetworkWork() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let result = PodcastSearchResult(
+            title: "Instant Add",
+            author: "Fast Author",
+            feedURL: URL(string: "https://example.com/instant.xml")!,
+            artworkURL: URL(string: "https://example.com/instant.jpg")!,
+            websiteURL: URL(string: "https://example.com")!,
+            summary: "A show added from Search."
+        )
+
+        let podcast = try FeedSyncService().subscribeThenHydrate(
+            from: result,
+            into: context,
+            startHydration: false
+        )
+
+        let podcasts = try context.fetch(FetchDescriptor<Podcast>())
+        #expect(podcasts.count == 1)
+        #expect(podcast.isSubscribed)
+        #expect(podcast.title == "Instant Add")
+        #expect(podcast.syncStatus == "idle")
         #expect(podcast.syncErrorMessage == nil)
     }
 


### PR DESCRIPTION
## Summary
- add a single-add bootstrap feed sync profile that caps parsing/enrichment work
- make Home starter/discovery, Search add, and pasted feed URL import save subscriptions before feed hydration
- cover the stage-before-network path in unit tests and update the changelog

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testPostOnboardingShellSmoke
- Xcode MCP BuildProject passed