### PR TITLE
Frame Apple sign-in in Tuner identity panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Settings now uses a subscribed-show `fetchCount` instead of materializing the podcast table**, and the custom tab bar indicator now slides as one continuous Tuner rail.
 - **Home rail cards now use compact Tuner reason tags and shorter signal traces**, keeping recommendation explanations inside narrow 168px cards.
 - **Tuner typography no longer uses negative tracking in app-authored titles and cards**, improving compact-device fitting and keeping OLED text rhythm consistent.
+- **Settings now frames Sign in with Apple inside an authored Tuner identity panel** with compact credential and iCloud readouts while preserving Apple's native authorization button.
 - **OPML batch hydration now uses a lightweight bootstrap pass** that imports only a small first slice of episodes and skips episode profile enrichment, avoiding thousands of episode/profile writes during the initial import.
 - **The root Library podcast query now filters subscribed shows in SwiftData instead of fetching every historical podcast and filtering in Swift.**
 - **Large-library scrolling no longer waits on per-show unplayed count churn by default.** Library now loads the aggregate unplayed count, fresh rail, and bounded in-progress rail first; exact per-show counts are deferred until `UNPLAYED` or `ATTN` directory modes need them.

--- a/OffScript/AppleIdentityService.swift
+++ b/OffScript/AppleIdentityService.swift
@@ -24,6 +24,17 @@ enum AppleCredentialValidationState: Equatable {
         case .unknown: "APPLE ID · UNKNOWN"
         }
     }
+
+    var shortLabel: String {
+        switch self {
+        case .signedOut: "SIGNED OUT"
+        case .authorized: "VERIFIED"
+        case .revoked: "REVOKED"
+        case .notFound: "NOT FOUND"
+        case .transferred: "TRANSFERRED"
+        case .unknown: "UNKNOWN"
+        }
+    }
 }
 
 enum CloudKitAccountAvailability: Equatable {
@@ -46,6 +57,17 @@ enum CloudKitAccountAvailability: Equatable {
         case .couldNotDetermine: "ICLOUD · UNKNOWN"
         case .temporarilyUnavailable: "ICLOUD · TEMPORARY ISSUE"
         case .notConfigured: "ICLOUD · NOT CONFIGURED"
+        }
+    }
+
+    var shortLabel: String {
+        switch self {
+        case .available: "AVAILABLE"
+        case .noAccount: "NO ACCOUNT"
+        case .restricted: "RESTRICTED"
+        case .couldNotDetermine: "UNKNOWN"
+        case .temporarilyUnavailable: "TEMP ISSUE"
+        case .notConfigured: "NOT CONFIG"
         }
     }
 }

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -493,28 +493,7 @@ struct SettingsView: View {
                     }
                 }
             } else {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Sign in with Apple identifies this install. iCloud availability is checked separately before sync is enabled.")
-                        .font(.system(size: 13))
-                        .foregroundStyle(Color.offscriptPaperWhite)
-
-                    SignInWithAppleButton(.signIn) { request in
-                        request.requestedScopes = [.fullName]
-                    } onCompletion: { result in
-                        handleSignInResult(result)
-                    }
-                    .signInWithAppleButtonStyle(.whiteOutline)
-                    .frame(height: 48)
-
-                    if let signInMessage {
-                        Text(signInMessage)
-                            .font(.system(size: 11))
-                            .foregroundStyle(Color.offscriptSoftPaper)
-                            .transition(.opacity)
-                    }
-
-                    identityStatusRows
-                }
+                signInPanel
             }
         }
         .padding(.vertical, 12)
@@ -523,6 +502,56 @@ struct SettingsView: View {
             Rectangle().fill(Color.offscriptHairline).frame(height: 1),
             alignment: .top
         )
+    }
+
+    private var signInPanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                TunerLabel(text: "○ APPLE ID", color: .offscriptSoftPaper)
+                Spacer()
+                TunerLabel(text: cloudKitAvailability.allowsSync ? "ICLOUD READY" : "LOCAL MODE", color: cloudKitAvailability.allowsSync ? .offscriptFnMode : .offscriptSoftPaper, size: 8)
+            }
+
+            Text("Sign in with Apple identifies this install. iCloud availability is checked separately before sync is enabled.")
+                .font(.system(size: 13))
+                .foregroundStyle(Color.offscriptPaperWhite.opacity(0.82))
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                identityReadout(label: "CREDENTIAL", value: appleCredentialState.shortLabel, isReady: appleCredentialState.isAuthorized)
+                Rectangle().fill(Color.offscriptHairline).frame(width: 1, height: 34)
+                identityReadout(label: "CLOUD", value: cloudKitAvailability.shortLabel, isReady: cloudKitAvailability.allowsSync)
+            }
+
+            SignInWithAppleButton(.signIn) { request in
+                request.requestedScopes = [.fullName]
+            } onCompletion: { result in
+                handleSignInResult(result)
+            }
+            .signInWithAppleButtonStyle(.whiteOutline)
+            .frame(height: 48)
+            .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+
+            if let signInMessage {
+                Text(signInMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.offscriptSoftPaper)
+                    .transition(.opacity)
+            }
+        }
+        .padding(12)
+        .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+    }
+
+    private func identityReadout(label: String, value: String, isReady: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            TunerLabel(text: label, color: .offscriptSoftPaper, size: 8)
+            TunerLabel(text: value, color: isReady ? .offscriptFnMode : .offscriptSignalYellow, size: 9)
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var identityStatusRows: some View {


### PR DESCRIPTION
## Summary
- wrap signed-out Settings identity controls in an authored Tuner panel
- add compact Apple credential and iCloud short labels for the panel readouts
- keep Apple's native Sign in with Apple authorization button intact inside the Tuner frame

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- Xcode MCP BuildProject