### PR TITLE
Compose authored recommendation evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Podcast and episode detail pushes now use inline Tuner back keys** so Library and Home drill-down flows no longer fall back to native iOS back-button chrome.
 
 ### Changed — recommendation quality
+- **Home recommendations now compose multiple local evidence signals instead of stopping at the first matching rule**, so explicit topic feedback and “more from this show” reinforce one authored recommendation rather than competing as generic ranking buckets.
+- **Recommendation reason copy now has deterministic rail-length clipping for combined evidence**, keeping long show/topic explanations inside Tuner cards.
 - **Explicit “more like this” and like signals now carry substantially more weight than passive completions** so recommendations follow intentional user feedback instead of feeling like generic completion-based ranking.
 - **Episode Detail feedback now uses the same retune notification path as Home cards** so likes and `NOT FOR ME` taps refresh recommendations consistently across entry points.
 - **Discovery genre matches now stay low-confidence until backed by local evidence** such as latest-episode tag overlap, topic matches, show affinity, or feed freshness, and genre-only WHY copy no longer claims local evidence.

--- a/OffScript/RecommendationExplainer.swift
+++ b/OffScript/RecommendationExplainer.swift
@@ -49,6 +49,24 @@ enum RecommendationExplainer {
             .map { $0.value.lowercased() }
         let source = authoredSource(from: sources)
 
+        if sources.contains("explicit signal"),
+           sources.contains("show intent"),
+           let tags = lookup["tags"],
+           let show = lookup["show"],
+           !tags.isEmpty,
+           !show.isEmpty {
+            return clipped("More from \(show), matching your \(joinedList(tags)) signal", maxCharacters: 72)
+        }
+
+        if sources.contains("completion"),
+           sources.contains("tag match"),
+           let tags = lookup["tags"],
+           let show = lookup["show"],
+           !tags.isEmpty,
+           !show.isEmpty {
+            return clipped("\(show) plus your \(joinedList(tags)) signal", maxCharacters: 72)
+        }
+
         switch source {
         case "queue":
             if let position = lookup["position"] {
@@ -62,9 +80,14 @@ enum RecommendationExplainer {
             return "Ready to pick up from your last session"
         case "completion":
             if let show = lookup["show"], !show.isEmpty {
-                return "More from \(show), a show you keep finishing"
+                return clipped("More from \(show), a show you keep finishing", maxCharacters: 72)
             }
             return "More from a show you keep finishing"
+        case "show intent":
+            if let show = lookup["show"], !show.isEmpty {
+                return clipped("More from \(show), because you asked for it", maxCharacters: 72)
+            }
+            return "More from a show you chose"
         case "show affinity":
             if let show = lookup["show"], !show.isEmpty {
                 return "More from \(show), a show you already trust"
@@ -77,7 +100,7 @@ enum RecommendationExplainer {
             return "More from the show already playing"
         case "tag match":
             if let tags = lookup["tags"], !tags.isEmpty {
-                return "Tuned to your saved \(joinedList(tags)) signal\(isPluralList(tags) ? "s" : "")"
+                return clipped("Tuned to your saved \(joinedList(tags)) signal\(isPluralList(tags) ? "s" : "")", maxCharacters: 72)
             }
             return "Tuned to your saved listening signals"
         case "taste tag":
@@ -161,6 +184,8 @@ enum RecommendationExplainer {
             "queue",
             "resume",
             "latest episode",
+            "explicit signal",
+            "show intent",
             "tag match",
             "taste tag",
             "topic overlap",
@@ -187,6 +212,16 @@ enum RecommendationExplainer {
             .filter { !$0.isEmpty }
         guard parts.count > 1 else { return parts.first ?? value }
         return parts.dropLast().joined(separator: ", ") + " and " + parts.last!
+    }
+
+    private static func clipped(_ value: String, maxCharacters: Int) -> String {
+        guard value.count > maxCharacters else { return value }
+        let boundary = value.index(value.startIndex, offsetBy: max(0, maxCharacters - 1))
+        let prefix = value[..<boundary]
+        if let lastSpace = prefix.lastIndex(where: { $0 == " " }), lastSpace > value.startIndex {
+            return String(prefix[..<lastSpace]) + "…"
+        }
+        return String(prefix) + "…"
     }
 
     private static func isPluralList(_ value: String) -> Bool {

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -524,7 +524,7 @@ final class RecommendationService {
 
         guard !evidence.isEmpty else { return nil }
         let localEvidence = evidence.filter { $0.strength == .chosen || $0.strength == .listened }
-        let usableEvidence = localEvidence.isEmpty ? evidence : evidence
+        let usableEvidence = localEvidence.isEmpty ? evidence : localEvidence
         let primary = usableEvidence.sorted { $0.weight > $1.weight }.first!
         let secondary = usableEvidence
             .filter { $0.source != primary.source }

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -69,6 +69,30 @@ enum RecommendationScorer {
 final class RecommendationService {
     let discoveryService = DiscoveryService()
 
+    private enum EvidenceStrength: Int {
+        case catalog = 0
+        case inferred = 1
+        case listened = 2
+        case chosen = 3
+
+        var displayValue: String {
+            switch self {
+            case .catalog: "catalog"
+            case .inferred: "inferred"
+            case .listened: "listened"
+            case .chosen: "chosen"
+            }
+        }
+    }
+
+    private struct RecommendationEvidence {
+        let source: String
+        let weight: Double
+        let explanation: String
+        let signals: [RecommendationSignal]
+        let strength: EvidenceStrength
+    }
+
     private struct ScoringContext {
         let profileByEpisodeID: [UUID: EpisodeProfile]
         let likedTags: Set<String>
@@ -95,8 +119,10 @@ final class RecommendationService {
         let sourceValues = Set(scored.signalTrace
             .filter { $0.label == "source" }
             .map { $0.value.lowercased() })
+        let strength = Self.signalStrength(from: scored.signalTrace)
         var score = scored.score
         score += Double(min(scored.signalTrace.count, 4)) * 4
+        score += Double(strength.rawValue) * 32
 
         if sourceValues.contains("queue") {
             score += 40
@@ -112,6 +138,52 @@ final class RecommendationService {
         }
 
         return score
+    }
+
+    private static func signalStrength(from signals: [RecommendationSignal]) -> EvidenceStrength {
+        let sources = Set(signals
+            .filter { $0.label.caseInsensitiveCompare("source") == .orderedSame }
+            .map { $0.value.lowercased() })
+        if !sources.intersection(["queue", "resume", "explicit signal", "show intent", "now playing"]).isEmpty {
+            return .chosen
+        }
+        if !sources.intersection(["completion", "show affinity", "tag match", "topic overlap", "liked episode", "recent interest"]).isEmpty {
+            return .listened
+        }
+        if !sources.intersection(["genre", "duration", "fresh", "subscription", "available"]).isEmpty {
+            return .inferred
+        }
+        return .catalog
+    }
+
+    private static func composedExplanation(primary: RecommendationEvidence, secondary: RecommendationEvidence?) -> String {
+        guard let secondary else { return primary.explanation }
+
+        if primary.source == "explicit signal", secondary.source == "show intent" {
+            let tags = primary.signals.first(where: { $0.label == "tags" })?.value ?? "your saved signal"
+            let show = secondary.signals.first(where: { $0.label == "show" })?.value ?? "that show"
+            return "You asked for more from \(show), and this matches \(tags)"
+        }
+
+        if primary.source == "show intent", secondary.source == "explicit signal" {
+            let show = primary.signals.first(where: { $0.label == "show" })?.value ?? "this show"
+            let tags = secondary.signals.first(where: { $0.label == "tags" })?.value ?? "your saved signal"
+            return "You asked for more from \(show), and this matches \(tags)"
+        }
+
+        if primary.source == "completion", secondary.source == "tag match" {
+            let show = primary.signals.first(where: { $0.label == "show" })?.value ?? "this show"
+            let tags = secondary.signals.first(where: { $0.label == "tags" })?.value ?? "your saved signal"
+            return "You keep finishing \(show), and this carries \(tags)"
+        }
+
+        if primary.source == "tag match", secondary.source == "completion" {
+            let tags = primary.signals.first(where: { $0.label == "tags" })?.value ?? "your saved signal"
+            let show = secondary.signals.first(where: { $0.label == "show" })?.value ?? "a show you finish"
+            return "Matches \(tags) from a show you keep finishing: \(show)"
+        }
+
+        return primary.explanation
     }
 
     @MainActor
@@ -327,28 +399,34 @@ final class RecommendationService {
         let durationTieBreak = durationFit * 5
         let qualityTieBreak = quality * 5
 
+        var evidence: [RecommendationEvidence] = []
+
         if let queuePosition = context.queuedPositionByEpisodeID[episode.id] {
             let positionLabel = queuePosition == 0 ? "first" : "#\(queuePosition + 1)"
-            return (
-                500 - Double(queuePosition * 10) + freshnessTieBreak,
-                "You put this \(positionLabel) in queue",
-                [
+            evidence.append(RecommendationEvidence(
+                source: "queue",
+                weight: 500 - Double(queuePosition * 10),
+                explanation: "You put this \(positionLabel) in queue",
+                signals: [
                     RecommendationSignal(label: "source", value: "queue"),
                     RecommendationSignal(label: "position", value: positionLabel)
-                ]
-            )
+                ],
+                strength: .chosen
+            ))
         }
 
         if Self.hasMeaningfulProgress(episode) {
             let remaining = max(0, (episode.duration ?? 0) - episode.playedPosition)
-            return (
-                420 + freshnessTieBreak + durationTieBreak,
-                "\(EpisodeDurationFormatter.short(remaining)) left from your last session",
-                [
+            evidence.append(RecommendationEvidence(
+                source: "resume",
+                weight: 420 + durationTieBreak,
+                explanation: "\(EpisodeDurationFormatter.short(remaining)) left from your last session",
+                signals: [
                     RecommendationSignal(label: "source", value: "resume"),
                     RecommendationSignal(label: "left", value: EpisodeDurationFormatter.short(remaining))
-                ]
-            )
+                ],
+                strength: .chosen
+            ))
         }
 
         let negativeEvidence = Self.negativeEvidence(for: episode, profileTags: profileTags, context: context)
@@ -359,80 +437,111 @@ final class RecommendationService {
 
         if !matchingExplicitTags.isEmpty {
             let sample = matchingExplicitTags.sorted().prefix(2).joined(separator: ", ")
-            return (
-                360 + Double(min(matchingExplicitTags.count, 4)) * 22 + freshnessTieBreak + qualityTieBreak - negativePenalty,
-                "Matches what you asked for: \(sample)",
-                [
+            evidence.append(RecommendationEvidence(
+                source: "explicit signal",
+                weight: 400 + Double(min(matchingExplicitTags.count, 4)) * 24,
+                explanation: "Matches what you asked for: \(sample)",
+                signals: [
                     RecommendationSignal(label: "source", value: "explicit signal"),
                     RecommendationSignal(label: "tags", value: sample)
-                ]
-            )
+                ],
+                strength: .chosen
+            ))
         }
 
         let explicitShowCount = context.explicitPositiveShowCounts[episode.podcast.title, default: 0]
         if explicitShowCount > 0 {
-            return (
-                380 + Double(min(explicitShowCount, 4)) * 20 + freshnessTieBreak + qualityTieBreak - negativePenalty,
-                "You asked for more from \(episode.podcast.title)",
-                [
+            evidence.append(RecommendationEvidence(
+                source: "show intent",
+                weight: 380 + Double(min(explicitShowCount, 4)) * 20,
+                explanation: "You asked for more from \(episode.podcast.title)",
+                signals: [
                     RecommendationSignal(label: "source", value: "show intent"),
                     RecommendationSignal(label: "show", value: episode.podcast.title),
                     RecommendationSignal(label: "signals", value: "\(explicitShowCount)")
-                ]
-            )
+                ],
+                strength: .chosen
+            ))
         }
 
         let completedShowCount = context.completedShowCounts[episode.podcast.title, default: 0]
         if completedShowCount > 0 || context.showAffinity.contains(episode.podcast.title) {
             let showSignal = max(completedShowCount, 1)
-            return (
-                320 + Double(min(showSignal, 5)) * 18 + freshnessTieBreak + qualityTieBreak - negativePenalty,
-                "You keep finishing \(episode.podcast.title)",
-                [
+            evidence.append(RecommendationEvidence(
+                source: "completion",
+                weight: 320 + Double(min(showSignal, 5)) * 18,
+                explanation: "You keep finishing \(episode.podcast.title)",
+                signals: [
                     RecommendationSignal(label: "source", value: "completion"),
                     RecommendationSignal(label: "show", value: episode.podcast.title),
                     RecommendationSignal(label: "finishes", value: "\(showSignal)")
-                ]
-            )
+                ],
+                strength: .listened
+            ))
         }
 
         if !matchingTags.isEmpty {
             let sample = matchingTags.sorted().prefix(2).joined(separator: ", ")
-            return (
-                260 + Double(min(matchingTags.count, 4)) * 16 + freshnessTieBreak + qualityTieBreak - negativePenalty,
-                "Matches your saved signal: \(sample)",
-                [
+            evidence.append(RecommendationEvidence(
+                source: "tag match",
+                weight: 260 + Double(min(matchingTags.count, 4)) * 16,
+                explanation: "Matches your saved signal: \(sample)",
+                signals: [
                     RecommendationSignal(label: "source", value: "tag match"),
                     RecommendationSignal(label: "tags", value: sample)
-                ]
-            )
+                ],
+                strength: .listened
+            ))
         }
 
         let genreMatches = Set(episode.podcast.categories.map { $0.lowercased() }).intersection(context.preferredGenres)
         if !genreMatches.isEmpty {
             let genre = genreMatches.sorted().first ?? "saved genre"
-            return (
-                210 + freshnessTieBreak + durationTieBreak - negativePenalty,
-                "Matches your selected \(genre) lane",
-                [
+            evidence.append(RecommendationEvidence(
+                source: "genre",
+                weight: 210 + durationTieBreak,
+                explanation: "Matches your selected \(genre) lane",
+                signals: [
                     RecommendationSignal(label: "source", value: "genre"),
                     RecommendationSignal(label: "lane", value: genre)
-                ]
-            )
+                ],
+                strength: .inferred
+            ))
         }
 
         if AppSettings.preferShortEpisodes, minutes <= 35 {
-            return (
-                190 + durationTieBreak + qualityTieBreak - negativePenalty,
-                "Fits your short-listen setting",
-                [
+            evidence.append(RecommendationEvidence(
+                source: "duration",
+                weight: 190 + durationTieBreak,
+                explanation: "Fits your short-listen setting",
+                signals: [
                     RecommendationSignal(label: "source", value: "duration"),
                     RecommendationSignal(label: "window", value: EpisodeDurationFormatter.short(episode.duration ?? 0))
-                ]
-            )
+                ],
+                strength: .inferred
+            ))
         }
 
-        return nil
+        guard !evidence.isEmpty else { return nil }
+        let localEvidence = evidence.filter { $0.strength == .chosen || $0.strength == .listened }
+        let usableEvidence = localEvidence.isEmpty ? evidence : evidence
+        let primary = usableEvidence.sorted { $0.weight > $1.weight }.first!
+        let secondary = usableEvidence
+            .filter { $0.source != primary.source }
+            .sorted { $0.weight > $1.weight }
+            .first
+        let composedScore = primary.weight
+            + (secondary.map { min($0.weight * 0.18, 72) } ?? 0)
+            + freshnessTieBreak
+            + qualityTieBreak
+            - negativePenalty
+        var trace = primary.signals
+        if let secondary {
+            trace.append(contentsOf: secondary.signals.filter { !trace.contains($0) })
+        }
+        trace.append(RecommendationSignal(label: "strength", value: primary.strength.displayValue))
+        let explanation = Self.composedExplanation(primary: primary, secondary: secondary)
+        return (composedScore, explanation, trace)
     }
 
     private func scoreWithExplanation(

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -629,6 +629,53 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func homeRecommendationsComposeExplicitTagAndShowIntent() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let originalGenres = AppSettings.preferredGenres
+        AppSettings.preferredGenres = []
+        defer { AppSettings.preferredGenres = originalGenres }
+
+        let show = Podcast(title: "Decoder", feedURL: URL(string: "https://example.com/decoder.xml")!)
+        let seed = Episode(
+            title: "AI Tooling Seed",
+            pubDate: Date().addingTimeInterval(-3 * 86_400),
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/decoder-seed.mp3")!,
+            podcast: show
+        )
+        let followUp = Episode(
+            title: "AI Tooling Follow Up",
+            pubDate: .now,
+            duration: 2_100,
+            audioURL: URL(string: "https://example.com/decoder-follow.mp3")!,
+            podcast: show
+        )
+        let seedProfile = EpisodeProfile(episodeID: seed.id)
+        seedProfile.tags = ["ai tooling"]
+        let followUpProfile = EpisodeProfile(episodeID: followUp.id)
+        followUpProfile.tags = ["ai tooling", "developer workflows"]
+
+        context.insert(show)
+        context.insert(seed)
+        context.insert(followUp)
+        context.insert(seedProfile)
+        context.insert(followUpProfile)
+        context.insert(PreferenceSignal(action: .moreLikeThis, episode: seed))
+        try context.save()
+
+        let sections = try RecommendationService().homeSections(context: context, limit: 3)
+        let scoredSection = try #require(sections.first(where: { $0.episodes.contains(where: { $0.id == followUp.id }) }))
+        let trace = scoredSection.signalTrace(for: followUp)
+
+        #expect(trace.contains(RecommendationSignal(label: "source", value: "explicit signal")))
+        #expect(trace.contains(RecommendationSignal(label: "source", value: "show intent")))
+        #expect(scoredSection.explanation(for: followUp).contains("Decoder") == true)
+        #expect(scoredSection.explanation(for: followUp).contains("ai tooling") == true)
+    }
+
+    @Test
+    @MainActor
     func homeRecommendationsUseCurrentLikedShowSignalWithoutCachedProfileRefresh() throws {
         let container = try makeContainer()
         let context = container.mainContext
@@ -1191,6 +1238,22 @@ struct OffScriptTests {
         )
 
         #expect(reason == "Tuned to your saved audio craft and interviews signals")
+    }
+
+    @Test
+    func recommendationExplainerComposesAndClipsExplicitEvidence() {
+        let reason = RecommendationExplainer.authoredReason(
+            fallback: "You asked for more from Decoder, and this matches artificial intelligence infrastructure, developer workflows",
+            signals: [
+                RecommendationSignal(label: "source", value: "explicit signal"),
+                RecommendationSignal(label: "tags", value: "artificial intelligence infrastructure, developer workflows"),
+                RecommendationSignal(label: "source", value: "show intent"),
+                RecommendationSignal(label: "show", value: "Decoder")
+            ]
+        )
+
+        #expect(reason.hasPrefix("More from Decoder, matching your artificial intelligence"))
+        #expect(reason.count <= 72)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace Home recommendation early-return scoring with composed evidence so explicit topics, show intent, completion, genre, and duration can reinforce one recommendation
- bias headline selection toward chosen/listened evidence instead of small catalog-score tie breaks
- add deterministic clipped WHY copy for combined evidence so long show/topic reasons stay inside Tuner cards
- cover explicit tag + show intent composition and rail-length copy clipping in unit tests

## Test plan
- [x] `git diff --check`
- [x] `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO`

## Risk
- **Affected surfaces:** Home recommendations, recommendation reason copy, headline selection.
- **Rollback path:** revert this PR; no persistence migration.