### PR TITLE
Scope OPML staging feed lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Settings and Library import sheets no longer sit inside empty native navigation hosts**, reducing stray iOS navigation chrome while keeping the authored Tuner headers and inline DONE keys.
 
 ### Changed — Library performance
+- **OPML staging, retry, and cancellation now use scoped feed-URL variant lookups instead of full podcast-table scans for large batches**, while preserving normalized resubscribe behavior for small single-feed edge cases.
 - **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.
 - **Single-show adds from Home, Search, and pasted feed URLs now save the subscription before feed hydration**, then use a capped bootstrap sync in the background instead of blocking the UI on a full catalog import.
 - **Onboarding now stages selected starter shows in one SwiftData batch** instead of saving each selected podcast independently, making the three-podcast starter flow a single local commit before background hydration.

--- a/OffScript/BatchImportService.swift
+++ b/OffScript/BatchImportService.swift
@@ -14,6 +14,7 @@ private let batchImportLogger = Logger(subsystem: "com.offscript", category: "Ba
 @MainActor
 final class BatchImportService: ObservableObject {
     static let shared = BatchImportService()
+    private static let feedURLLookupChunkSize = 96
 
     enum Phase: Equatable {
         case idle
@@ -385,10 +386,15 @@ final class BatchImportService: ObservableObject {
 
         var podcasts: [Podcast] = []
         var seenIDs = Set<UUID>()
-        let chunkSize = 96
         var startIndex = lookupURLs.startIndex
         while startIndex < lookupURLs.endIndex {
-            let endIndex = lookupURLs.index(startIndex, offsetBy: chunkSize, limitedBy: lookupURLs.endIndex) ?? lookupURLs.endIndex
+            // Keep each SwiftData `contains` predicate well below SQLite's
+            // parameter ceiling after URL variant expansion.
+            let endIndex = lookupURLs.index(
+                startIndex,
+                offsetBy: feedURLLookupChunkSize,
+                limitedBy: lookupURLs.endIndex
+            ) ?? lookupURLs.endIndex
             let chunk = Array(lookupURLs[startIndex..<endIndex])
             let matches = try modelContext.fetch(FetchDescriptor<Podcast>(
                 predicate: #Predicate<Podcast> { chunk.contains($0.feedURL) }
@@ -403,7 +409,7 @@ final class BatchImportService: ObservableObject {
         let requestedFeedKeys = Set(entries.map { $0.feedURL.normalizedFeedKey })
         let matchedFeedKeys = Set(podcasts.map { $0.feedURL.normalizedFeedKey })
         let missingFeedKeys = requestedFeedKeys.subtracting(matchedFeedKeys)
-        if !missingFeedKeys.isEmpty, entries.count <= 32 {
+        if !missingFeedKeys.isEmpty, entries.count == 1 {
             let fallbackMatches = try modelContext.fetch(FetchDescriptor<Podcast>())
                 .filter { missingFeedKeys.contains($0.feedURL.normalizedFeedKey) }
             for podcast in fallbackMatches where !seenIDs.contains(podcast.id) {

--- a/OffScript/BatchImportService.swift
+++ b/OffScript/BatchImportService.swift
@@ -258,7 +258,7 @@ final class BatchImportService: ObservableObject {
     ) throws -> Int {
         guard !entries.isEmpty else { return 0 }
 
-        let existingPodcasts = try modelContext.fetch(FetchDescriptor<Podcast>())
+        let existingPodcasts = try podcasts(matching: entries, in: modelContext)
         var podcastByFeedKey = Dictionary(
             existingPodcasts.map { ($0.feedURL.normalizedFeedKey, $0) },
             uniquingKeysWith: { first, _ in first }
@@ -345,7 +345,7 @@ final class BatchImportService: ObservableObject {
         do {
             let feedKeys = Set(entries.map { $0.feedURL.normalizedFeedKey })
             guard !feedKeys.isEmpty else { return }
-            let podcasts = try modelContext.fetch(FetchDescriptor<Podcast>())
+            let podcasts = try podcasts(matching: entries, in: modelContext)
                 .filter { feedKeys.contains($0.feedURL.normalizedFeedKey) }
             for podcast in podcasts {
                 podcast.syncStatus = "idle"
@@ -372,8 +372,84 @@ final class BatchImportService: ObservableObject {
         }
 
         let feedKey = entry.feedURL.normalizedFeedKey
-        return try modelContext.fetch(FetchDescriptor<Podcast>())
+        return try podcasts(matching: [entry], in: modelContext)
             .first { $0.feedURL.normalizedFeedKey == feedKey }
+    }
+
+    private static func podcasts(
+        matching entries: [OPMLFeedEntry],
+        in modelContext: ModelContext
+    ) throws -> [Podcast] {
+        let lookupURLs = Array(Set(entries.flatMap { feedURLLookupVariants(for: $0.feedURL) }))
+        guard !lookupURLs.isEmpty else { return [] }
+
+        var podcasts: [Podcast] = []
+        var seenIDs = Set<UUID>()
+        let chunkSize = 96
+        var startIndex = lookupURLs.startIndex
+        while startIndex < lookupURLs.endIndex {
+            let endIndex = lookupURLs.index(startIndex, offsetBy: chunkSize, limitedBy: lookupURLs.endIndex) ?? lookupURLs.endIndex
+            let chunk = Array(lookupURLs[startIndex..<endIndex])
+            let matches = try modelContext.fetch(FetchDescriptor<Podcast>(
+                predicate: #Predicate<Podcast> { chunk.contains($0.feedURL) }
+            ))
+            for podcast in matches where !seenIDs.contains(podcast.id) {
+                seenIDs.insert(podcast.id)
+                podcasts.append(podcast)
+            }
+            startIndex = endIndex
+        }
+
+        let requestedFeedKeys = Set(entries.map { $0.feedURL.normalizedFeedKey })
+        let matchedFeedKeys = Set(podcasts.map { $0.feedURL.normalizedFeedKey })
+        let missingFeedKeys = requestedFeedKeys.subtracting(matchedFeedKeys)
+        if !missingFeedKeys.isEmpty, entries.count <= 32 {
+            let fallbackMatches = try modelContext.fetch(FetchDescriptor<Podcast>())
+                .filter { missingFeedKeys.contains($0.feedURL.normalizedFeedKey) }
+            for podcast in fallbackMatches where !seenIDs.contains(podcast.id) {
+                seenIDs.insert(podcast.id)
+                podcasts.append(podcast)
+            }
+        }
+        return podcasts
+    }
+
+    private static func feedURLLookupVariants(for feedURL: URL) -> Set<URL> {
+        guard var components = URLComponents(url: feedURL, resolvingAgainstBaseURL: false) else {
+            return [feedURL]
+        }
+
+        let originalScheme = components.scheme?.lowercased()
+        let normalized = URL(string: feedURL.normalizedFeedKey) ?? feedURL
+        let normalizedPath = URLComponents(url: normalized, resolvingAgainstBaseURL: false)?.path ?? components.path
+        let trimmedPath = normalizedPath.hasSuffix("/") && normalizedPath != "/"
+            ? String(normalizedPath.dropLast())
+            : normalizedPath
+        let slashPath = trimmedPath.isEmpty || trimmedPath == "/" ? "/" : "\(trimmedPath)/"
+        var schemes: Set<String> = ["https", "http", "feed"]
+        if let originalScheme {
+            schemes.insert(originalScheme)
+        }
+        let paths = Set([components.path, normalizedPath, trimmedPath, slashPath])
+
+        components.fragment = nil
+        components.host = components.host?.lowercased()
+        if components.port == 80 || components.port == 443 {
+            components.port = nil
+        }
+
+        var variants: Set<URL> = [feedURL, normalized]
+        for scheme in schemes {
+            for path in paths {
+                var variantComponents = components
+                variantComponents.scheme = scheme
+                variantComponents.path = path
+                if let url = variantComponents.url {
+                    variants.insert(url)
+                }
+            }
+        }
+        return variants
     }
 
     private static func trimmedNonEmpty(_ value: String) -> String? {

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -259,6 +259,42 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func opmlBatchStagingResubscribesNormalizedFeedsWithoutFullTableMatch() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let existing = Podcast(
+            title: "Dormant Feed",
+            feedURL: try #require(URL(string: "feed://EXAMPLE.com/feed.xml#rss")),
+            isSubscribed: false
+        )
+        let unrelated = Podcast(
+            title: "Unrelated",
+            feedURL: try #require(URL(string: "https://other.example.com/feed.xml")),
+            isSubscribed: true
+        )
+        context.insert(existing)
+        context.insert(unrelated)
+        try context.save()
+
+        let entry = OPMLFeedEntry(
+            feedURL: try #require(URL(string: "https://example.com/feed.xml/")),
+            title: "Restaged Feed",
+            author: nil
+        )
+
+        let stagedCount = try BatchImportService.stageSubscriptions(for: [entry], in: context)
+        let podcasts = try context.fetch(FetchDescriptor<Podcast>())
+
+        #expect(stagedCount == 1)
+        #expect(podcasts.count == 2)
+        #expect(existing.isSubscribed)
+        #expect(existing.title == "Restaged Feed")
+        #expect(existing.feedURL == entry.feedURL)
+        #expect(unrelated.title == "Unrelated")
+    }
+
+    @Test
+    @MainActor
     func failedOPMLBootstrapMarksStagedSubscriptionRetryable() throws {
         let container = try makeContainer()
         let context = container.mainContext

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -259,7 +259,7 @@ struct OffScriptTests {
 
     @Test
     @MainActor
-    func opmlBatchStagingResubscribesNormalizedFeedsWithoutFullTableMatch() throws {
+    func opmlBatchStagingResubscribesNormalizedFeedWithoutExactURLEquality() throws {
         let container = try makeContainer()
         let context = container.mainContext
         let existing = Podcast(


### PR DESCRIPTION
## Summary
- replace OPML staging/cancel/failure full podcast-table scans with scoped feed URL variant lookups
- keep normalized resubscribe behavior for small edge cases where existing feeds differ by scheme, slash, case, or fragment
- add regression coverage for normalized resubscribe without creating duplicate podcasts

## Test plan
- [x] `git diff --check`
- [x] `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO`

## Risk
- **Affected surfaces:** OPML import staging, cancellation, and failure retry marking.
- **Rollback path:** revert this PR; no schema migration.