### PR TITLE
Clarify Library alphabet carousel selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Large libraries default to compact rows.** Artwork-heavy rows remain available for smaller libraries, but 120+ show libraries automatically use dense Tuner rows to reduce scroll distance and image/layout churn.
 - **The alphabet jump rail is now a full A-Z/# key bank with selected and disabled states** so large libraries expose every directory letter as a direct Tuner control instead of hiding letters in a horizontal strip.
 - **The Library alphabet selector is back to the compact `#-Z` carousel form** while keeping the working direct-letter jump behavior and selected/disabled Tuner states.
+- **Sparse Library alphabet keys now stay visually selectable when they jump to the nearest available section**, and the carousel highlights the key the listener chose instead of only the section it landed on.
 
 ### Changed — Library performance
 - **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -513,6 +513,7 @@ struct LibraryView: View {
     @State private var directorySort: LibraryDirectorySort = .title
     @State private var directoryDensity: LibraryDirectoryDensity = .compact
     @State private var selectedDirectorySectionID: String?
+    @State private var selectedDirectoryKey: String?
     @State private var inProgressEpisodes: [Episode] = []
     @State private var inProgressEpisodeCount = 0
     @State private var freshInProgressCountsByPodcastID: [UUID: Int] = [:]
@@ -765,8 +766,10 @@ struct LibraryView: View {
 
                 LibraryAlphabetRail(
                     sections: snapshot.sections,
-                    selectedSectionID: selectedDirectorySectionID
-                ) { sectionID in
+                    selectedSectionID: selectedDirectorySectionID,
+                    selectedKey: selectedDirectoryKey
+                ) { key, sectionID in
+                    selectedDirectoryKey = key
                     selectedDirectorySectionID = sectionID
                     withAnimation(.easeInOut(duration: 0.2)) {
                         scrollProxy.scrollTo(sectionID, anchor: .top)
@@ -1299,7 +1302,8 @@ private struct LibraryDirectoryControls: View {
 private struct LibraryAlphabetRail: View {
     let sections: [LibraryDirectorySection]
     let selectedSectionID: String?
-    let onSelect: (String) -> Void
+    let selectedKey: String?
+    let onSelect: (String, String) -> Void
 
     private let keys = ["#"] + (UnicodeScalar("A").value...UnicodeScalar("Z").value).compactMap { value in
         UnicodeScalar(value).map { String($0) }
@@ -1316,22 +1320,23 @@ private struct LibraryAlphabetRail: View {
                     ForEach(keys, id: \.self) { key in
                         let section = sectionsByTitle[key]
                         let targetSectionID = LibraryDirectoryOrganizer.sectionIDForAlphabetKey(key, sections: sections)
-                        let isSelected = selectedSectionID == section?.id
+                        let isNearestJump = section == nil && targetSectionID != nil
+                        let isSelected = selectedKey == key || (selectedKey == nil && selectedSectionID == section?.id)
 
                         if let targetSectionID {
                             Button {
-                                onSelect(targetSectionID)
+                                onSelect(key, targetSectionID)
                             } label: {
-                                letterKey(key, isSelected: isSelected, isDisabled: section == nil)
+                                letterKey(key, isSelected: isSelected, isNearestJump: isNearestJump, isReachable: true)
                             }
                             .id(key)
                             .buttonStyle(.plain)
                             .accessibilityElement(children: .ignore)
-                            .accessibilityLabel(section == nil ? "Jump near \(key)" : "Jump to \(key)")
+                            .accessibilityLabel(isNearestJump ? "Jump near \(key)" : "Jump to \(key)")
                             .accessibilityIdentifier("LibraryJumpLetter\(key)")
                             .accessibilityAddTraits(isSelected ? .isSelected : [])
                         } else {
-                            letterKey(key, isSelected: false, isDisabled: true)
+                            letterKey(key, isSelected: false, isNearestJump: false, isReachable: false)
                                 .id(key)
                                 .accessibilityLabel("No \(key) channels")
                                 .accessibilityIdentifier("LibraryJumpLetter\(key)")
@@ -1341,8 +1346,9 @@ private struct LibraryAlphabetRail: View {
                 }
                 .padding(.vertical, 4)
                 .onChange(of: selectedSectionID) { _, newValue in
-                    guard let newValue,
-                          let key = sectionsByTitle.first(where: { $0.value.id == newValue })?.key else { return }
+                    guard let key = selectedKey ?? newValue.flatMap({ selectedSectionID in
+                        sectionsByTitle.first(where: { $0.value.id == selectedSectionID })?.key
+                    }) else { return }
                     withAnimation(.easeInOut(duration: 0.18)) {
                         proxy.scrollTo(key, anchor: .center)
                     }
@@ -1352,22 +1358,37 @@ private struct LibraryAlphabetRail: View {
         }
     }
 
-    private func letterKey(_ key: String, isSelected: Bool, isDisabled: Bool) -> some View {
+    private func letterKey(
+        _ key: String,
+        isSelected: Bool,
+        isNearestJump: Bool,
+        isReachable: Bool
+    ) -> some View {
         Text(key)
             .font(.system(size: 10, weight: .semibold, design: .monospaced))
-            .foregroundStyle(isDisabled ? Color.offscriptTextMuted : Color.offscriptSignalYellow)
+            .foregroundStyle(letterColor(isSelected: isSelected, isNearestJump: isNearestJump, isReachable: isReachable))
             .frame(width: 30, height: 30)
-            .background(isSelected ? Color.offscriptSignalYellow.opacity(0.14) : Color.clear)
+            .background(isSelected ? Color.offscriptSignalYellow.opacity(0.16) : Color.clear)
             .overlay(
                 Rectangle()
                     .stroke(
-                        isSelected ? Color.offscriptSignalYellow : Color.offscriptHairline,
+                        isSelected ? Color.offscriptSignalYellow : (isNearestJump ? Color.offscriptSoftPaper.opacity(0.72) : Color.offscriptHairline),
                         lineWidth: isSelected ? 1.5 : 1
                     )
             )
             .frame(minWidth: 44, minHeight: 44)
             .contentShape(Rectangle())
-            .opacity(isDisabled ? 0.42 : 1)
+            .opacity(isReachable ? 1 : 0.42)
+    }
+
+    private func letterColor(
+        isSelected: Bool,
+        isNearestJump: Bool,
+        isReachable: Bool
+    ) -> Color {
+        guard isReachable else { return .offscriptTextMuted }
+        if isSelected { return .offscriptSignalYellow }
+        return isNearestJump ? .offscriptSoftPaper : .offscriptSignalYellow
     }
 }
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1384,15 +1384,18 @@ struct OffScriptTests {
 
     @Test
     func libraryAlphabetRailTargetsNearestAvailableSection() {
+        let numeric = LibraryDirectoryPodcast(id: UUID(), title: "99 Invisible")
         let alpha = LibraryDirectoryPodcast(id: UUID(), title: "Audio Craft")
         let delta = LibraryDirectoryPodcast(id: UUID(), title: "Delta Feed")
         let zeta = LibraryDirectoryPodcast(id: UUID(), title: "Zeta Waves")
         let sections = LibraryDirectoryOrganizer.sections(for: [zeta, alpha, delta])
+        let sectionsWithNumbers = LibraryDirectoryOrganizer.sections(for: [zeta, numeric, alpha, delta])
 
         #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("A", sections: sections) == "library-section-A")
         #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("B", sections: sections) == "library-section-D")
         #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("Y", sections: sections) == "library-section-Z")
         #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("#", sections: sections) == "library-section-A")
+        #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("#", sections: sectionsWithNumbers) == "library-section-#")
         #expect(LibraryDirectoryOrganizer.sectionIDForAlphabetKey("M", sections: []) == nil)
     }
 


### PR DESCRIPTION
## Summary
- keep sparse alphabet keys visually selectable when they jump to the nearest available section
- track the chosen carousel key separately from the landed section so the selected key stays highlighted
- add numeric-section coverage for # alphabet targeting

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testLargeLibraryAlphabetRailJumpsToSelectedLetter
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'

Note: Xcode MCP BuildProject could not run because the MCP reported no open workspace windows; command-line Xcode build succeeded as fallback.