### PR TITLE
Use Tuner inline back chrome on detail screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Large Library sections now render as flattened lazy headers, rows, and separators** so a 250+ show directory does not build an entire oversized letter section as one SwiftUI child.
 - **The Library directory now renders from value snapshots instead of live SwiftData podcast models** so 250+ show scrolling does less model work and only resolves a show when a row is opened.
 - **Home retune and Library sync now use explicit Tuner header keys instead of native pull-to-refresh chrome**, removing another app-controlled Liquid Glass surface while keeping refresh actions discoverable.
+- **Podcast and episode detail pushes now use inline Tuner back keys** so Library and Home drill-down flows no longer fall back to native iOS back-button chrome.
 
 ### Changed — recommendation quality
 - **Explicit “more like this” and like signals now carry substantially more weight than passive completions** so recommendations follow intentional user feedback instead of feeling like generic completion-based ranking.

--- a/OffScript/AppTheme.swift
+++ b/OffScript/AppTheme.swift
@@ -528,9 +528,34 @@ struct RecommendationSignalTraceView: View {
     }
 }
 
-/// Ring meter — colored arc on a hairline base. value 0…1; glyph is the
-/// optical-center text (e.g. "34%", "1.2×", "OFF", "−6"); units optionally sit
-/// inside the ring. Built so a row of meters shares one optical baseline.
+/// Inline navigation key for pushed Tuner detail screens. The visible control
+/// stays compact, but the outer frame preserves a 44pt hit target.
+struct TunerInlineBackButton: View {
+    let label: String
+    let accessibilityLabel: String
+    let accessibilityIdentifier: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 11, weight: .bold))
+                TunerLabel(text: label, color: .offscriptSignalYellow, size: 10)
+            }
+            .foregroundStyle(Color.offscriptSignalYellow)
+            .padding(.horizontal, 10)
+            .frame(height: 32)
+            .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+            .frame(minWidth: 44, minHeight: 44, alignment: .center)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}
+
 // TunerRingMeter, TunerTrace, TunerTransportButton, TunerModeToggle,
 // TunerArtworkTile were defined for the design spec but never composed
 // into any actual screen. The Player built its own transport row, the

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -18,6 +18,7 @@ import SwiftUI
 //   └───────────────────────────────────────────────────┘
 
 struct EpisodeDetailView: View {
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @ObservedObject private var player = PlaybackController.shared
     @ObservedObject private var downloadService = DownloadService.shared
@@ -48,6 +49,14 @@ struct EpisodeDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 22) {
+                TunerInlineBackButton(
+                    label: "BACK",
+                    accessibilityLabel: "Back to previous screen",
+                    accessibilityIdentifier: "EpisodeDetailBackButton"
+                ) {
+                    dismiss()
+                }
+
                 specHeader
                 hero
                 if progressValue > 0, !episode.isPlayed {
@@ -74,8 +83,10 @@ struct EpisodeDetailView: View {
             .padding(.bottom, 28)
         }
         .background(Color.offscriptStudioBlack.ignoresSafeArea())
+        .accessibilityIdentifier("EpisodeDetailScreen")
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -1591,6 +1591,7 @@ private struct LibraryDirectoryMissingShowView: View {
 // MARK: - PodcastDetailView (Tuner channel detail)
 
 struct PodcastDetailView: View {
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     let podcast: Podcast
     @State private var filter: EpisodeFilter = .all
@@ -1609,6 +1610,14 @@ struct PodcastDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
+                TunerInlineBackButton(
+                    label: "BACK",
+                    accessibilityLabel: "Back to library",
+                    accessibilityIdentifier: "PodcastDetailBackButton"
+                ) {
+                    dismiss()
+                }
+
                 PodcastDetailTunerHeader(podcast: podcast, episodeCount: matchingEpisodeCount)
 
                 // Custom Tuner search input — `.searchable()` renders a system
@@ -1677,8 +1686,10 @@ struct PodcastDetailView: View {
             .padding(.bottom, 90)
         }
         .background(Color.offscriptStudioBlack.ignoresSafeArea())
+        .accessibilityIdentifier("PodcastDetailScreen")
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -136,6 +136,35 @@ final class OffScriptUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["A Channel 001"].waitForExistence(timeout: 10))
     }
 
+    @MainActor
+    func testTunerDetailScreensUseInlineBackChrome() throws {
+        let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 4, debugEpisodesPerShow: 2, debugLaunchTab: 1)
+        app.launch()
+
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 12))
+        XCTAssertTrue(app.staticTexts["SHOWS · DIRECTORY"].waitForExistence(timeout: 8))
+
+        for _ in 0..<3 where !app.staticTexts["A Channel 001"].exists {
+            app.swipeUp()
+        }
+        tapWhenReady(app.staticTexts["A Channel 001"], in: app, name: "A Channel 001 row")
+        XCTAssertTrue(app.screen("PodcastDetailScreen").waitForExistence(timeout: 10), "Podcast detail did not open. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.buttons["PodcastDetailBackButton"].waitForExistence(timeout: 5), "Podcast detail inline back control missing. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertFalse(app.navigationBars.buttons["Library"].exists, "Podcast detail exposed native Library back chrome. Hierarchy:\n\(app.debugDescription)")
+
+        tapWhenReady(app.staticTexts["A Channel 001 Episode 1"], in: app, name: "A Channel 001 Episode 1", maxSwipes: 6)
+        XCTAssertTrue(app.screen("EpisodeDetailScreen").waitForExistence(timeout: 10), "Episode detail did not open. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.buttons["EpisodeDetailBackButton"].waitForExistence(timeout: 5), "Episode detail inline back control missing. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertFalse(app.navigationBars.buttons["Back"].exists, "Episode detail exposed native Back chrome. Hierarchy:\n\(app.debugDescription)")
+
+        app.buttons["EpisodeDetailBackButton"].tap()
+        XCTAssertTrue(app.screen("PodcastDetailScreen").waitForExistence(timeout: 8), "Episode back did not return to podcast detail. Hierarchy:\n\(app.debugDescription)")
+
+        app.buttons["PodcastDetailBackButton"].tap()
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 8), "Podcast back did not return to library. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.staticTexts["SHOWS · DIRECTORY"].waitForExistence(timeout: 5))
+    }
+
     private func tapWhenReady(
         _ element: XCUIElement,
         in app: XCUIApplication,


### PR DESCRIPTION
## Summary
- add a shared Tuner inline back key with a compact visual frame and 44pt hit target
- use the inline key on podcast and episode detail pushes while hiding native SwiftUI back buttons
- add a seeded UI smoke that drills Library -> podcast detail -> episode detail and asserts native back chrome is absent
- update the changelog

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testTunerDetailScreensUseInlineBackChrome
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'

Xcode MCP note: XcodeListWindows returned no workspace windows, so command-line Xcode verification was used.