### PR TITLE
Avoid sorting onboarding episode relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Single-show adds from Home, Search, and pasted feed URLs now save the subscription before feed hydration**, then use a capped bootstrap sync in the background instead of blocking the UI on a full catalog import.
 - **Onboarding now stages selected starter shows in one SwiftData batch** instead of saving each selected podcast independently, making the three-podcast starter flow a single local commit before background hydration.
 - **Capped feed bootstrap now selects the newest episode slice without sorting full back catalogs**, so OPML and onboarding bootstrap paths do not pay full-feed sort cost when they only need the first few newest episodes.
+- **Onboarding preference seeding now fetches the newest hydrated episode with a one-row SwiftData query** instead of sorting the podcast's relationship collection after background sync.
 - **OPML batch hydration now uses a lightweight bootstrap pass** that imports only a small first slice of episodes and skips episode profile enrichment, avoiding thousands of episode/profile writes during the initial import.
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**
 - **Large-library scrolling no longer waits on per-show unplayed count churn by default.** Library now loads the aggregate unplayed count, fresh rail, and bounded in-progress rail first; exact per-show counts are deferred until `UNPLAYED` or `ATTN` directory modes need them.

--- a/OffScript/ImportProgressView.swift
+++ b/OffScript/ImportProgressView.swift
@@ -213,9 +213,10 @@ struct ImportProgressView: View {
         )
         for result in results {
             if result.isSuccess {
-                if let newestEpisode = result.podcast.episodes
-                    .sorted(by: { $0.pubDate > $1.pubDate })
-                    .first {
+                if let newestEpisode = OnboardingPreferenceSignalService.newestEpisode(
+                    for: result.podcast,
+                    in: modelContext
+                ) {
                     modelContext.insert(PreferenceSignal(action: .like, episode: newestEpisode))
                     modelContext.saveOrLog("OnboardingPreferenceSignal")
                 }
@@ -229,6 +230,19 @@ struct ImportProgressView: View {
                 importLogger.error("Onboarding background sync failed for \(result.podcast.feedURL, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
+}
+
+enum OnboardingPreferenceSignalService {
+    @MainActor
+    static func newestEpisode(for podcast: Podcast, in context: ModelContext) -> Episode? {
+        let podcastID = podcast.id
+        var descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { $0.podcast.id == podcastID },
+            sortBy: [SortDescriptor(\Episode.pubDate, order: .reverse)]
+        )
+        descriptor.fetchLimit = 1
+        return try? context.fetch(descriptor).first
     }
 }
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -2176,6 +2176,44 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func onboardingPreferenceSignalFetchesNewestEpisodeWithoutSortingRelationship() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let podcast = Podcast(title: "Onboarding Pick", feedURL: URL(string: "https://example.com/pick.xml")!)
+        let otherPodcast = Podcast(title: "Other Pick", feedURL: URL(string: "https://example.com/other.xml")!)
+        context.insert(podcast)
+        context.insert(otherPodcast)
+
+        let older = Episode(
+            title: "Older",
+            pubDate: Date(timeIntervalSince1970: 100),
+            audioURL: URL(string: "https://example.com/older.mp3")!,
+            podcast: podcast
+        )
+        let newest = Episode(
+            title: "Newest",
+            pubDate: Date(timeIntervalSince1970: 300),
+            audioURL: URL(string: "https://example.com/newest.mp3")!,
+            podcast: podcast
+        )
+        let otherNewest = Episode(
+            title: "Other Newest",
+            pubDate: Date(timeIntervalSince1970: 500),
+            audioURL: URL(string: "https://example.com/other-newest.mp3")!,
+            podcast: otherPodcast
+        )
+        context.insert(older)
+        context.insert(newest)
+        context.insert(otherNewest)
+        try context.save()
+
+        let selected = OnboardingPreferenceSignalService.newestEpisode(for: podcast, in: context)
+
+        #expect(selected?.id == newest.id)
+    }
+
+    @Test
+    @MainActor
     func feedSyncOnboardingBootstrapCapsEpisodesAndSkipsExpensiveEnrichment() async throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- Seed onboarding preference signals with a one-row SwiftData newest-episode query instead of sorting the podcast relationship collection after background sync.
- Add coverage that the selector returns the newest episode for the selected podcast without crossing podcast boundaries.
- Update the changelog under the current performance work.

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination platform=iOS\ Simulator,OS=latest,name=iPhone\ 17\ Pro -only-testing:OffScriptTests
- Xcode MCP BuildProject