### PR TITLE
Add performance signposts for Home and Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ### Changed — Library performance
 - **Inactive Home and Library tabs now stop rendering their heavy page bodies** while preserving tab state, so switching from a 250+ show Library back to Home no longer keeps the hidden directory tree in the transition path.
 - **Count-driven Library directory modes now derive unplayed and in-progress per-show counts from one scoped fetch** instead of scanning overlapping episode sets twice for `ATTN` views.
+- **Home/Library tab changes, recommendation loads, directory snapshots, summary fetches, and per-show count fetches now emit performance timings** so 250+ show lag can be measured from device logs instead of guessed from simulator feel.
 - **OPML staging, retry, and cancellation now use scoped feed-URL variant lookups instead of full podcast-table scans for large batches**, while preserving normalized resubscribe behavior for small single-feed edge cases.
 - **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.
 - **Single-show adds from Home, Search, and pasted feed URLs now save the subscription before feed hydration**, then use a capped bootstrap sync in the background instead of blocking the UI on a full catalog import.

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -5,6 +5,45 @@ import SwiftUI
 
 private let appLogger = Logger(subsystem: "com.offscript", category: "App")
 
+nonisolated enum OffScriptPerformanceLog {
+    private static let logger = Logger(subsystem: "com.offscript", category: "Performance")
+    private static let signposter = OSSignposter(subsystem: "com.offscript", category: "Performance")
+
+    struct Interval {
+        fileprivate let name: StaticString
+        fileprivate let state: OSSignpostIntervalState
+        fileprivate let start: ContinuousClock.Instant
+    }
+
+    static func milliseconds(since start: ContinuousClock.Instant) -> Double {
+        let duration = start.duration(to: .now).components
+        return Double(duration.seconds) * 1_000 + Double(duration.attoseconds) / 1_000_000_000_000_000
+    }
+
+    static func begin(_ name: StaticString, metadata: String = "") -> Interval {
+        let state = signposter.beginInterval(name, "\(metadata, privacy: .public)")
+        return Interval(name: name, state: state, start: .now)
+    }
+
+    static func end(_ interval: Interval, metadata: String = "") {
+        let elapsed = milliseconds(since: interval.start)
+        signposter.endInterval(interval.name, interval.state, "\(metadata, privacy: .public)")
+        log(String(describing: interval.name), elapsedMilliseconds: elapsed, metadata: metadata)
+    }
+
+    static func log(_ name: String, since start: ContinuousClock.Instant, metadata: String = "") {
+        log(name, elapsedMilliseconds: milliseconds(since: start), metadata: metadata)
+    }
+
+    private static func log(_ name: String, elapsedMilliseconds: Double, metadata: String = "") {
+        if metadata.isEmpty {
+            logger.info("\(name, privacy: .public) completed in \(elapsedMilliseconds, format: .fixed(precision: 1), privacy: .public)ms")
+        } else {
+            logger.info("\(name, privacy: .public) completed in \(elapsedMilliseconds, format: .fixed(precision: 1), privacy: .public)ms · \(metadata, privacy: .public)")
+        }
+    }
+}
+
 // MARK: - Tab identity (typed enum, not raw Int)
 
 private enum AppTab: Int, CaseIterable, Identifiable, Hashable {
@@ -143,12 +182,20 @@ struct ContentView: View {
                 selectedTab = tab
             }
         }
-        .onChange(of: selectedTab) { _, tab in
+        .onChange(of: selectedTab) { previous, tab in
+            let interval = OffScriptPerformanceLog.begin(
+                "tab.switch",
+                metadata: "\(previous.deepLinkName)->\(tab.deepLinkName)"
+            )
             loadedTabs.insert(tab)
             NotificationCenter.default.post(
                 name: .offscriptActiveTabChanged,
                 object: nil,
                 userInfo: ["tab": tab.deepLinkName]
+            )
+            OffScriptPerformanceLog.end(
+                interval,
+                metadata: "\(previous.deepLinkName)->\(tab.deepLinkName)"
             )
         }
     }

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -165,7 +165,15 @@ struct HomeView: View {
         }
         do {
             let mode = AppSettings.recommendationMode
+            let loadInterval = OffScriptPerformanceLog.begin(
+                "home.sections.fetch",
+                metadata: "mode=\(mode.rawValue)"
+            )
             let loaded = try recommendationService.homeSections(context: modelContext, mode: mode)
+            OffScriptPerformanceLog.end(
+                loadInterval,
+                metadata: "mode=\(mode.rawValue) sections=\(loaded.count)"
+            )
             guard generation == loadGeneration else { return }
             withAnimation(.easeInOut(duration: 0.25)) {
                 sections = loaded
@@ -204,13 +212,26 @@ struct HomeView: View {
             }
         }
 
+        let discoveryInterval = OffScriptPerformanceLog.begin(
+            "home.discovery",
+            metadata: "mode=\(mode.rawValue)"
+        )
         if let discovery = await recommendationService.discoverySection(context: modelContext, mode: mode) {
+            OffScriptPerformanceLog.end(
+                discoveryInterval,
+                metadata: "mode=\(mode.rawValue) results=\(discovery.discoveryResults.count)"
+            )
             guard !Task.isCancelled,
                   AppSettings.recommendationMode == mode,
                   generation == loadGeneration else { return }
             withAnimation(.easeInOut(duration: 0.25)) {
                 sections = existingSections + [discovery]
             }
+        } else {
+            OffScriptPerformanceLog.end(
+                discoveryInterval,
+                metadata: "mode=\(mode.rawValue) results=0"
+            )
         }
     }
 

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -799,8 +799,16 @@ struct LibraryView: View {
 
     @MainActor
     private func rebuildDirectorySnapshot() {
+        let interval = OffScriptPerformanceLog.begin(
+            "library.snapshot",
+            metadata: "podcasts=\(directoryPodcasts.count) scope=\(directoryScope.rawValue) sort=\(directorySort.rawValue)"
+        )
         cachedDirectorySnapshot = makeDirectorySnapshot()
         didBuildDirectorySnapshot = true
+        OffScriptPerformanceLog.end(
+            interval,
+            metadata: "podcasts=\(directoryPodcasts.count) visible=\(cachedDirectorySnapshot.visibleCount) scope=\(directoryScope.rawValue) sort=\(directorySort.rawValue)"
+        )
     }
 
     private func makeDirectorySnapshot() -> LibraryDirectorySnapshot {
@@ -925,15 +933,27 @@ struct LibraryView: View {
     @MainActor
     private func loadDirectoryPodcasts(force: Bool = false) {
         guard force || !didLoadDirectoryPodcasts else { return }
+        let interval = OffScriptPerformanceLog.begin(
+            "library.directory.fetch",
+            metadata: "force=\(force)"
+        )
         do {
             directoryPodcasts = try LibraryDirectorySnapshotLoader.subscribedPodcasts(in: modelContext)
             didLoadDirectoryPodcasts = true
             rebuildDirectorySnapshot()
+            OffScriptPerformanceLog.end(
+                interval,
+                metadata: "podcasts=\(directoryPodcasts.count) force=\(force)"
+            )
         } catch {
             directoryPodcasts = []
             didLoadDirectoryPodcasts = true
             cachedDirectorySnapshot = .empty
             didBuildDirectorySnapshot = true
+            OffScriptPerformanceLog.end(
+                interval,
+                metadata: "podcasts=0 force=\(force) failed=true"
+            )
             libraryLogger.error("Library directory snapshot load failed: \(error.localizedDescription, privacy: .public)")
         }
     }
@@ -1035,6 +1055,10 @@ struct LibraryView: View {
 
     @MainActor
     private func refreshLibraryEpisodeSummary(podcastIDs: [UUID]) async {
+        let interval = OffScriptPerformanceLog.begin(
+            "library.summary",
+            metadata: "podcasts=\(podcastIDs.count)"
+        )
         do {
             let countDescriptor = FetchDescriptor<Episode>(
                 predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed }
@@ -1066,6 +1090,10 @@ struct LibraryView: View {
                     needsInProgress: directoryNeedsFullInProgressCounts
                 )
             }
+            OffScriptPerformanceLog.end(
+                interval,
+                metadata: "podcasts=\(podcastIDs.count) unplayed=\(unplayedEpisodeCount) inProgress=\(inProgressEpisodeCount)"
+            )
         } catch {
             freshEpisodes = []
             inProgressEpisodes = []
@@ -1077,6 +1105,10 @@ struct LibraryView: View {
             fullInProgressCountsByPodcastID = [:]
             didLoadFullUnplayedCounts = false
             didLoadFullInProgressCounts = false
+            OffScriptPerformanceLog.end(
+                interval,
+                metadata: "podcasts=\(podcastIDs.count) failed=true"
+            )
             libraryLogger.error("Library summary load failed: \(error.localizedDescription, privacy: .public)")
         }
     }
@@ -1123,9 +1155,17 @@ struct LibraryView: View {
         needsUnplayed: Bool,
         needsInProgress: Bool
     ) async {
+        let interval = OffScriptPerformanceLog.begin(
+            "library.fullCounts",
+            metadata: "podcasts=\(podcastIDs.count) unplayed=\(needsUnplayed) inProgress=\(needsInProgress)"
+        )
         do {
             guard !Task.isCancelled else {
                 isLoadingFullDirectoryCounts = false
+                OffScriptPerformanceLog.end(
+                    interval,
+                    metadata: "podcasts=\(podcastIDs.count) unplayed=\(needsUnplayed) inProgress=\(needsInProgress) cancelled=true"
+                )
                 return
             }
             let counts = try await LibraryDirectoryCountLoader.countsByPodcastID(
@@ -1137,6 +1177,10 @@ struct LibraryView: View {
 
             guard !Task.isCancelled else {
                 isLoadingFullDirectoryCounts = false
+                OffScriptPerformanceLog.end(
+                    interval,
+                    metadata: "podcasts=\(podcastIDs.count) unplayed=\(needsUnplayed) inProgress=\(needsInProgress) cancelled=true"
+                )
                 return
             }
             if needsUnplayed {
@@ -1148,6 +1192,10 @@ struct LibraryView: View {
                 didLoadFullInProgressCounts = true
             }
             isLoadingFullDirectoryCounts = false
+            OffScriptPerformanceLog.end(
+                interval,
+                metadata: "podcasts=\(podcastIDs.count) unplayed=\(needsUnplayed) inProgress=\(needsInProgress)"
+            )
         } catch {
             if needsUnplayed {
                 fullUnplayedCountsByPodcastID = [:]
@@ -1158,6 +1206,10 @@ struct LibraryView: View {
                 didLoadFullInProgressCounts = false
             }
             isLoadingFullDirectoryCounts = false
+            OffScriptPerformanceLog.end(
+                interval,
+                metadata: "podcasts=\(podcastIDs.count) failed=true"
+            )
             libraryLogger.error("Library per-show directory count load failed: \(error.localizedDescription, privacy: .public)")
         }
     }


### PR DESCRIPTION
## Summary
- add a shared `OffScriptPerformanceLog` wrapper that emits `OSSignposter` intervals plus readable Performance log summaries
- instrument tab switches, Home recommendation/discovery loads, Library directory snapshots, Library summary fetches, and full per-show count fetches
- update the changelog so this measurement surface is tracked under Library performance

Closes #122.

## Verification
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination "platform=iOS Simulator,OS=latest,name=iPhone 17 Pro" -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO (88 tests passed)

## Notes
- This does not claim to fix the remaining count-scan or recommendation candidate-pool bottlenecks; it gives us device/Instruments evidence for those follow-up PRs.