### PR TITLE
Prune inactive Home and Library tab work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Settings and Library import sheets no longer sit inside empty native navigation hosts**, reducing stray iOS navigation chrome while keeping the authored Tuner headers and inline DONE keys.
 
 ### Changed — Library performance
+- **Inactive Home and Library tabs now stop rendering their heavy page bodies** while preserving tab state, so switching from a 250+ show Library back to Home no longer keeps the hidden directory tree in the transition path.
 - **OPML staging, retry, and cancellation now use scoped feed-URL variant lookups instead of full podcast-table scans for large batches**, while preserving normalized resubscribe behavior for small single-feed edge cases.
 - **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.
 - **Single-show adds from Home, Search, and pasted feed URLs now save the subscription before feed hydration**, then use a capped bootstrap sync in the background instead of blocking the UI on a full catalog import.

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -172,7 +172,10 @@ struct ContentView: View {
             if loadedTabs.contains(.home) {
                 tabPane(.home) {
                     NavigationStack {
-                        HomeView(onOpenSettings: { isSettingsPresented = true })
+                        HomeView(
+                            isActive: selectedTab == .home,
+                            onOpenSettings: { isSettingsPresented = true }
+                        )
                     }
                 }
             }
@@ -180,7 +183,10 @@ struct ContentView: View {
             if loadedTabs.contains(.library) {
                 tabPane(.library) {
                     NavigationStack {
-                        LibraryView(onOpenSettings: { isSettingsPresented = true })
+                        LibraryView(
+                            isActive: selectedTab == .library,
+                            onOpenSettings: { isSettingsPresented = true }
+                        )
                     }
                 }
             }

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -26,73 +26,83 @@ struct HomeView: View {
     @State private var isRetuning = false
     @State private var loadGeneration = 0
     @State private var feedbackRetuneTask: Task<Void, Never>?
+    @State private var loadedRecommendationModeRaw: String?
+    let isActive: Bool
     let onOpenSettings: () -> Void
 
     private let recommendationService = RecommendationService()
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                HomeTunerHeader(
-                    isRetuning: isRetuning,
-                    onRetune: {
-                        Task { await loadSections(manual: true) }
-                    },
-                    onOpenSettings: onOpenSettings
-                )
-
-                if let errorMessage {
-                    HomeErrorRow(message: errorMessage)
-                }
-
-                if isLoading {
-                    HomeSkeletonStack()
-                } else if sections.isEmpty {
-                    // Cold start — show curated starter picks instead of a
-                    // dead-end "go search" empty state. Once the user has
-                    // three subscriptions and recommendations have any data
-                    // to work with, `sections` populates and this hides.
-                    HomeStarterRail()
-                } else {
-                    let episodeSections = sections.filter { !$0.isDiscoverySection }
-                    let discoverySections = sections.filter(\.isDiscoverySection)
-                    let leadScoredEpisode = RecommendationService.headlineCandidate(from: episodeSections)
-
-                    if let leadScoredEpisode {
-                        HeroTunerCard(
-                            episode: leadScoredEpisode.episode,
-                            reason: leadScoredEpisode.explanation,
-                            signals: leadScoredEpisode.signalTrace
+        Group {
+            if isActive {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        HomeTunerHeader(
+                            isRetuning: isRetuning,
+                            onRetune: {
+                                Task { await loadSections(manual: true) }
+                            },
+                            onOpenSettings: onOpenSettings
                         )
-                        .padding(.horizontal, OffScriptTheme.pagePadding)
-                        .padding(.bottom, 6)
-                    }
 
-                    let railSections = Self.sections(episodeSections, excluding: leadScoredEpisode?.episode.id)
-                    ForEach(Array(railSections.enumerated()), id: \.element.id) { _, section in
-                        TunerRail(
-                            title: section.title.uppercased(),
-                            episodes: section.episodes,
-                            reasonProvider: { section.explanation(for: $0) },
-                            signalProvider: { section.signalTrace(for: $0) }
-                        )
-                    }
+                        if let errorMessage {
+                            HomeErrorRow(message: errorMessage)
+                        }
 
-                    ForEach(discoverySections) { section in
-                        TunerDiscoveryRail(section: section)
-                    }
+                        if isLoading {
+                            HomeSkeletonStack()
+                        } else if sections.isEmpty {
+                            // Cold start — show curated starter picks instead of a
+                            // dead-end "go search" empty state. Once the user has
+                            // three subscriptions and recommendations have any data
+                            // to work with, `sections` populates and this hides.
+                            HomeStarterRail()
+                        } else {
+                            let episodeSections = sections.filter { !$0.isDiscoverySection }
+                            let discoverySections = sections.filter(\.isDiscoverySection)
+                            let leadScoredEpisode = RecommendationService.headlineCandidate(from: episodeSections)
 
-                    if isLoadingDiscovery {
-                        HomeDiscoveryLoadingStrip()
-                            .padding(.horizontal, OffScriptTheme.pagePadding)
+                            if let leadScoredEpisode {
+                                HeroTunerCard(
+                                    episode: leadScoredEpisode.episode,
+                                    reason: leadScoredEpisode.explanation,
+                                    signals: leadScoredEpisode.signalTrace
+                                )
+                                .padding(.horizontal, OffScriptTheme.pagePadding)
+                                .padding(.bottom, 6)
+                            }
+
+                            let railSections = Self.sections(episodeSections, excluding: leadScoredEpisode?.episode.id)
+                            ForEach(Array(railSections.enumerated()), id: \.element.id) { _, section in
+                                TunerRail(
+                                    title: section.title.uppercased(),
+                                    episodes: section.episodes,
+                                    reasonProvider: { section.explanation(for: $0) },
+                                    signalProvider: { section.signalTrace(for: $0) }
+                                )
+                            }
+
+                            ForEach(discoverySections) { section in
+                                TunerDiscoveryRail(section: section)
+                            }
+
+                            if isLoadingDiscovery {
+                                HomeDiscoveryLoadingStrip()
+                                    .padding(.horizontal, OffScriptTheme.pagePadding)
+                            }
+                        }
                     }
+                    .padding(.top, OffScriptTheme.rootContentTopPadding)
+                    .padding(.bottom, 28)
                 }
+                .accessibilityIdentifier("HomeScreen")
+            } else {
+                Color.offscriptStudioBlack
+                    .ignoresSafeArea()
+                    .accessibilityHidden(true)
             }
-            .padding(.top, OffScriptTheme.rootContentTopPadding)
-            .padding(.bottom, 28)
         }
         .background(Color.offscriptStudioBlack.ignoresSafeArea())
-        .accessibilityIdentifier("HomeScreen")
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
@@ -103,8 +113,19 @@ struct HomeView: View {
         // styling and our color tokens — that's the gray-circle chrome we
         // saw in the screenshot. The settings affordance is rendered inline
         // in HomeTunerHeader instead, where we have full control.
-        .task(id: recommendationModeRaw) { await loadSections() }
+        .task(id: "\(recommendationModeRaw)-\(isActive)") {
+            guard isActive else { return }
+            await loadSectionsIfNeeded()
+        }
+        .onChange(of: isActive) { _, active in
+            if active {
+                Task { await loadSectionsIfNeeded() }
+            } else {
+                feedbackRetuneTask?.cancel()
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .offscriptRecommendationFeedbackChanged)) { _ in
+            guard isActive else { return }
             feedbackRetuneTask?.cancel()
             feedbackRetuneTask = Task {
                 do {
@@ -117,6 +138,12 @@ struct HomeView: View {
             }
         }
         .onDisappear { feedbackRetuneTask?.cancel() }
+    }
+
+    @MainActor
+    private func loadSectionsIfNeeded() async {
+        guard sections.isEmpty || errorMessage != nil || loadedRecommendationModeRaw != recommendationModeRaw else { return }
+        await loadSections()
     }
 
     @MainActor
@@ -142,6 +169,7 @@ struct HomeView: View {
                 errorMessage = nil
                 isLoading = false
                 isLoadingDiscovery = false
+                loadedRecommendationModeRaw = recommendationModeRaw
             }
             await loadDiscovery(mode: mode, existingSections: loaded, generation: generation)
         } catch {

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -125,8 +125,11 @@ struct HomeView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .offscriptRecommendationFeedbackChanged)) { _ in
-            guard isActive else { return }
             feedbackRetuneTask?.cancel()
+            guard isActive else {
+                loadedRecommendationModeRaw = nil
+                return
+            }
             feedbackRetuneTask = Task {
                 do {
                     try await Task.sleep(nanoseconds: 180_000_000)

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -512,6 +512,7 @@ private extension BatchImportService.Phase {
 struct LibraryView: View {
     @Environment(\.modelContext) private var modelContext
 
+    let isActive: Bool
     let onOpenSettings: () -> Void
 
     private let syncService = FeedSyncService()
@@ -595,8 +596,81 @@ struct LibraryView: View {
     }
 
     var body: some View {
+        Group {
+            if isActive {
+                activeLibraryContent
+            } else {
+                Color.offscriptStudioBlack
+                    .ignoresSafeArea()
+                    .accessibilityHidden(true)
+            }
+        }
+        .background(Color.offscriptStudioBlack.ignoresSafeArea())
+        .accessibilityIdentifier("LibraryScreen")
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .navigationDestination(item: $selectedPodcastID) { podcastID in
+            if let podcast = podcast(withID: podcastID) {
+                PodcastDetailView(podcast: podcast)
+            } else {
+                LibraryDirectoryMissingShowView()
+            }
+        }
+        .task(id: isActive) {
+            guard isActive else { return }
+            activateLibraryTab()
+            loadDirectoryPodcastsIfNeeded()
+            loadLibraryEpisodeSummary()
+        }
+        .onAppear {
+            guard isActive else { return }
+            activateLibraryTab()
+        }
+        .onChange(of: isActive) { _, active in
+            if active {
+                activateLibraryTab()
+            } else {
+                isLibraryTabActive = false
+                cancelDeferredLibraryWork()
+            }
+        }
+        .onChange(of: subscribedPodcastIDs) { _, _ in scheduleLibraryEpisodeSummaryLoad() }
+        .onChange(of: directoryQuery) { _, newValue in scheduleDirectoryQuery(newValue) }
+        .onChange(of: directorySnapshotInputs) { _, _ in rebuildDirectorySnapshot() }
+        .onChange(of: selectedPodcastID) { _, _ in reloadDirectoryAfterSubscriptionChangeIfPossible() }
+        .onChange(of: directoryScope) { _, _ in
+            ensureFullDirectoryCountsIfNeeded()
+        }
+        .onChange(of: directorySort) { _, _ in
+            ensureFullDirectoryCountsIfNeeded()
+        }
+        .onDisappear {
+            isLibraryTabActive = false
+            cancelDeferredLibraryWork()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .offscriptLibrarySubscriptionsChanged)) { _ in
+            shouldReloadDirectoryOnAppear = true
+            if isActive {
+                reloadDirectoryAfterSubscriptionChangeIfPossible()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .offscriptActiveTabChanged)) { note in
+            handleActiveTabChanged(note)
+        }
+        // Settings + Import buttons render inline in LibraryTunerHeader, not
+        // as toolbar items — iOS 26 wraps toolbar buttons in glass chrome.
+        .sheet(isPresented: $isImportPresented) {
+            LibraryImportSheet()
+                .tunerModalSurface()
+        }
+    }
+
+    private var activeLibraryContent: some View {
         let snapshot = didBuildDirectorySnapshot ? cachedDirectorySnapshot : makeDirectorySnapshot()
-        ScrollViewReader { scrollProxy in
+        return ScrollViewReader { scrollProxy in
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     LibraryTunerHeader(
@@ -665,60 +739,15 @@ struct LibraryView: View {
                 .padding(.bottom, 90)
             }
         }
-        .background(Color.offscriptStudioBlack.ignoresSafeArea())
-        .accessibilityIdentifier("LibraryScreen")
-        .navigationTitle("")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
-        .toolbarColorScheme(.dark, for: .navigationBar)
-        .navigationDestination(item: $selectedPodcastID) { podcastID in
-            if let podcast = podcast(withID: podcastID) {
-                PodcastDetailView(podcast: podcast)
-            } else {
-                LibraryDirectoryMissingShowView()
-            }
-        }
-        .task {
+    }
+
+    @MainActor
+    private func activateLibraryTab() {
+        isLibraryTabActive = true
+        effectiveDirectoryQuery = directoryQuery
+        reloadDirectoryAfterSubscriptionChangeIfPossible()
+        if !shouldReloadDirectoryOnAppear {
             loadDirectoryPodcastsIfNeeded()
-            loadLibraryEpisodeSummary()
-        }
-        .onAppear {
-            isLibraryTabActive = true
-            effectiveDirectoryQuery = directoryQuery
-            reloadDirectoryAfterSubscriptionChangeIfPossible()
-            if !shouldReloadDirectoryOnAppear {
-                loadDirectoryPodcastsIfNeeded()
-            }
-        }
-        .onChange(of: subscribedPodcastIDs) { _, _ in scheduleLibraryEpisodeSummaryLoad() }
-        .onChange(of: directoryQuery) { _, newValue in scheduleDirectoryQuery(newValue) }
-        .onChange(of: directorySnapshotInputs) { _, _ in rebuildDirectorySnapshot() }
-        .onChange(of: selectedPodcastID) { _, _ in reloadDirectoryAfterSubscriptionChangeIfPossible() }
-        .onChange(of: directoryScope) { _, _ in
-            ensureFullDirectoryCountsIfNeeded()
-        }
-        .onChange(of: directorySort) { _, _ in
-            ensureFullDirectoryCountsIfNeeded()
-        }
-        .onDisappear {
-            isLibraryTabActive = false
-            summaryLoadTask?.cancel()
-            fullCountLoadTask?.cancel()
-            directoryQueryTask?.cancel()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .offscriptLibrarySubscriptionsChanged)) { _ in
-            shouldReloadDirectoryOnAppear = true
-            reloadDirectoryAfterSubscriptionChangeIfPossible()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .offscriptActiveTabChanged)) { note in
-            handleActiveTabChanged(note)
-        }
-        // Settings + Import buttons render inline in LibraryTunerHeader, not
-        // as toolbar items — iOS 26 wraps toolbar buttons in glass chrome.
-        .sheet(isPresented: $isImportPresented) {
-            LibraryImportSheet()
-                .tunerModalSurface()
         }
     }
 

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -637,14 +637,28 @@ struct LibraryView: View {
                 cancelDeferredLibraryWork()
             }
         }
-        .onChange(of: subscribedPodcastIDs) { _, _ in scheduleLibraryEpisodeSummaryLoad() }
-        .onChange(of: directoryQuery) { _, newValue in scheduleDirectoryQuery(newValue) }
-        .onChange(of: directorySnapshotInputs) { _, _ in rebuildDirectorySnapshot() }
-        .onChange(of: selectedPodcastID) { _, _ in reloadDirectoryAfterSubscriptionChangeIfPossible() }
+        .onChange(of: subscribedPodcastIDs) { _, _ in
+            guard isActive && isLibraryTabActive else { return }
+            scheduleLibraryEpisodeSummaryLoad()
+        }
+        .onChange(of: directoryQuery) { _, newValue in
+            guard isActive && isLibraryTabActive else { return }
+            scheduleDirectoryQuery(newValue)
+        }
+        .onChange(of: directorySnapshotInputs) { _, _ in
+            guard isActive && isLibraryTabActive else { return }
+            rebuildDirectorySnapshot()
+        }
+        .onChange(of: selectedPodcastID) { _, _ in
+            guard isActive && isLibraryTabActive else { return }
+            reloadDirectoryAfterSubscriptionChangeIfPossible()
+        }
         .onChange(of: directoryScope) { _, _ in
+            guard isActive && isLibraryTabActive else { return }
             ensureFullDirectoryCountsIfNeeded()
         }
         .onChange(of: directorySort) { _, _ in
+            guard isActive && isLibraryTabActive else { return }
             ensureFullDirectoryCountsIfNeeded()
         }
         .onDisappear {

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -81,6 +81,18 @@ final class OffScriptUITests: XCTestCase {
     }
 
     @MainActor
+    func testLargeLibrarySwitchesFromLibraryToHomeQuickly() throws {
+        let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 258, debugEpisodesPerShow: 3, debugLaunchTab: 1)
+        app.launch()
+
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 12))
+        XCTAssertTrue(app.staticTexts["SHOWS · DIRECTORY"].waitForExistence(timeout: 8))
+
+        app.buttons["Home"].tap()
+        XCTAssertTrue(app.screen("HomeScreen").waitForExistence(timeout: 4), "Home did not become visible quickly after leaving a 258-show Library. Hierarchy:\n\(app.debugDescription)")
+    }
+
+    @MainActor
     func testLargeLibraryAlphabetRailJumpsToSelectedLetter() throws {
         let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 258, debugEpisodesPerShow: 1, debugLaunchTab: 1)
         app.launch()


### PR DESCRIPTION
## Summary
- pass active-tab state into Home and Library so their expensive page bodies are not rendered while hidden behind the custom Tuner tab shell
- keep Home recommendations cached for the current mode and skip feedback retunes while Home is inactive
- keep Library deferred work cancelled off-tab and only refresh subscription changes when the Library is active
- add a large-library UI regression for Library -> Home switching with a seeded 258-show library

## Verification
- git diff --check
- xcodebuild build -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptUITests/OffScriptUITests/testLargeLibrarySwitchesFromLibraryToHomeQuickly CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO

Refs #107
Refs #122