### PR TITLE
Remove deprecated Apple sign-in anchor fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Large Library count-driven filters no longer fetch every matching episode just to compute per-show badges** and instead use cancellable per-show count queries for `UNPLAYED`, `IN PROGRESS`, and `ATTN`.
 - **Recommendation negative signals are now graded instead of binary** so one `Less Like This` no longer erases a whole show while repeated negative evidence still suppresses strongly matched candidates.
 - **Tuner chrome now uses shared modal/detail top insets and more resilient compact headers/import rows** so Settings, Import, and Library fallback surfaces keep the OLED instrument look at narrow widths and larger text sizes.
+- **Onboarding Sign in with Apple fallback anchoring no longer emits the iOS 26 `ASPresentationAnchor(frame:)` archive warning** when no foreground scene is available.
 - **Large OPML and onboarding bootstrap imports now use shorter feed request timeouts** so dead feeds release bounded import slots faster while normal subscribed-feed sync keeps its more patient timeout.
 - **Onboarding Sign in with Apple now presents from the actual button window when available** and no longer uses the old crash-prone missing-scene path for the normal sign-in flow.
 - **Onboarding starter subscriptions now commit immediately and hydrate in the background** using the same lightweight bootstrap profile as large imports, so picking three podcasts no longer waits on serial feed parsing, full episode enrichment, or external chapter lookups before entering the app.

--- a/OffScript/OnboardingFlowView.swift
+++ b/OffScript/OnboardingFlowView.swift
@@ -239,6 +239,7 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
         // with Apple does nothing." Apple's docs describe holding the
         // controller for the lifetime of the request.
         private var inFlightController: ASAuthorizationController?
+        private var inFlightPresentationAnchor: ASPresentationAnchor?
         var presentationAnchorProvider: (() -> ASPresentationAnchor?)?
 
         init(onComplete: @escaping () -> Void, onFailure: @escaping (String) -> Void) {
@@ -247,6 +248,13 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
         }
 
         @objc func handleSignIn() {
+            guard let anchor = resolvedPresentationAnchor() else {
+                let logger = Logger(subsystem: "com.offscript", category: "AppleSignin")
+                logger.error("Sign in with Apple requested without an active window scene")
+                onFailure("SIGN-IN NEEDS AN ACTIVE APP WINDOW. TRY AGAIN.")
+                return
+            }
+
             let request = ASAuthorizationAppleIDProvider().createRequest()
             request.requestedScopes = [.fullName]
 
@@ -254,6 +262,7 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
             controller.delegate = self
             controller.presentationContextProvider = self
             inFlightController = controller
+            inFlightPresentationAnchor = anchor
             controller.performRequests()
         }
 
@@ -263,9 +272,14 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
         // active one and fall back to the key window if none match. Without
         // this, the auth sheet refuses to present and the request errors out.
         func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-            if let anchor = presentationAnchorProvider?() {
-                return anchor
-            }
+            if let inFlightPresentationAnchor { return inFlightPresentationAnchor }
+            if let anchor = resolvedPresentationAnchor() { return anchor }
+            preconditionFailure("Sign in with Apple presentation requested without an active window scene")
+        }
+
+        private func resolvedPresentationAnchor() -> ASPresentationAnchor? {
+            if let anchor = presentationAnchorProvider?() { return anchor }
+
             let active = UIApplication.shared.connectedScenes
                 .compactMap { $0 as? UIWindowScene }
                 .first { $0.activationState == .foregroundActive }
@@ -278,14 +292,13 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
                     ?? active.windows.first
                     ?? UIWindow(windowScene: active)
             }
-            let logger = Logger(subsystem: "com.offscript", category: "AppleSignin")
-            logger.error("Sign in with Apple requested without an active window scene; using detached fallback anchor")
-            return ASPresentationAnchor(frame: .zero)
+            return nil
         }
 
         func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
             guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
                 inFlightController = nil
+                inFlightPresentationAnchor = nil
                 onFailure("SIGN-IN RETURNED NO APPLE ID CREDENTIAL")
                 return
             }
@@ -300,6 +313,7 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
                     displayName: displayName.isEmpty ? nil : displayName
                 )
                 inFlightController = nil
+                inFlightPresentationAnchor = nil
                 Task { @MainActor in
                     AppSettings.cloudSyncEnabled = (await CloudKitAccountService.currentStatus()).allowsSync
                     onComplete()
@@ -312,6 +326,7 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
                     logger.error("Failed to persist Apple credential: \(error.localizedDescription, privacy: .public)")
                 }
                 inFlightController = nil
+                inFlightPresentationAnchor = nil
                 onFailure("SIGN-IN COULD NOT BE SAVED. TRY AGAIN.")
             }
         }
@@ -322,6 +337,7 @@ private struct SignInWithAppleButtonView: UIViewRepresentable {
             let logger = Logger(subsystem: "com.offscript", category: "AppleSignin")
             logger.error("Sign in with Apple failed: \(error.localizedDescription, privacy: .public)")
             inFlightController = nil
+            inFlightPresentationAnchor = nil
             onFailure("SIGN-IN FAILED. RETRY OR POWER ON WITHOUT SYNC.")
         }
     }


### PR DESCRIPTION
## Summary
- preflight Sign in with Apple for an active presentation anchor before starting authorization
- retain the resolved anchor for the in-flight authorization request
- remove the deprecated detached ASPresentationAnchor fallback that was warning in iOS 26 archives
- update the changelog

## Verification
- git diff --check
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' 2>&1 | tee /tmp/offscript-anchor-build.log; ! rg 'ASPresentationAnchor|deprecated' /tmp/offscript-anchor-build.log
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- Xcode MCP BuildProject passed