### PR TITLE
Defer onboarding hydration after completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Discovery genre matches now stay low-confidence until backed by local evidence** such as latest-episode tag overlap, topic matches, show affinity, or feed freshness, and genre-only WHY copy no longer claims local evidence.
 
 ### Fixed — onboarding, import, and sync UI honesty
+- **Onboarding background hydration now yields and waits briefly after local subscription completion** so the first Home render is not immediately contending with starter-feed apply/save work on the main SwiftData context.
 - **Settings and Sign in with Apple now log identity, iCloud, signal-profile, and Keychain OSStatus breadcrumbs** so TestFlight Settings crashes and Apple sign-in failures can be correlated to the failing subsystem.
 - **Onboarding Sign in with Apple no longer has an iOS 26 missing-window precondition crash path** and now logs Keychain OSStatus details when credential persistence fails.
 - **Large OPML bootstrap imports now fetch feeds concurrently but apply SwiftData changes serially** and cap bootstrap RSS parsing to the small starter window, reducing 250+ show import stalls without changing normal full-feed sync.

--- a/OffScript/ImportProgressView.swift
+++ b/OffScript/ImportProgressView.swift
@@ -198,6 +198,8 @@ struct ImportProgressView: View {
         }
 
         Task { @MainActor in
+            await OnboardingHydrationScheduler.waitForPostOnboardingPaintGap()
+            guard !Task.isCancelled else { return }
             await syncStagedPodcastsInBackground(stagedPodcasts)
         }
     }
@@ -230,6 +232,20 @@ struct ImportProgressView: View {
                 importLogger.error("Onboarding background sync failed for \(result.podcast.feedURL, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
+}
+
+enum OnboardingHydrationScheduler {
+    nonisolated static let defaultDelayNanoseconds: UInt64 = 1_200_000_000
+
+    /// Applies a fixed post-onboarding yield plus sleep before applying feed
+    /// hydration writes on the main SwiftData context. This is a timing
+    /// heuristic only; it does not detect a completed Home render.
+    @MainActor
+    static func waitForPostOnboardingPaintGap(delayNanoseconds: UInt64 = defaultDelayNanoseconds) async {
+        await Task.yield()
+        guard delayNanoseconds > 0 else { return }
+        try? await Task.sleep(nanoseconds: delayNanoseconds)
     }
 }
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -229,6 +229,12 @@ struct OffScriptTests {
     }
 
     @Test
+    func onboardingHydrationDefersAfterCompletionToProtectFirstHomePaint() {
+        #expect(OnboardingHydrationScheduler.defaultDelayNanoseconds >= 1_000_000_000)
+        #expect(OnboardingHydrationScheduler.defaultDelayNanoseconds < 2_000_000_000)
+    }
+
+    @Test
     @MainActor
     func opmlBatchStagingResubscribesExistingNormalizedFeeds() throws {
         let container = try makeContainer()


### PR DESCRIPTION
## Summary
- add an explicit onboarding hydration scheduler that yields and waits briefly after local subscription completion
- start starter-feed hydration after that first-paint gap so Home is not immediately contending with RSS apply/save work on the main SwiftData context
- document the onboarding latency behavior and add regression coverage for the scheduler window

## Verification
- SENTRY_DSN= ci_scripts/ci_post_clone.sh
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO

Refs #106