### PR TITLE
Fix Xcode Cloud release diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Sentry TestFlight/App Store environment tagging now uses StoreKit 2 app transactions** instead of the deprecated receipt URL path, clearing the recurring iOS 18 `appStoreReceiptURL` archive warning.
 
 ### Fixed — Xcode Cloud signing
+- **Xcode Cloud diagnostics now flag `INTERNAL_ONLY` archive workflows and use Apple's current `APP_STORE_ELIGIBLE` API enum** for TestFlight/App Store deployment preparation, with an explicit failure path when App Store Connect rejects action-array replacement because of hidden deployment config state.
 - **Build number advanced to 41 after Xcode Cloud runs #40 and #41 failed exporting app build 40.**
 - **Build number advanced to 42 after Xcode Cloud run #63 failed during App Store Connect preparation** while the product line continued shipping performance builds on main.
 - **Build number advanced to 43 after App Store Connect reported `2.3.11 (42)` already uploaded** despite Cloud run #64 failing during preparation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ iOS 26 wraps SwiftUI-vended chrome in floating Liquid Glass / glass-capsule trea
 - Visual audits: `xcrun simctl io booted screenshot` is the reliable path; `xcrun simctl spawn DEVICE defaults write com.offscript.app offscript.debugLaunchTab -int N` swaps tabs without taps. `-offscript.debugSeedSampleData YES` populates 3 podcasts × 3 episodes for populated-state audits.
 
 ## CI
-- TestFlight ships through **Xcode Cloud** (`Default` workflow on App Store Connect, branch start condition `main`, tag `v*`, action `ARCHIVE` with `buildDistributionAudience = INTERNAL_ONLY`).
+- TestFlight ships through **Xcode Cloud** (`Default` workflow on App Store Connect, branch start condition `main`, tag `v*`, action `ARCHIVE` with `buildDistributionAudience = APP_STORE_ELIGIBLE` so the same build can go to internal and external TestFlight testers).
 - The legacy GH-Actions workflow lives at `.github/workflows/testflight.yml.disabled` for reference.
 - Operational tools: `scripts/app_store_connect.py xcode-cloud {probe,inspect,reconfigure,start-build,build-run}`. The `Xcode Cloud Probe` GH workflow runs them on demand without a local `.env`.
 - Sentry DSN injection: `ci_scripts/ci_post_clone.sh` materializes `Config/Secrets.xcconfig` from the `SENTRY_DSN` Xcode Cloud env var.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ extension targets just works), and uploads to TestFlight as a built-in action.
 **Path 1 — Push to `main`** (fast, day-to-day):
 - Push (or merge a PR) to `main`
 - Xcode Cloud detects the push, archives, signs, uploads to TestFlight
-  Internal Testers automatically
+  with TestFlight and App Store deployment preparation so the same build can
+  be assigned to internal and external testers
 - No release notes are written; testers see the commit message
 
 **Path 2 — Cut a GitHub Release with `vX.Y.Z` tag** (curated):

--- a/scripts/app_store_connect.py
+++ b/scripts/app_store_connect.py
@@ -129,6 +129,10 @@ def attrs(resource: dict[str, Any]) -> dict[str, Any]:
     return resource.get("attributes") or {}
 
 
+def is_xcode_cloud_deployment_config_error(exc: ASCError) -> bool:
+    return "Deployment configured for unknown action" in str(exc)
+
+
 def find_app(client: ASCClient, bundle_id: str) -> dict[str, Any]:
     response = client.request(
         "GET",
@@ -718,6 +722,11 @@ def command_xcode_cloud_inspect(args: argparse.Namespace) -> None:
     print(f"  actions: {len(actions)}")
     for action in actions:
         print(f"    - {json.dumps(action, indent=6)}")
+        if (
+            action.get("actionType") == "ARCHIVE"
+            and action.get("buildDistributionAudience") == "INTERNAL_ONLY"
+        ):
+            print("      WARNING: archive uses INTERNAL_ONLY; external TestFlight needs APP_STORE_ELIGIBLE.")
 
     print()
     print(f"Recent build runs (limit {args.limit}):")
@@ -740,15 +749,15 @@ def command_xcode_cloud_reconfigure(args: argparse.Namespace) -> None:
     """
     PATCH an existing Xcode Cloud workflow so it triggers on push to main
     (and optionally release tags vX.Y.Z), and so the Archive action
-    auto-publishes to TestFlight internal testers.
+    prepares archives for TestFlight and App Store distribution.
 
     Idempotent — safe to re-run. Only mutates fields specified by flags.
 
     The default behavior:
       - branchStartCondition pattern → 'main' (autoCancel on)
       - tagStartCondition pattern → 'v*' (catches v2.2.0, v2.3.0, etc.)
-      - actions[].buildDistributionAudience → INTERNAL_ONLY for any
-        ARCHIVE action that currently has it null
+      - actions[].buildDistributionAudience → APP_STORE_ELIGIBLE for any
+        ARCHIVE action that currently differs
     """
     client = ASCClient()
     workflow_id = args.workflow_id
@@ -781,20 +790,25 @@ def command_xcode_cloud_reconfigure(args: argparse.Namespace) -> None:
             "autoCancel": False,
         }
 
-    # Auto-publish to TestFlight by setting buildDistributionAudience on
-    # any ARCHIVE action that currently has it null. Preserves everything
-    # else about the action.
+    # Configure archive deployment preparation. Apple's API enum maps to:
+    #   INTERNAL_ONLY      -> TestFlight (Internal Testing Only)
+    #   APP_STORE_ELIGIBLE -> TestFlight and App Store
+    #
+    # Keep the whole action payload intact because PATCH replaces this array.
     if args.testflight:
         actions = a.get("actions") or []
         updated_actions = []
+        changed_actions = False
         for action in actions:
-            if action.get("actionType") == "ARCHIVE" and not action.get("buildDistributionAudience"):
+            if action.get("actionType") == "ARCHIVE" and action.get("buildDistributionAudience") != args.audience:
                 updated = dict(action)
                 updated["buildDistributionAudience"] = args.audience
                 updated_actions.append(updated)
+                changed_actions = True
             else:
                 updated_actions.append(action)
-        new_attributes["actions"] = updated_actions
+        if changed_actions:
+            new_attributes["actions"] = updated_actions
 
     if not new_attributes:
         print("Nothing to update.")
@@ -814,7 +828,24 @@ def command_xcode_cloud_reconfigure(args: argparse.Namespace) -> None:
         print("\nDry run. Re-run with --apply to actually PATCH.")
         return
 
-    response = client.request("PATCH", f"/v1/ciWorkflows/{workflow_id}", json=payload)
+    try:
+        response = client.request("PATCH", f"/v1/ciWorkflows/{workflow_id}", json=payload)
+    except ASCError as exc:
+        if is_xcode_cloud_deployment_config_error(exc):
+            print()
+            print("PATCH failed because App Store Connect rejected the action replacement:")
+            print("  Deployment configured for unknown action.")
+            print()
+            print("Apple's ciWorkflows PATCH endpoint replaces the actions array, and")
+            print("some existing workflows have a hidden deploymentConfig tied to the")
+            print("original archive action. Change Deployment Preparation for this")
+            print("workflow in App Store Connect or Xcode Cloud from")
+            print("  TestFlight (Internal Testing Only)")
+            print("to")
+            print("  TestFlight and App Store")
+            print("then re-run:")
+            print(f"  scripts/app_store_connect.py xcode-cloud inspect {workflow_id}")
+        raise
     print("\nPATCH succeeded.")
     new_attrs = attrs(response.get("data", {}))
     print(f"  branchStartCondition: {json.dumps(new_attrs.get('branchStartCondition'), indent=2)}")
@@ -969,7 +1000,7 @@ def build_parser() -> argparse.ArgumentParser:
     xcc_reconfig.add_argument("--tag-pattern", default="v*", help="Tag pattern to start on (default 'v*'). Set empty string to skip.")
     xcc_reconfig.add_argument("--skip-branch", action="store_true", help="Don't touch branchStartCondition.")
     xcc_reconfig.add_argument("--testflight", action="store_true", help="Set buildDistributionAudience on ARCHIVE actions.")
-    xcc_reconfig.add_argument("--audience", default="INTERNAL_ONLY", choices=["INTERNAL_ONLY", "APP_STORE_CONNECT_USERS"])
+    xcc_reconfig.add_argument("--audience", default="APP_STORE_ELIGIBLE", choices=["INTERNAL_ONLY", "APP_STORE_ELIGIBLE"])
     xcc_reconfig.add_argument("--apply", action="store_true", help="Actually PATCH. Without this flag, dry-run.")
     xcc_reconfig.set_defaults(func=command_xcode_cloud_reconfigure)
 


### PR DESCRIPTION
## Summary
- correct Xcode Cloud deployment-preparation tooling to use Apple's `APP_STORE_ELIGIBLE` enum for TestFlight/App Store archives
- warn when the live workflow is still `INTERNAL_ONLY` so release blockers are visible from `inspect`
- document the App Store Connect hidden deployment-config failure path when action-array PATCHes are rejected

## Test plan
- [x] `python3 -m py_compile scripts/app_store_connect.py`
- [x] `git diff --check`
- [x] `scripts/app_store_connect.py xcode-cloud inspect C23266BA-6A8D-410F-B641-011F1A397CE3 --limit 1`
- [x] `scripts/app_store_connect.py xcode-cloud reconfigure C23266BA-6A8D-410F-B641-011F1A397CE3 --testflight --skip-branch --tag-pattern ""`

## Risk
- **Affected surfaces:** release diagnostics and Xcode Cloud workflow operations docs only.
- **Rollback path:** revert this PR; no app runtime behavior changes.