### PR TITLE
Coalesce Library load and rebuild work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Root page headers sit tighter to the safe area** to reclaim top-of-app space while keeping the iOS status/Dynamic Island safe region intact.
 - **Large Library sections now render as flattened lazy headers, rows, and separators** so a 250+ show directory does not build an entire oversized letter section as one SwiftUI child.
 - **The Library directory now renders from value snapshots instead of live SwiftData podcast models** so 250+ show scrolling does less model work and only resolves a show when a row is opened.
+- **Library launch now avoids duplicate directory loads and coalesces snapshot rebuilds** so large libraries do less repeated sort/filter work while counts and controls update.
 - **Home retune and Library sync now use explicit Tuner header keys instead of native pull-to-refresh chrome**, removing another app-controlled Liquid Glass surface while keeping refresh actions discoverable.
 - **Podcast and episode detail pushes now use inline Tuner back keys** so Library and Home drill-down flows no longer fall back to native iOS back-button chrome.
 
@@ -37,6 +38,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Onboarding Sign in with Apple no longer has an iOS 26 missing-window precondition crash path** and now logs Keychain OSStatus details when credential persistence fails.
 - **Large OPML bootstrap imports now fetch feeds concurrently but apply SwiftData changes serially** and cap bootstrap RSS parsing to the small starter window, reducing 250+ show import stalls without changing normal full-feed sync.
 - **Large Library count-driven filters no longer fetch every matching episode just to compute per-show badges** and instead use cancellable per-show count queries for `UNPLAYED`, `IN PROGRESS`, and `ATTN`.
+- **Library now refreshes its directory after unsubscribing from a show detail screen** so the removed channel and visible count do not stay stale when returning from detail.
 - **Recommendation negative signals are now graded instead of binary** so one `Less Like This` no longer erases a whole show while repeated negative evidence still suppresses strongly matched candidates.
 - **Tuner chrome now uses shared modal/detail top insets and more resilient compact headers/import rows** so Settings, Import, and Library fallback surfaces keep the OLED instrument look at narrow widths and larger text sizes.
 - **Onboarding Sign in with Apple fallback anchoring no longer emits the iOS 26 `ASPresentationAnchor(frame:)` archive warning** when no foreground scene is available.

--- a/OffScript/DeepLinkRouter.swift
+++ b/OffScript/DeepLinkRouter.swift
@@ -10,6 +10,7 @@ private let deepLinkLogger = Logger(subsystem: "com.offscript", category: "DeepL
 extension Notification.Name {
     static let offscriptSwitchTab = Notification.Name("offscript.switchTab")
     static let offscriptRecommendationFeedbackChanged = Notification.Name("offscript.recommendationFeedbackChanged")
+    static let offscriptLibrarySubscriptionsChanged = Notification.Name("offscript.librarySubscriptionsChanged")
 }
 
 /// Centralized handler for `offscript://` URLs coming from:

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -138,6 +138,15 @@ nonisolated struct LibraryDirectorySnapshot {
     var isEmpty: Bool { podcasts.isEmpty }
 }
 
+private struct LibraryDirectorySnapshotInputs: Equatable {
+    let podcasts: [LibraryDirectoryPodcast]
+    let query: String
+    let scope: LibraryDirectoryScope
+    let sort: LibraryDirectorySort
+    let unplayedCounts: [UUID: Int]
+    let inProgressCounts: [UUID: Int]
+}
+
 nonisolated enum LibraryDirectoryListItem: Identifiable {
     case sectionHeader(LibraryDirectorySection)
     case row(LibraryDirectoryRow)
@@ -534,6 +543,7 @@ struct LibraryView: View {
     @State private var cachedDirectorySnapshot = LibraryDirectorySnapshot.empty
     @State private var didBuildDirectorySnapshot = false
     @State private var isSyncingLibrary = false
+    @State private var shouldReloadDirectoryOnAppear = false
 
     private var directoryNeedsFullUnplayedCounts: Bool {
         LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: directoryScope, sort: directorySort)
@@ -572,6 +582,17 @@ struct LibraryView: View {
         directoryPodcasts.map(\.id)
     }
 
+    private var directorySnapshotInputs: LibraryDirectorySnapshotInputs {
+        LibraryDirectorySnapshotInputs(
+            podcasts: directoryPodcasts,
+            query: effectiveDirectoryQuery,
+            scope: directoryScope,
+            sort: directorySort,
+            unplayedCounts: directoryUnplayedCountsByPodcastID,
+            inProgressCounts: directoryInProgressCountsByPodcastID
+        )
+    }
+
     var body: some View {
         let snapshot = didBuildDirectorySnapshot ? cachedDirectorySnapshot : makeDirectorySnapshot()
         ScrollViewReader { scrollProxy in
@@ -594,7 +615,7 @@ struct LibraryView: View {
                     // batch importer is mid-flight or has just finished and
                     // hasn't been dismissed yet.
                     LibraryBatchImportStrip(onFinished: {
-                        loadDirectoryPodcasts()
+                        loadDirectoryPodcasts(force: true)
                         scheduleLibraryEpisodeSummaryLoad()
                     })
 
@@ -659,33 +680,35 @@ struct LibraryView: View {
             }
         }
         .task {
-            loadDirectoryPodcasts()
+            loadDirectoryPodcastsIfNeeded()
             loadLibraryEpisodeSummary()
         }
         .onAppear {
             effectiveDirectoryQuery = directoryQuery
-            loadDirectoryPodcasts()
-            rebuildDirectorySnapshot()
+            if shouldReloadDirectoryOnAppear {
+                shouldReloadDirectoryOnAppear = false
+                loadDirectoryPodcasts(force: true)
+                loadLibraryEpisodeSummary()
+            } else {
+                loadDirectoryPodcastsIfNeeded()
+            }
         }
         .onChange(of: subscribedPodcastIDs) { _, _ in scheduleLibraryEpisodeSummaryLoad() }
         .onChange(of: directoryQuery) { _, newValue in scheduleDirectoryQuery(newValue) }
-        .onChange(of: effectiveDirectoryQuery) { _, _ in rebuildDirectorySnapshot() }
+        .onChange(of: directorySnapshotInputs) { _, _ in rebuildDirectorySnapshot() }
         .onChange(of: directoryScope) { _, _ in
-            rebuildDirectorySnapshot()
             ensureFullDirectoryCountsIfNeeded()
         }
         .onChange(of: directorySort) { _, _ in
-            rebuildDirectorySnapshot()
             ensureFullDirectoryCountsIfNeeded()
         }
-        .onChange(of: freshUnplayedCountsByPodcastID) { _, _ in rebuildDirectorySnapshot() }
-        .onChange(of: freshInProgressCountsByPodcastID) { _, _ in rebuildDirectorySnapshot() }
-        .onChange(of: fullUnplayedCountsByPodcastID) { _, _ in rebuildDirectorySnapshot() }
-        .onChange(of: fullInProgressCountsByPodcastID) { _, _ in rebuildDirectorySnapshot() }
         .onDisappear {
             summaryLoadTask?.cancel()
             fullCountLoadTask?.cancel()
             directoryQueryTask?.cancel()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .offscriptLibrarySubscriptionsChanged)) { _ in
+            shouldReloadDirectoryOnAppear = true
         }
         // Settings + Import buttons render inline in LibraryTunerHeader, not
         // as toolbar items — iOS 26 wraps toolbar buttons in glass chrome.
@@ -815,7 +838,14 @@ struct LibraryView: View {
     }
 
     @MainActor
-    private func loadDirectoryPodcasts() {
+    private func loadDirectoryPodcastsIfNeeded() {
+        guard !didLoadDirectoryPodcasts else { return }
+        loadDirectoryPodcasts()
+    }
+
+    @MainActor
+    private func loadDirectoryPodcasts(force: Bool = false) {
+        guard force || !didLoadDirectoryPodcasts else { return }
         do {
             directoryPodcasts = try LibraryDirectorySnapshotLoader.subscribedPodcasts(in: modelContext)
             didLoadDirectoryPodcasts = true
@@ -1055,7 +1085,7 @@ struct LibraryView: View {
                 libraryLogger.error("Pull-to-refresh sync failed for '\(podcast.title, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             }
         }
-        loadDirectoryPodcasts()
+        loadDirectoryPodcasts(force: true)
         loadLibraryEpisodeSummary()
     }
 }
@@ -1883,6 +1913,8 @@ private struct PodcastDetailTunerHeader: View {
                             .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Unsubscribe from \(podcast.title)")
+                    .accessibilityIdentifier("PodcastDetailUnsubscribeButton")
                 }
 
                 if let url = podcast.websiteURL {
@@ -1947,6 +1979,8 @@ private struct PodcastDetailTunerHeader: View {
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Confirm unsubscribe")
+                .accessibilityIdentifier("PodcastDetailConfirmUnsubscribeButton")
             }
         }
         .padding(12)

--- a/OffScript/PodcastUnsubscribeService.swift
+++ b/OffScript/PodcastUnsubscribeService.swift
@@ -77,6 +77,7 @@ enum PodcastUnsubscribeService {
         }
 
         unsubscribeLogger.info("Unsubscribe complete: \(podcast.title, privacy: .public), \(episodeIDs.count) episodes deindexed")
+        NotificationCenter.default.post(name: .offscriptLibrarySubscriptionsChanged, object: podcast.id)
         return true
     }
 }

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -165,6 +165,52 @@ final class OffScriptUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["SHOWS · DIRECTORY"].waitForExistence(timeout: 5))
     }
 
+    @MainActor
+    func testLibraryReloadsAfterDetailUnsubscribe() throws {
+        let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 4, debugEpisodesPerShow: 2, debugLaunchTab: 1)
+        app.launch()
+
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 12))
+        XCTAssertTrue(app.staticTexts["4 VISIBLE"].waitForExistence(timeout: 8))
+        tapAfterScrolling(app.staticTexts["A Channel 001"], in: app, name: "A Channel 001 row", direction: .up)
+        XCTAssertTrue(app.screen("PodcastDetailScreen").waitForExistence(timeout: 10), "Podcast detail did not open. Hierarchy:\n\(app.debugDescription)")
+
+        tapWhenReady(app.buttons["PodcastDetailUnsubscribeButton"], in: app, name: "detail unsubscribe button", maxSwipes: 2)
+        tapWhenReady(app.buttons["PodcastDetailConfirmUnsubscribeButton"], in: app, name: "confirm unsubscribe button", maxSwipes: 1)
+
+        app.buttons["PodcastDetailBackButton"].tap()
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 8), "Podcast back did not return to library. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.staticTexts["3 VISIBLE"].waitForExistence(timeout: 8), "Library did not refresh its directory count after unsubscribe. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertFalse(app.staticTexts["A Channel 001"].exists, "Unsubscribed show remained visible in the Library directory. Hierarchy:\n\(app.debugDescription)")
+    }
+
+    private enum ScrollDirection {
+        case up
+        case down
+    }
+
+    private func tapAfterScrolling(
+        _ element: XCUIElement,
+        in app: XCUIApplication,
+        name: String,
+        direction: ScrollDirection,
+        maxSwipes: Int = 6,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for _ in 0..<maxSwipes where !element.exists || !element.isHittable {
+            switch direction {
+            case .up:
+                app.swipeUp()
+            case .down:
+                app.swipeDown()
+            }
+        }
+        XCTAssertTrue(element.waitForExistence(timeout: 4), "\(name) did not appear. Hierarchy:\n\(app.debugDescription)", file: file, line: line)
+        XCTAssertTrue(element.isHittable, "\(name) was not hittable. Hierarchy:\n\(app.debugDescription)", file: file, line: line)
+        element.tap()
+    }
+
     private func tapWhenReady(
         _ element: XCUIElement,
         in app: XCUIApplication,


### PR DESCRIPTION
## Summary
- avoid duplicate Library directory loads on task/onAppear and force reloads only for import/sync/subscription changes
- coalesce Library snapshot rebuilds through one Equatable input bundle instead of separate count/query/sort observers
- broadcast successful unsubscribes and refresh Library on return from detail so removed shows/counts do not stay stale
- add UI coverage for detail unsubscribe directory refresh

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testLibraryReloadsAfterDetailUnsubscribe
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testLargeLibraryDirectoryControlsStayResponsive
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'

## Notes
- Xcode MCP is available, but XcodeListWindows reported no open workspace windows, so the active-tab build/test tools could not run in this session.