### PR TITLE
Constrain home rail recommendation reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Onboarding preference seeding now fetches the newest hydrated episode with a one-row SwiftData query** instead of sorting the podcast's relationship collection after background sync.
 - **The Library directory now renders from a cached value snapshot instead of a live `@Query` podcast array**, reducing SwiftData invalidation churn while scrolling large subscribed libraries.
 - **Settings now uses a subscribed-show `fetchCount` instead of materializing the podcast table**, and the custom tab bar indicator now slides as one continuous Tuner rail.
+- **Home rail cards now use compact Tuner reason tags and shorter signal traces**, keeping recommendation explanations inside narrow 168px cards.
 - **OPML batch hydration now uses a lightweight bootstrap pass** that imports only a small first slice of episodes and skips episode profile enrichment, avoiding thousands of episode/profile writes during the initial import.
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**
 - **Large-library scrolling no longer waits on per-show unplayed count churn by default.** Library now loads the aggregate unplayed count, fresh rail, and bounded in-progress rail first; exact per-show counts are deferred until `UNPLAYED` or `ATTN` directory modes need them.

--- a/OffScript/AppTheme.swift
+++ b/OffScript/AppTheme.swift
@@ -476,6 +476,28 @@ struct TunerTag: View {
     }
 }
 
+struct TunerRailReasonTag: View {
+    let text: String
+    var color: Color = .offscriptSignalYellow
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: CGFloat(7.8).offscriptScaled(), weight: .semibold, design: .monospaced))
+            .tracking(0.4)
+            .foregroundStyle(color.opacity(0.68))
+            .lineLimit(2)
+            .multilineTextAlignment(.leading)
+            .truncationMode(.tail)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2.5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .overlay(
+                Rectangle().stroke(color.opacity(0.32), lineWidth: 1)
+            )
+    }
+}
+
 struct RecommendationSignalTraceView: View {
     let signals: [RecommendationSignal]
     var limit: Int = 3

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -605,8 +605,8 @@ private struct TunerDiscoveryRail: View {
                 .multilineTextAlignment(.leading)
                 .frame(width: 168, alignment: .leading)
 
-            TunerTag(text: displayReason, color: .offscriptFnInfo, dim: true, wraps: true)
-            RecommendationSignalTraceView(signals: scored.signalTrace, limit: 2, color: .offscriptSoftPaper)
+            TunerRailReasonTag(text: displayReason, color: .offscriptFnInfo)
+            RecommendationSignalTraceView(signals: scored.signalTrace, limit: 1, color: .offscriptSoftPaper)
 
             Button {
                 Task { await add(scored.result) }
@@ -975,8 +975,8 @@ private struct TunerRailCard: View {
                         .multilineTextAlignment(.leading)
                         .frame(width: 168, alignment: .leading)
 
-                    TunerTag(text: displayReason, color: .offscriptSignalYellow, dim: true, wraps: true)
-                    RecommendationSignalTraceView(signals: signals, limit: 2, color: .offscriptSoftPaper)
+                    TunerRailReasonTag(text: displayReason, color: .offscriptSignalYellow)
+                    RecommendationSignalTraceView(signals: signals, limit: 1, color: .offscriptSoftPaper)
 
                     TunerLabel(text: metadata, color: .offscriptSoftPaper, size: 8)
                 }


### PR DESCRIPTION
## Summary
- Add a compact Tuner rail reason tag for narrow Home rail cards.
- Use the compact tag and a one-line signal trace in discovery and episode rail cards so recommendation text stays inside 168px cards.
- Update the changelog.

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination platform=iOS\ Simulator,OS=latest,name=iPhone\ 17\ Pro -only-testing:OffScriptTests
- Xcode MCP BuildProject