### PR TITLE
Unify recommendation feedback notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Changed — recommendation quality
 - **Explicit “more like this” and like signals now carry substantially more weight than passive completions** so recommendations follow intentional user feedback instead of feeling like generic completion-based ranking.
+- **Episode Detail feedback now uses the same retune notification path as Home cards** so likes and `NOT FOR ME` taps refresh recommendations consistently across entry points.
 - **Discovery genre matches now stay low-confidence until backed by local evidence** such as latest-episode tag overlap, topic matches, show affinity, or feed freshness, and genre-only WHY copy no longer claims local evidence.
 
 ### Fixed — onboarding, import, and sync UI honesty

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -373,7 +373,9 @@ struct EpisodeDetailView: View {
             HStack(spacing: 8) {
                 Button {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                        register(.like); feedbackGiven = .like
+                        if register(.like) {
+                            feedbackGiven = .like
+                        }
                     }
                 } label: {
                     HStack(spacing: 6) {
@@ -396,7 +398,9 @@ struct EpisodeDetailView: View {
 
                 Button {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                        register(.lessLikeThis); feedbackGiven = .lessLikeThis
+                        if register(.lessLikeThis) {
+                            feedbackGiven = .lessLikeThis
+                        }
                     }
                 } label: {
                     HStack(spacing: 6) {
@@ -486,10 +490,12 @@ struct EpisodeDetailView: View {
         return "\(EpisodeDurationFormatter.short(remaining).uppercased()) LEFT"
     }
 
-    private func register(_ action: PreferenceSignal.Action) {
-        modelContext.insert(PreferenceSignal(action: action, episode: episode))
-        try? modelContext.save()
-        // origin/main doesn't have TasteProfileService — feedback signals are
-        // persisted but not yet reprocessed into a refreshed taste profile.
+    private func register(_ action: PreferenceSignal.Action) -> Bool {
+        do {
+            try PreferenceFeedbackService.register(action, for: episode, in: modelContext)
+            return true
+        } catch {
+            return false
+        }
     }
 }

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -832,17 +832,13 @@ private struct HeroTunerCard: View {
     }
 
     private func register(_ action: PreferenceSignal.Action) {
-        let signal = PreferenceSignal(action: action, episode: episode)
-        modelContext.insert(signal)
         do {
-            try modelContext.save()
+            try PreferenceFeedbackService.register(action, for: episode, in: modelContext)
             withAnimation(.easeInOut(duration: 0.18)) {
                 feedbackStatusMessage = statusMessage(for: action)
             }
             scheduleFeedbackStatusClear()
-            NotificationCenter.default.post(name: .offscriptRecommendationFeedbackChanged, object: nil)
         } catch {
-            modelContext.delete(signal)
             homeLogger.error("Failed to save preference: \(error.localizedDescription, privacy: .public)")
             withAnimation(.easeInOut(duration: 0.18)) {
                 feedbackStatusMessage = "COULDN'T SAVE SIGNAL"

--- a/OffScript/PreferenceFeedbackService.swift
+++ b/OffScript/PreferenceFeedbackService.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum PreferenceFeedbackService {
+    static func register(
+        _ action: PreferenceSignal.Action,
+        for episode: Episode,
+        in context: ModelContext,
+        notificationCenter: NotificationCenter = .default
+    ) throws {
+        let signal = PreferenceSignal(action: action, episode: episode)
+        context.insert(signal)
+        do {
+            try context.save()
+            notificationCenter.post(name: .offscriptRecommendationFeedbackChanged, object: episode.id)
+        } catch {
+            context.delete(signal)
+            throw error
+        }
+    }
+}

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -673,6 +673,41 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func preferenceFeedbackServicePostsRetuneNotificationAfterSaving() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let podcast = Podcast(title: "Signal Show", feedURL: URL(string: "https://example.com/signal.xml")!)
+        let episode = Episode(
+            title: "Signal Episode",
+            pubDate: .now,
+            audioURL: URL(string: "https://example.com/signal.mp3")!,
+            podcast: podcast
+        )
+        context.insert(podcast)
+        context.insert(episode)
+        try context.save()
+
+        var notificationCount = 0
+        let token = NotificationCenter.default.addObserver(
+            forName: .offscriptRecommendationFeedbackChanged,
+            object: nil,
+            queue: nil
+        ) { _ in
+            notificationCount += 1
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        try PreferenceFeedbackService.register(.like, for: episode, in: context)
+
+        let descriptor = FetchDescriptor<PreferenceSignal>()
+        let signals = try context.fetch(descriptor)
+        #expect(signals.count == 1)
+        #expect(signals.first?.action == .like)
+        #expect(notificationCount == 1)
+    }
+
+    @Test
+    @MainActor
     func homeRecommendationsSeparateExplicitShowIntentFromCompletionAffinity() throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- add a shared PreferenceFeedbackService for saving preference signals and posting the Home retune notification only after a successful save
- route Home card feedback and Episode Detail feedback through the same service
- add unit coverage proving the service saves the signal and emits exactly one retune notification

## Verification
- red: targeted feedback-service test failed before implementation because PreferenceFeedbackService was missing
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
- subagent review: Noether clean for duplicate-signal, notification timing, error handling, and Home retune compatibility regressions

## Notes
- Residual existing behavior: preference signals remain append-only for repeated feedback taps across surfaces; this PR does not change ranking semantics or dedupe policy.