### PR TITLE
Require stronger evidence for discovery recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Changed — recommendation quality
 - **Explicit “more like this” and like signals now carry substantially more weight than passive completions** so recommendations follow intentional user feedback instead of feeling like generic completion-based ranking.
+- **Discovery genre matches now stay low-confidence until backed by local evidence** such as latest-episode tag overlap, topic matches, show affinity, or feed freshness, and genre-only WHY copy no longer claims local evidence.
 
 ### Fixed — onboarding, import, and sync UI honesty
 - **Settings and Sign in with Apple now log identity, iCloud, signal-profile, and Keychain OSStatus breadcrumbs** so TestFlight Settings crashes and Apple sign-in failures can be correlated to the failing subsystem.

--- a/OffScript/DiscoveryService.swift
+++ b/OffScript/DiscoveryService.swift
@@ -165,6 +165,7 @@ actor DiscoveryService {
         var score: Double = 0.0
         var explanations: [String] = []
         var signals: [RecommendationSignal] = []
+        var hasConcreteEvidence = false
 
         let titleLower = result.title.lowercased()
         let summaryLower = (result.summary ?? "").lowercased()
@@ -182,7 +183,7 @@ actor DiscoveryService {
             .compactMap { $0?.lowercased() })
         if let resultGenre = resultGenres.intersection(preferredGenresLower).sorted().first {
             score += 0.35
-            explanations.append("Matches your saved \(resultGenre) lane")
+            explanations.append("Explore \(resultGenre) podcasts")
             signals.append(RecommendationSignal(label: "source", value: "genre"))
             signals.append(RecommendationSignal(label: "lane", value: resultGenre))
         }
@@ -202,6 +203,7 @@ actor DiscoveryService {
             }
         }
         if !latestEpisodeMatchedTags.isEmpty {
+            hasConcreteEvidence = true
             let sample = latestEpisodeMatchedTags.prefix(2).joined(separator: ", ")
             explanations.insert("Latest episodes overlap your \(sample) signal", at: 0)
             signals.append(RecommendationSignal(label: "source", value: "latest episode"))
@@ -214,6 +216,7 @@ actor DiscoveryService {
                 signals.append(RecommendationSignal(label: "episode", value: Self.truncated(title, limit: 42)))
             }
         } else if !matchedTags.isEmpty {
+            hasConcreteEvidence = true
             let sample = matchedTags.prefix(2).joined(separator: ", ")
             explanations.append("Covers topics you like: \(sample)")
             signals.append(RecommendationSignal(label: "source", value: "taste tag"))
@@ -226,6 +229,7 @@ actor DiscoveryService {
             let titleWords = Set(titleLower.split(separator: " ").map(String.init))
             let overlap = showWords.intersection(titleWords)
             if !overlap.isEmpty {
+                hasConcreteEvidence = true
                 score += 0.10
                 explanations.append("Similar to shows you finish")
                 signals.append(RecommendationSignal(label: "source", value: "show affinity"))
@@ -237,9 +241,11 @@ actor DiscoveryService {
             let days = max(0, Date().timeIntervalSince(freshestEpisode) / 86_400)
             switch days {
             case ..<14:
+                hasConcreteEvidence = true
                 score += 0.08
                 signals.append(RecommendationSignal(label: "freshness", value: "active feed"))
             case ..<45:
+                hasConcreteEvidence = true
                 score += 0.04
                 signals.append(RecommendationSignal(label: "freshness", value: "recent feed"))
             default:
@@ -249,6 +255,10 @@ actor DiscoveryService {
 
         // Novelty baseline
         score += 0.05
+        signals.append(RecommendationSignal(label: "evidence", value: hasConcreteEvidence ? "local" : "catalog"))
+        if !hasConcreteEvidence {
+            score = min(score, 0.12)
+        }
 
         // Build final explanation
         let explanation: String

--- a/OffScript/RecommendationExplainer.swift
+++ b/OffScript/RecommendationExplainer.swift
@@ -107,7 +107,13 @@ enum RecommendationExplainer {
             return "Pairs with what is playing now"
         case "genre":
             if let lane = lookup["lane"], !lane.isEmpty {
+                if lookup["evidence"] != "local" {
+                    return "A \(lane) lane pick to sample"
+                }
                 return "A \(lane) lane pick with local evidence behind it"
+            }
+            if lookup["evidence"] != "local" {
+                return "A genre-lane pick to sample"
             }
             return "A genre-lane pick with local evidence behind it"
         case "fresh":

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1031,9 +1031,13 @@ struct OffScriptTests {
         let evidencedScore = DiscoveryService.score(result: evidenced, tasteProfile: tasteProfile, preview: preview)
 
         #expect(evidencedScore.score > genericScore.score)
+        #expect(genericScore.score <= 0.12)
+        #expect(genericScore.explanation == "Explore technology podcasts")
+        #expect(genericScore.signalTrace.contains(RecommendationSignal(label: "evidence", value: "catalog")))
         #expect(evidencedScore.explanation == "Latest episodes overlap your audio craft signal")
         #expect(evidencedScore.signalTrace.contains(RecommendationSignal(label: "source", value: "latest episode")))
         #expect(evidencedScore.signalTrace.contains(RecommendationSignal(label: "tags", value: "audio craft")))
+        #expect(evidencedScore.signalTrace.contains(RecommendationSignal(label: "evidence", value: "local")))
     }
 
     @Test
@@ -1160,7 +1164,8 @@ struct OffScriptTests {
             fallback: "Matches your selected technology lane",
             signals: [
                 RecommendationSignal(label: "source", value: "genre"),
-                RecommendationSignal(label: "lane", value: "technology")
+                RecommendationSignal(label: "lane", value: "technology"),
+                RecommendationSignal(label: "evidence", value: "local")
             ]
         )
 
@@ -1175,11 +1180,26 @@ struct OffScriptTests {
                 RecommendationSignal(label: "source", value: "genre"),
                 RecommendationSignal(label: "lane", value: "technology"),
                 RecommendationSignal(label: "source", value: "latest episode"),
-                RecommendationSignal(label: "tags", value: "audio craft")
+                RecommendationSignal(label: "tags", value: "audio craft"),
+                RecommendationSignal(label: "evidence", value: "local")
             ]
         )
 
         #expect(reason == "Latest episodes overlap your audio craft signal")
+    }
+
+    @Test
+    func recommendationExplainerDoesNotClaimLocalEvidenceForGenreOnlyDiscovery() {
+        let reason = RecommendationExplainer.authoredReason(
+            fallback: "Matches your selected technology lane",
+            signals: [
+                RecommendationSignal(label: "source", value: "genre"),
+                RecommendationSignal(label: "lane", value: "technology"),
+                RecommendationSignal(label: "evidence", value: "catalog")
+            ]
+        )
+
+        #expect(reason == "A technology lane pick to sample")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- cap genre-only discovery matches below results with actual local evidence
- mark discovery traces as catalog vs local evidence
- stop genre-only explainer copy from claiming local evidence
- add tests for catalog-only discovery scoring and explanation copy

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- Xcode MCP BuildProject passed