### PR TITLE
Normalize Tuner text tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **The Library directory now renders from a cached value snapshot instead of a live `@Query` podcast array**, reducing SwiftData invalidation churn while scrolling large subscribed libraries.
 - **Settings now uses a subscribed-show `fetchCount` instead of materializing the podcast table**, and the custom tab bar indicator now slides as one continuous Tuner rail.
 - **Home rail cards now use compact Tuner reason tags and shorter signal traces**, keeping recommendation explanations inside narrow 168px cards.
+- **Tuner typography no longer uses negative tracking in app-authored titles and cards**, improving compact-device fitting and keeping OLED text rhythm consistent.
 - **OPML batch hydration now uses a lightweight bootstrap pass** that imports only a small first slice of episodes and skips episode profile enrichment, avoiding thousands of episode/profile writes during the initial import.
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**
 - **Large-library scrolling no longer waits on per-show unplayed count churn by default.** Library now loads the aggregate unplayed count, fresh rail, and bounded in-progress rail first; exact per-show counts are deferred until `UNPLAYED` or `ATTN` directory modes need them.

--- a/OffScript/AppTheme.swift
+++ b/OffScript/AppTheme.swift
@@ -558,7 +558,7 @@ struct TunerReadout: View {
             HStack(alignment: .lastTextBaseline, spacing: 4) {
                 Text(value)
                     .font(.system(size: fontSize.offscriptScaled(.title1), weight: .light, design: .default))
-                    .tracking(-1)
+                    .tracking(0)
                     .foregroundStyle(Color.offscriptPaperWhite)
                     .monospacedDigit()
                 if let unit {

--- a/OffScript/CardComponents.swift
+++ b/OffScript/CardComponents.swift
@@ -67,7 +67,7 @@ struct EpisodeVerticalCard: View {
                 } label: {
                     Text(episode.title)
                         .font(.system(size: 14, weight: .semibold, design: .default))
-                        .tracking(-0.2)
+                        .tracking(0)
                         .foregroundStyle(Color.offscriptPaperWhite)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
@@ -227,7 +227,7 @@ struct EpisodeCompactCard: View {
 
                     Text(episode.title)
                         .font(.system(size: 13.5, weight: .semibold, design: .default))
-                        .tracking(-0.2)
+                        .tracking(0)
                         .foregroundStyle(Color.offscriptPaperWhite)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -126,7 +126,7 @@ struct EpisodeDetailView: View {
                     }
                     Text(episode.title)
                         .font(.system(size: 22, weight: .light, design: .default))
-                        .tracking(-0.4)
+                        .tracking(0)
                         .foregroundStyle(Color.offscriptPaperWhite)
                         .lineLimit(4)
                         .multilineTextAlignment(.leading)

--- a/OffScript/GenrePickerView.swift
+++ b/OffScript/GenrePickerView.swift
@@ -26,7 +26,7 @@ struct GenrePickerView: View {
 
                         Text("Pick your bands")
                             .font(.system(size: 32, weight: .bold, design: .default))
-                            .tracking(-0.6)
+                            .tracking(0)
                             .foregroundStyle(Color.offscriptPaperWhite)
                             .staggeredEntrance(index: 1)
 

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -222,7 +222,7 @@ private struct HomeTunerHeader: View {
                 // Big spec-sheet headline
                 Text("Home")
                     .font(.system(size: 32, weight: .bold))
-                    .tracking(-0.5)
+                    .tracking(0)
                     .foregroundStyle(Color.offscriptPaperWhite)
 
                 Spacer()
@@ -326,7 +326,7 @@ private struct HomeStarterRail: View {
             }
             Text("Pick a few well-liked channels")
                 .font(.system(size: 22, weight: .semibold))
-                .tracking(-0.3)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
             Text("These are widely-loved podcasts to seed your library. Subscribe to a few that look interesting — OffScript will start tailoring your feed once it has signal to work with.")
                 .font(.system(size: 13))
@@ -451,7 +451,7 @@ private struct HomeEmptyState: View {
             TunerLabel(text: "● NO CHANNELS TUNED", color: .offscriptFnInfo)
             Text("Add three shows you trust")
                 .font(.system(size: 22, weight: .semibold))
-                .tracking(-0.3)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
             Text("OffScript will build a feed that feels curated, not algorithmic. Open Search to find your first three.")
                 .font(.system(size: 13.5))
@@ -703,7 +703,7 @@ private struct HeroTunerCard: View {
                 } label: {
                     Text(episode.title)
                         .font(.system(size: 20, weight: .semibold))
-                        .tracking(-0.3)
+                        .tracking(0)
                         .foregroundStyle(Color.offscriptPaperWhite)
                         .multilineTextAlignment(.leading)
                         .lineLimit(3)

--- a/OffScript/ImportProgressView.swift
+++ b/OffScript/ImportProgressView.swift
@@ -44,7 +44,7 @@ struct ImportProgressView: View {
 
                 Text(headerTitle)
                     .font(.system(size: 32, weight: .bold))
-                    .tracking(-0.5)
+                    .tracking(0)
                     .foregroundStyle(Color.offscriptPaperWhite)
 
                 Text(headerCopy)

--- a/OffScript/LibraryImportSheet.swift
+++ b/OffScript/LibraryImportSheet.swift
@@ -138,7 +138,7 @@ struct LibraryImportSheet: View {
             TunerLabel(text: "● PICK A SOURCE", color: .offscriptFnInfo)
             Text("Bring shows in by URL or OPML")
                 .font(.system(size: 16, weight: .semibold))
-                .tracking(-0.2)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
             Text("Paste a podcast feed URL to add a single show, or pick an OPML file exported from another podcast app to bring everything across at once.")
                 .font(.system(size: 13))
@@ -213,7 +213,7 @@ struct LibraryImportSheet: View {
             TunerLabel(text: "● FEED URL", color: .offscriptSignalYellow)
             Text("Paste a podcast feed URL")
                 .font(.system(size: 16, weight: .semibold))
-                .tracking(-0.2)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
 
             HStack(spacing: 10) {
@@ -290,7 +290,7 @@ struct LibraryImportSheet: View {
 
             Text("Found \(entries.count) feed\(entries.count == 1 ? "" : "s")")
                 .font(.system(size: 16, weight: .semibold))
-                .tracking(-0.2)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
 
             // Hint that import keeps running after the sheet closes — the

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -689,7 +689,7 @@ struct LibraryView: View {
             TunerLabel(text: "● NO CHANNELS TUNED", color: .offscriptFnInfo)
             Text("Your library is empty")
                 .font(.system(size: 22, weight: .semibold))
-                .tracking(-0.3)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
             Text("Use Search to bring in shows. OffScript keeps them fresh here once you subscribe.")
                 .font(.system(size: 13.5))
@@ -1766,7 +1766,7 @@ private struct PodcastDetailTunerHeader: View {
 
             Text(podcast.title)
                 .font(.system(size: 26, weight: .semibold))
-                .tracking(-0.4)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
                 .lineSpacing(2)
 

--- a/OffScript/OnboardingFlowView.swift
+++ b/OffScript/OnboardingFlowView.swift
@@ -98,7 +98,7 @@ struct OnboardingFlowView: View {
                     }
                 }
                 .font(.system(size: 56, weight: .bold, design: .default))
-                .tracking(-2)
+                .tracking(0)
                 .staggeredEntrance(index: 1, delay: 0.10)
 
                 TunerLabel(text: "A RECEIVER FOR WHAT YOU ACTUALLY LIKE", size: 10)

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -152,7 +152,7 @@ struct PlayerView: View {
     private func titleBlock(episode: Episode) -> some View {
         Text(episode.title)
             .font(.system(size: 22, weight: .semibold))
-            .tracking(-0.4)
+            .tracking(0)
             .foregroundStyle(Color.offscriptPaperWhite)
             .lineSpacing(2)
             .fixedSize(horizontal: false, vertical: true)

--- a/OffScript/PodcastPickerView.swift
+++ b/OffScript/PodcastPickerView.swift
@@ -45,7 +45,7 @@ struct PodcastPickerView: View {
                         TunerLabel(text: "02 · CHANNELS", color: .offscriptSignalYellow, size: 10)
                         Text("Tune the bank")
                             .font(.system(size: 32, weight: .bold, design: .default))
-                            .tracking(-0.6)
+                            .tracking(0)
                             .foregroundStyle(Color.offscriptPaperWhite)
                         Text("PICK 3+ CHANNELS · 2+ BANDS · WE'LL LEARN FROM HERE")
                             .font(.system(size: 9, weight: .semibold, design: .monospaced))
@@ -225,7 +225,7 @@ private struct OnboardingPodcastCard: View {
 
                 Text(podcast.title)
                     .font(.system(size: 11, weight: .semibold, design: .default))
-                    .tracking(-0.1)
+                    .tracking(0)
                     .foregroundStyle(Color.offscriptPaperWhite)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)

--- a/OffScript/QueueView.swift
+++ b/OffScript/QueueView.swift
@@ -61,7 +61,7 @@ struct QueueView: View {
             TunerLabel(text: "● QUEUE EMPTY", color: .offscriptSoftPaper)
             Text("Nothing queued yet")
                 .font(.system(size: 22, weight: .semibold))
-                .tracking(-0.3)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
             Text("This is your working set, not a backlog. Queue a few episodes you actually plan to hear next.")
                 .font(.system(size: 13.5))
@@ -165,7 +165,7 @@ private struct QueueTunerHeader: View {
 
             Text("Queue")
                 .font(.system(size: 32, weight: .bold))
-                .tracking(-0.5)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
 
             if let totalDuration {
@@ -212,7 +212,7 @@ private struct QueueLeadStrip: View {
                         .lineLimit(1)
                     Text(item.episode.title)
                         .font(.system(size: 16, weight: .semibold))
-                        .tracking(-0.2)
+                        .tracking(0)
                         .foregroundStyle(Color.offscriptPaperWhite)
                         .lineLimit(3)
                 }

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -269,7 +269,7 @@ private struct SearchTunerHeader: View {
             }
             Text("Search")
                 .font(.system(size: 32, weight: .bold))
-                .tracking(-0.5)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
             Rectangle().fill(Color.offscriptHairline).frame(height: 1)
                 .padding(.top, 4)
@@ -283,7 +283,7 @@ private struct SearchPromptStrip: View {
             TunerLabel(text: "● TUNING TIP", color: .offscriptFnInfo)
             Text("Three strong inputs")
                 .font(.system(size: 16, weight: .semibold))
-                .tracking(-0.2)
+                .tracking(0)
                 .foregroundStyle(Color.offscriptPaperWhite)
             Text("Search uses Apple Podcasts results and imports RSS feeds. Exact show or host names work best; topics are broader catalog scans.")
                 .font(.system(size: 13))


### PR DESCRIPTION
## Summary
- Remove remaining negative tracking from app-authored SwiftUI text surfaces.
- Keep titles, cards, onboarding, picker, import, player, queue, search, and shared card typography aligned with the zero-tracking Tuner/OLED rule.
- Update the changelog.

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination platform=iOS\ Simulator,OS=latest,name=iPhone\ 17\ Pro -only-testing:OffScriptTests
- Xcode MCP BuildProject