### PR TITLE
Improve settings counts and tab rail chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Capped feed bootstrap now selects the newest episode slice without sorting full back catalogs**, so OPML and onboarding bootstrap paths do not pay full-feed sort cost when they only need the first few newest episodes.
 - **Onboarding preference seeding now fetches the newest hydrated episode with a one-row SwiftData query** instead of sorting the podcast's relationship collection after background sync.
 - **The Library directory now renders from a cached value snapshot instead of a live `@Query` podcast array**, reducing SwiftData invalidation churn while scrolling large subscribed libraries.
+- **Settings now uses a subscribed-show `fetchCount` instead of materializing the podcast table**, and the custom tab bar indicator now slides as one continuous Tuner rail.
 - **OPML batch hydration now uses a lightweight bootstrap pass** that imports only a small first slice of episodes and skips episode profile enrichment, avoiding thousands of episode/profile writes during the initial import.
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**
 - **Large-library scrolling no longer waits on per-show unplayed count churn by default.** Library now loads the aggregate unplayed count, fresh rail, and bounded in-progress rail first; exact per-show counts are deferred until `UNPLAYED` or `ATTN` directory modes need them.

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -169,7 +169,6 @@ struct ContentView: View {
 private struct TunerTabBar: View {
     @Binding var selection: AppTab
     let queueBadge: Int
-    @Namespace private var indicatorNamespace
 
     var body: some View {
         VStack(spacing: 0) {
@@ -177,23 +176,39 @@ private struct TunerTabBar: View {
                 .fill(Color.offscriptHairline)
                 .frame(height: 1)
 
-            HStack(spacing: 0) {
-                ForEach(AppTab.allCases) { tab in
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.22)) {
-                            selection = tab
+            GeometryReader { proxy in
+                let segmentWidth = max(proxy.size.width / CGFloat(AppTab.allCases.count), 1)
+                ZStack(alignment: .topLeading) {
+                    Rectangle()
+                        .fill(Color.offscriptSignalYellow)
+                        .frame(width: min(42, segmentWidth * 0.44), height: 1)
+                        .offset(
+                            x: segmentWidth * CGFloat(selection.rawValue)
+                                + (segmentWidth - min(42, segmentWidth * 0.44)) / 2,
+                            y: 0
+                        )
+                        .animation(.snappy(duration: 0.28, extraBounce: 0.08), value: selection.rawValue)
+                        .accessibilityHidden(true)
+
+                    HStack(spacing: 0) {
+                        ForEach(AppTab.allCases) { tab in
+                            Button {
+                                withAnimation(.snappy(duration: 0.28, extraBounce: 0.08)) {
+                                    selection = tab
+                                }
+                            } label: {
+                                tabContent(for: tab)
+                            }
+                            .buttonStyle(.plain)
+                            .frame(width: segmentWidth)
+                            .accessibilityLabel(tab.label.capitalized)
+                            .accessibilityAddTraits(selection == tab ? .isSelected : [])
                         }
-                    } label: {
-                        tabContent(for: tab)
                     }
-                    .buttonStyle(.plain)
-                    .frame(maxWidth: .infinity)
-                    .accessibilityLabel(tab.label.capitalized)
-                    .accessibilityAddTraits(selection == tab ? .isSelected : [])
                 }
+                .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
             }
-            .padding(.top, 6)
-            .padding(.bottom, 2)
+            .frame(height: 62)
             .background(Color.offscriptStudioBlack)
         }
         .sensoryFeedback(.selection, trigger: selection.rawValue)
@@ -229,17 +244,6 @@ private struct TunerTabBar: View {
         .padding(.vertical, 6)
         .frame(maxWidth: .infinity)
         .contentShape(Rectangle())
-        .overlay(alignment: .top) {
-            if isActive {
-                // 1px signal-yellow active indicator at the top of the cell —
-                // matches the function-coded eyebrow rules used everywhere else.
-                Rectangle()
-                    .fill(Color.offscriptSignalYellow)
-                    .frame(width: 36, height: 1)
-                    .offset(y: -6)
-                    .matchedGeometryEffect(id: "tuner-tab-indicator", in: indicatorNamespace)
-            }
-        }
     }
 }
 

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -10,7 +10,6 @@ private let settingsLogger = Logger(subsystem: "com.offscript", category: "Setti
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
-    @Query private var podcasts: [Podcast]
     @AppStorage("offscript.autoPlayNext") private var autoPlayNext = true
     @AppStorage("offscript.preferShortEpisodes") private var preferShortEpisodes = false
     @AppStorage("offscript.cloudSyncEnabled") private var cloudSyncEnabled = false
@@ -23,6 +22,7 @@ struct SettingsView: View {
     @State private var signInMessage: String?
     @State private var isDefaultRatePickerExpanded = false
 
+    @State private var subscribedPodcastCount: Int = 0
     @State private var episodeCount: Int = 0
     @State private var unplayedCount: Int = 0
     @State private var queuedCount: Int = 0
@@ -121,7 +121,7 @@ struct SettingsView: View {
 
     private var statsBlock: some View {
         HStack(spacing: 0) {
-            stat(label: "SUBSCRIBED", value: "\(podcasts.filter(\.isSubscribed).count)")
+            stat(label: "SUBSCRIBED", value: "\(subscribedPodcastCount)")
             divider
             stat(label: "EPISODES", value: "\(episodeCount)")
             divider
@@ -735,6 +735,7 @@ struct SettingsView: View {
 
     /// fetchCount-backed counts so Settings doesn't materialize the entire Episode table.
     private func refreshCounts() {
+        subscribedPodcastCount = SettingsCountService.subscribedPodcastCount(in: modelContext)
         episodeCount  = (try? modelContext.fetchCount(FetchDescriptor<Episode>())) ?? 0
         unplayedCount = (try? modelContext.fetchCount(
             FetchDescriptor<Episode>(predicate: #Predicate<Episode> { !$0.isPlayed })
@@ -742,6 +743,15 @@ struct SettingsView: View {
         queuedCount   = (try? modelContext.fetchCount(
             FetchDescriptor<Episode>(predicate: #Predicate<Episode> { $0.isQueued })
         )) ?? 0
-        settingsLogger.info("Settings counts refreshed: episodes=\(episodeCount, privacy: .public), unplayed=\(unplayedCount, privacy: .public), queued=\(queuedCount, privacy: .public)")
+        settingsLogger.info("Settings counts refreshed: subscribed=\(subscribedPodcastCount, privacy: .public), episodes=\(episodeCount, privacy: .public), unplayed=\(unplayedCount, privacy: .public), queued=\(queuedCount, privacy: .public)")
+    }
+}
+
+@MainActor
+enum SettingsCountService {
+    static func subscribedPodcastCount(in context: ModelContext) -> Int {
+        (try? context.fetchCount(
+            FetchDescriptor<Podcast>(predicate: #Predicate<Podcast> { $0.isSubscribed })
+        )) ?? 0
     }
 }

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1297,6 +1297,23 @@ struct OffScriptTests {
     }
 
     @Test
+    @MainActor
+    func settingsCountServiceCountsSubscribedPodcastsWithoutFetchingRows() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let first = Podcast(title: "First", feedURL: URL(string: "https://example.com/first.xml")!)
+        let second = Podcast(title: "Second", feedURL: URL(string: "https://example.com/second.xml")!)
+        let ignored = Podcast(title: "Ignored", feedURL: URL(string: "https://example.com/ignored.xml")!)
+        ignored.isSubscribed = false
+        context.insert(first)
+        context.insert(second)
+        context.insert(ignored)
+        try context.save()
+
+        #expect(SettingsCountService.subscribedPodcastCount(in: context) == 2)
+    }
+
+    @Test
     func libraryDirectoryOrganizerFiltersAndSortsLargeLibraries() {
         let stale = LibraryDirectoryPodcast(
             id: UUID(),


### PR DESCRIPTION
## Summary
- Remove the Settings live podcast query and use a subscribed-show fetchCount for the SUBSCRIBED stat.
- Move the custom tab indicator to a single animated rail over the full tab bar so it visibly slides between pages.
- Add coverage for the Settings subscribed count helper and update the changelog.

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination platform=iOS\ Simulator,OS=latest,name=iPhone\ 17\ Pro -only-testing:OffScriptTests
- Xcode MCP BuildProject