### PR TITLE
Remove empty navigation hosts from Tuner sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **The alphabet jump rail is now a full A-Z/# key bank with selected and disabled states** so large libraries expose every directory letter as a direct Tuner control instead of hiding letters in a horizontal strip.
 - **The Library alphabet selector is back to the compact `#-Z` carousel form** while keeping the working direct-letter jump behavior and selected/disabled Tuner states.
 - **Sparse Library alphabet keys now stay visually selectable when they jump to the nearest available section**, and the carousel highlights the key the listener chose instead of only the section it landed on.
+- **Settings and Library import sheets no longer sit inside empty native navigation hosts**, reducing stray iOS navigation chrome while keeping the authored Tuner headers and inline DONE keys.
 
 ### Changed — Library performance
 - **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.

--- a/OffScript/LibraryImportSheet.swift
+++ b/OffScript/LibraryImportSheet.swift
@@ -53,43 +53,34 @@ struct LibraryImportSheet: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Color.offscriptStudioBlack.ignoresSafeArea()
+        ZStack {
+            Color.offscriptStudioBlack.ignoresSafeArea()
 
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 18) {
-                        header
-                        switch mode {
-                        case .menu: menuBody
-                        case .pasteURL: pasteURLBody
-                        case .opml(let entries): opmlBody(entries: entries)
-                        }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    switch mode {
+                    case .menu: menuBody
+                    case .pasteURL: pasteURLBody
+                    case .opml(let entries): opmlBody(entries: entries)
                     }
-                    .padding(.horizontal, OffScriptTheme.pagePadding)
-                    .padding(.top, OffScriptTheme.modalContentTopPadding)
-                    .padding(.bottom, 90)
                 }
+                .padding(.horizontal, OffScriptTheme.pagePadding)
+                .padding(.top, OffScriptTheme.modalContentTopPadding)
+                .padding(.bottom, 90)
             }
-            // No `.toolbar` ToolbarItem — iOS 26 wraps toolbar buttons in
-            // glass chrome. DONE key is rendered inline inside `header`.
-            .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .navigationTitle("")
-            .navigationBarTitleDisplayMode(.inline)
-            .fileImporter(
-                isPresented: $opmlFilePresenting,
-                allowedContentTypes: [.opml, .xml, .data],
-                allowsMultipleSelection: false
-            ) { result in
-                handleOPMLPicked(result)
-            }
-            .sheet(isPresented: $isExportShareSheetPresented) {
-                if let exportFileURL {
-                    ShareSheet(items: [exportFileURL])
-                        .tunerModalSurface()
-                }
+        }
+        .fileImporter(
+            isPresented: $opmlFilePresenting,
+            allowedContentTypes: [.opml, .xml, .data],
+            allowsMultipleSelection: false
+        ) { result in
+            handleOPMLPicked(result)
+        }
+        .sheet(isPresented: $isExportShareSheetPresented) {
+            if let exportFileURL {
+                ShareSheet(items: [exportFileURL])
+                    .tunerModalSurface()
             }
         }
         .preferredColorScheme(.dark)

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -42,40 +42,30 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    settingsHeader
-                    statsBlock
-                    playbackSection
-                    recommendationSection
-                    signalProfileSection
-                    iCloudSection
-                    aboutSection
-                }
-                .padding(.horizontal, OffScriptTheme.pagePadding)
-                .padding(.top, OffScriptTheme.modalContentTopPadding)
-                .padding(.bottom, 32)
-                .frame(maxWidth: 720, alignment: .leading)
-                .frame(maxWidth: .infinity, alignment: .center)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                settingsHeader
+                statsBlock
+                playbackSection
+                recommendationSection
+                signalProfileSection
+                iCloudSection
+                aboutSection
             }
-            .background(Color.offscriptStudioBlack.ignoresSafeArea())
-            .navigationTitle("")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .task {
-                settingsLogger.info("Settings task started")
-                refreshCounts()
-                refreshSignInState()
-                refreshSignalProfile()
-                await refreshIdentityStatus()
-                settingsLogger.info("Settings task completed: episodes=\(episodeCount, privacy: .public), queued=\(queuedCount, privacy: .public), signedIn=\(isSignedIn, privacy: .public), apple=\(appleCredentialState.displayText, privacy: .public), iCloud=\(cloudKitAvailability.displayText, privacy: .public)")
-            }
-            // No `.toolbar` ToolbarItem — iOS 26 wraps toolbar buttons in
-            // glass-capsule chrome that ignores .plain styling. DONE key
-            // moved inline into `settingsHeader` below.
+            .padding(.horizontal, OffScriptTheme.pagePadding)
+            .padding(.top, OffScriptTheme.modalContentTopPadding)
+            .padding(.bottom, 32)
+            .frame(maxWidth: 720, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .background(Color.offscriptStudioBlack.ignoresSafeArea())
+        .task {
+            settingsLogger.info("Settings task started")
+            refreshCounts()
+            refreshSignInState()
+            refreshSignalProfile()
+            await refreshIdentityStatus()
+            settingsLogger.info("Settings task completed: episodes=\(episodeCount, privacy: .public), queued=\(queuedCount, privacy: .public), signedIn=\(isSignedIn, privacy: .public), apple=\(appleCredentialState.displayText, privacy: .public), iCloud=\(cloudKitAvailability.displayText, privacy: .public)")
         }
     }
 

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -66,7 +66,7 @@ final class OffScriptUITests: XCTestCase {
         let settingsLabel = app.staticTexts["SETTINGS · CONFIG PANEL"]
         XCTAssertTrue(settingsLabel.waitForExistence(timeout: 12), "Settings panel did not appear. Hierarchy:\n\(app.debugDescription)")
         XCTAssertTrue(app.staticTexts.containing(labelContaining: "258").waitForExistence(timeout: 12), "Settings counts did not reflect seeded library. Hierarchy:\n\(app.debugDescription)")
-        XCTAssertTrue(app.staticTexts["ICLOUD · NOT CONFIGURED"].waitForExistence(timeout: 8), "Simulator Settings should report missing iCloud entitlements without crashing. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.staticTexts["NOT CONFIG"].waitForExistence(timeout: 8), "Simulator Settings should report missing iCloud entitlements without crashing. Hierarchy:\n\(app.debugDescription)")
         XCTAssertTrue(app.buttons["Close settings"].waitForExistence(timeout: 5))
     }
 


### PR DESCRIPTION
## Summary
- remove unused NavigationStack wrappers from Settings and Library import sheets
- keep authored Tuner headers, inline DONE controls, file importer, and share sheet behavior intact
- update Settings UI smoke to assert the current compact iCloud fallback readout

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testSettingsPanelOpensWithLargeLibrarySeed -only-testing:OffScriptUITests/OffScriptUITests/testLargeLibrarySeedSmoke
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'