### PR TITLE
Persist Tuner tab stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Changed — Tuner UI conformance
 - **Shared Tuner labels, tags, and readouts now scale through Dynamic Type metrics** while preserving the mono instrument-panel vocabulary.
+- **The custom Tuner tab shell now keeps visited tab stacks alive** so returning from Library to Home does not rebuild the Home recommendation feed on every tab switch.
 - **Compact Tuner keys now keep their visual size but expose 44pt hit targets** across Library, Player, Queue, Search, downloads, and episode detail actions.
 - **Discovery/search copy now names Apple Podcasts Search explicitly** and avoids implying the app is running a generic opaque algorithmic feed.
 - **Remaining app-controlled Liquid Glass controls were replaced with Tuner surfaces**: Settings toggles, Player scrubber, sign-out/unsubscribe confirmations, and sheet presentation chrome now use flat OLED panels, hairlines, and signal-yellow keys.

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -7,7 +7,7 @@ private let appLogger = Logger(subsystem: "com.offscript", category: "App")
 
 // MARK: - Tab identity (typed enum, not raw Int)
 
-private enum AppTab: Int, CaseIterable, Identifiable {
+private enum AppTab: Int, CaseIterable, Identifiable, Hashable {
     case home, library, queue, search
 
     var id: Int { rawValue }
@@ -18,6 +18,15 @@ private enum AppTab: Int, CaseIterable, Identifiable {
         case .library: return "LIBRARY"
         case .queue:   return "QUEUE"
         case .search:  return "SEARCH"
+        }
+    }
+
+    var deepLinkName: String {
+        switch self {
+        case .home:    return "home"
+        case .library: return "library"
+        case .queue:   return "queue"
+        case .search:  return "search"
         }
     }
 
@@ -48,6 +57,7 @@ struct ContentView: View {
     @ObservedObject private var player = PlaybackController.shared
     @AppStorage("offscript.hasSeenOnboarding") private var hasSeenOnboarding = false
     @State private var selectedTab: AppTab = .home
+    @State private var loadedTabs: Set<AppTab> = [.home]
     @State private var isSettingsPresented = false
     @Query private var queueItems: [QueueItem]
 
@@ -70,7 +80,7 @@ struct ContentView: View {
                     }
 
                     TunerTabBar(
-                        selection: $selectedTab,
+                        selection: tabSelection,
                         queueBadge: queueItems.count
                     )
                 }
@@ -128,10 +138,29 @@ struct ContentView: View {
             // which tab is selected, so the routing happens at this layer.
             guard let name = note.userInfo?["tab"] as? String,
                   let tab = AppTab.from(deepLinkName: name) else { return }
+            loadedTabs.insert(tab)
             withAnimation(.easeInOut(duration: 0.15)) {
                 selectedTab = tab
             }
         }
+        .onChange(of: selectedTab) { _, tab in
+            loadedTabs.insert(tab)
+            NotificationCenter.default.post(
+                name: .offscriptActiveTabChanged,
+                object: nil,
+                userInfo: ["tab": tab.deepLinkName]
+            )
+        }
+    }
+
+    private var tabSelection: Binding<AppTab> {
+        Binding(
+            get: { selectedTab },
+            set: { tab in
+                loadedTabs.insert(tab)
+                selectedTab = tab
+            }
+        )
     }
 
     /// Switch on the typed tab so the compiler enforces exhaustive routing.
@@ -139,24 +168,47 @@ struct ContentView: View {
     /// switches.
     @ViewBuilder
     private var activeTabContent: some View {
-        switch selectedTab {
-        case .home:
-            NavigationStack {
-                HomeView(onOpenSettings: { isSettingsPresented = true })
+        ZStack {
+            if loadedTabs.contains(.home) {
+                tabPane(.home) {
+                    NavigationStack {
+                        HomeView(onOpenSettings: { isSettingsPresented = true })
+                    }
+                }
             }
-        case .library:
-            NavigationStack {
-                LibraryView(onOpenSettings: { isSettingsPresented = true })
+
+            if loadedTabs.contains(.library) {
+                tabPane(.library) {
+                    NavigationStack {
+                        LibraryView(onOpenSettings: { isSettingsPresented = true })
+                    }
+                }
             }
-        case .queue:
-            NavigationStack {
-                QueueView()
+
+            if loadedTabs.contains(.queue) {
+                tabPane(.queue) {
+                    NavigationStack {
+                        QueueView()
+                    }
+                }
             }
-        case .search:
-            NavigationStack {
-                SearchView()
+
+            if loadedTabs.contains(.search) {
+                tabPane(.search) {
+                    NavigationStack {
+                        SearchView()
+                    }
+                }
             }
         }
+    }
+
+    private func tabPane<Content: View>(_ tab: AppTab, @ViewBuilder content: () -> Content) -> some View {
+        let isSelected = selectedTab == tab
+        return content()
+            .opacity(isSelected ? 1 : 0)
+            .allowsHitTesting(isSelected)
+            .accessibilityHidden(!isSelected)
     }
 }
 
@@ -336,10 +388,11 @@ private extension ContentView {
         guard let existingPodcasts = try? modelContext.fetch(podcastDescriptor) else {
             return true
         }
-        guard existingPodcasts.count == requestedLibrarySize, existingEpisodes == expectedEpisodes else {
+        let subscribedPodcasts = existingPodcasts.filter(\.isSubscribed)
+        guard subscribedPodcasts.count == requestedLibrarySize, existingEpisodes == expectedEpisodes else {
             return true
         }
-        return existingPodcasts.first?.title != "A Channel 001"
+        return subscribedPodcasts.first?.title != "A Channel 001"
     }
 
     private func resetDebugLibrary() {

--- a/OffScript/DeepLinkRouter.swift
+++ b/OffScript/DeepLinkRouter.swift
@@ -9,6 +9,7 @@ private let deepLinkLogger = Logger(subsystem: "com.offscript", category: "DeepL
 /// surfaces without threading bindings through the whole shell.
 extension Notification.Name {
     static let offscriptSwitchTab = Notification.Name("offscript.switchTab")
+    static let offscriptActiveTabChanged = Notification.Name("offscript.activeTabChanged")
     static let offscriptRecommendationFeedbackChanged = Notification.Name("offscript.recommendationFeedbackChanged")
     static let offscriptLibrarySubscriptionsChanged = Notification.Name("offscript.librarySubscriptionsChanged")
 }

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -544,6 +544,7 @@ struct LibraryView: View {
     @State private var didBuildDirectorySnapshot = false
     @State private var isSyncingLibrary = false
     @State private var shouldReloadDirectoryOnAppear = false
+    @State private var isLibraryTabActive = false
 
     private var directoryNeedsFullUnplayedCounts: Bool {
         LibraryDirectoryOrganizer.needsPerShowUnplayedCounts(scope: directoryScope, sort: directorySort)
@@ -615,8 +616,7 @@ struct LibraryView: View {
                     // batch importer is mid-flight or has just finished and
                     // hasn't been dismissed yet.
                     LibraryBatchImportStrip(onFinished: {
-                        loadDirectoryPodcasts(force: true)
-                        scheduleLibraryEpisodeSummaryLoad()
+                        refreshDirectoryAfterBatchImportIfActive()
                     })
 
                     if didLoadDirectoryPodcasts && directoryPodcasts.isEmpty {
@@ -684,18 +684,17 @@ struct LibraryView: View {
             loadLibraryEpisodeSummary()
         }
         .onAppear {
+            isLibraryTabActive = true
             effectiveDirectoryQuery = directoryQuery
-            if shouldReloadDirectoryOnAppear {
-                shouldReloadDirectoryOnAppear = false
-                loadDirectoryPodcasts(force: true)
-                loadLibraryEpisodeSummary()
-            } else {
+            reloadDirectoryAfterSubscriptionChangeIfPossible()
+            if !shouldReloadDirectoryOnAppear {
                 loadDirectoryPodcastsIfNeeded()
             }
         }
         .onChange(of: subscribedPodcastIDs) { _, _ in scheduleLibraryEpisodeSummaryLoad() }
         .onChange(of: directoryQuery) { _, newValue in scheduleDirectoryQuery(newValue) }
         .onChange(of: directorySnapshotInputs) { _, _ in rebuildDirectorySnapshot() }
+        .onChange(of: selectedPodcastID) { _, _ in reloadDirectoryAfterSubscriptionChangeIfPossible() }
         .onChange(of: directoryScope) { _, _ in
             ensureFullDirectoryCountsIfNeeded()
         }
@@ -703,12 +702,17 @@ struct LibraryView: View {
             ensureFullDirectoryCountsIfNeeded()
         }
         .onDisappear {
+            isLibraryTabActive = false
             summaryLoadTask?.cancel()
             fullCountLoadTask?.cancel()
             directoryQueryTask?.cancel()
         }
         .onReceive(NotificationCenter.default.publisher(for: .offscriptLibrarySubscriptionsChanged)) { _ in
             shouldReloadDirectoryOnAppear = true
+            reloadDirectoryAfterSubscriptionChangeIfPossible()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .offscriptActiveTabChanged)) { note in
+            handleActiveTabChanged(note)
         }
         // Settings + Import buttons render inline in LibraryTunerHeader, not
         // as toolbar items — iOS 26 wraps toolbar buttons in glass chrome.
@@ -857,6 +861,43 @@ struct LibraryView: View {
             didBuildDirectorySnapshot = true
             libraryLogger.error("Library directory snapshot load failed: \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    @MainActor
+    private func reloadDirectoryAfterSubscriptionChangeIfPossible() {
+        guard isLibraryTabActive, shouldReloadDirectoryOnAppear, selectedPodcastID == nil else { return }
+        shouldReloadDirectoryOnAppear = false
+        loadDirectoryPodcasts(force: true)
+        loadLibraryEpisodeSummary()
+    }
+
+    @MainActor
+    private func refreshDirectoryAfterBatchImportIfActive() {
+        guard isLibraryTabActive else {
+            shouldReloadDirectoryOnAppear = true
+            return
+        }
+        loadDirectoryPodcasts(force: true)
+        scheduleLibraryEpisodeSummaryLoad()
+    }
+
+    @MainActor
+    private func handleActiveTabChanged(_ note: Notification) {
+        guard let tab = note.userInfo?["tab"] as? String else { return }
+        if tab == "library" {
+            isLibraryTabActive = true
+            reloadDirectoryAfterSubscriptionChangeIfPossible()
+        } else {
+            isLibraryTabActive = false
+            cancelDeferredLibraryWork()
+        }
+    }
+
+    @MainActor
+    private func cancelDeferredLibraryWork() {
+        summaryLoadTask?.cancel()
+        fullCountLoadTask?.cancel()
+        directoryQueryTask?.cancel()
     }
 
     private func podcast(withID id: UUID) -> Podcast? {

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -80,6 +80,10 @@ struct SearchView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task(id: query) { await search() }
+        .onReceive(NotificationCenter.default.publisher(for: .offscriptActiveTabChanged)) { note in
+            guard let tab = note.userInfo?["tab"] as? String, tab != "search" else { return }
+            searchFieldFocused = false
+        }
     }
 
     /// Custom Tuner search input — hairline rectangle with mono prompt,


### PR DESCRIPTION
## Summary
- keep visited Tuner tab NavigationStacks mounted so Library -> Home no longer rebuilds Home recommendations
- broadcast active-tab changes so hidden Library/Search work is deferred, cancelled, or unfocused
- tighten DEBUG library seeding to reset when subscribed show counts drift after unsubscribe flows
- update changelog

## Verification
- git diff --check
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testPostOnboardingShellSmoke
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testLibraryReloadsAfterDetailUnsubscribe
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests

## Notes
- Xcode MCP was available, but no workspace windows were open, so verification used xcodebuild.
- A parallel test attempt hit Xcode build.db contention; the same tests were rerun sequentially and passed.
