### PR TITLE
Consolidate Library directory count loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Changed — Library performance
 - **Inactive Home and Library tabs now stop rendering their heavy page bodies** while preserving tab state, so switching from a 250+ show Library back to Home no longer keeps the hidden directory tree in the transition path.
+- **Count-driven Library directory modes now derive unplayed and in-progress per-show counts from one scoped fetch** instead of scanning overlapping episode sets twice for `ATTN` views.
 - **OPML staging, retry, and cancellation now use scoped feed-URL variant lookups instead of full podcast-table scans for large batches**, while preserving normalized resubscribe behavior for small single-feed edge cases.
 - **Large OPML imports now stage subscribed shows before network sync finishes**, so 250+ show libraries appear in Library immediately while feed hydration continues in the background.
 - **Single-show adds from Home, Search, and pasted feed URLs now save the subscription before feed hydration**, then use a capped bootstrap sync in the background instead of blocking the UI on a full catalog import.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -138,6 +138,13 @@ nonisolated struct LibraryDirectorySnapshot {
     var isEmpty: Bool { podcasts.isEmpty }
 }
 
+nonisolated struct LibraryDirectoryCounts: Equatable {
+    let unplayedByPodcastID: [UUID: Int]
+    let inProgressByPodcastID: [UUID: Int]
+
+    static let empty = LibraryDirectoryCounts(unplayedByPodcastID: [:], inProgressByPodcastID: [:])
+}
+
 private struct LibraryDirectorySnapshotInputs: Equatable {
     let podcasts: [LibraryDirectoryPodcast]
     let query: String
@@ -451,44 +458,69 @@ enum LibraryDirectorySnapshotLoader {
 
 @MainActor
 enum LibraryDirectoryCountLoader {
+    static func countsByPodcastID(
+        podcastIDs: [UUID],
+        needsUnplayed: Bool,
+        needsInProgress: Bool,
+        context: ModelContext
+    ) async throws -> LibraryDirectoryCounts {
+        let allowedPodcastIDs = Set(podcastIDs)
+        guard !allowedPodcastIDs.isEmpty, needsUnplayed || needsInProgress else { return .empty }
+        try Task.checkCancellation()
+
+        let descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> {
+                allowedPodcastIDs.contains($0.podcast.id)
+                    && $0.podcast.isSubscribed
+                    && !$0.isPlayed
+                    && (needsUnplayed || $0.playedPosition > 0)
+            }
+        )
+        let episodes = try context.fetch(descriptor)
+        await Task.yield()
+        try Task.checkCancellation()
+
+        var unplayedCounts: [UUID: Int] = [:]
+        var inProgressCounts: [UUID: Int] = [:]
+        for episode in episodes {
+            let podcastID = episode.podcast.id
+            guard allowedPodcastIDs.contains(podcastID) else { continue }
+            if needsUnplayed {
+                unplayedCounts[podcastID, default: 0] += 1
+            }
+            if needsInProgress, episode.playedPosition > 0 {
+                inProgressCounts[podcastID, default: 0] += 1
+            }
+        }
+
+        return LibraryDirectoryCounts(
+            unplayedByPodcastID: needsUnplayed ? unplayedCounts : [:],
+            inProgressByPodcastID: needsInProgress ? inProgressCounts : [:]
+        )
+    }
+
     static func unplayedCountsByPodcastID(
         podcastIDs: [UUID],
         context: ModelContext
     ) async throws -> [UUID: Int] {
-        try await countsByPodcastID(podcastIDs: podcastIDs, context: context) { allowedPodcastIDs in
-            FetchDescriptor<Episode>(
-                predicate: #Predicate<Episode> {
-                    allowedPodcastIDs.contains($0.podcast.id) && $0.podcast.isSubscribed && !$0.isPlayed
-                }
-            )
-        }
+        try await countsByPodcastID(
+            podcastIDs: podcastIDs,
+            needsUnplayed: true,
+            needsInProgress: false,
+            context: context
+        ).unplayedByPodcastID
     }
 
     static func inProgressCountsByPodcastID(
         podcastIDs: [UUID],
         context: ModelContext
     ) async throws -> [UUID: Int] {
-        try await countsByPodcastID(podcastIDs: podcastIDs, context: context) { allowedPodcastIDs in
-            FetchDescriptor<Episode>(
-                predicate: #Predicate<Episode> {
-                    allowedPodcastIDs.contains($0.podcast.id) && $0.podcast.isSubscribed && !$0.isPlayed && $0.playedPosition > 0
-                }
-            )
-        }
-    }
-
-    private static func countsByPodcastID(
-        podcastIDs: [UUID],
-        context: ModelContext,
-        descriptor: (Set<UUID>) -> FetchDescriptor<Episode>
-    ) async throws -> [UUID: Int] {
-        let allowedPodcastIDs = Set(podcastIDs)
-        guard !allowedPodcastIDs.isEmpty else { return [:] }
-        try Task.checkCancellation()
-        let episodes = try context.fetch(descriptor(allowedPodcastIDs))
-        await Task.yield()
-        try Task.checkCancellation()
-        return LibraryDirectoryOrganizer.countsByPodcastID(for: episodes, limitedTo: allowedPodcastIDs)
+        try await countsByPodcastID(
+            podcastIDs: podcastIDs,
+            needsUnplayed: false,
+            needsInProgress: true,
+            context: context
+        ).inProgressByPodcastID
     }
 }
 
@@ -1096,36 +1128,25 @@ struct LibraryView: View {
                 isLoadingFullDirectoryCounts = false
                 return
             }
-            var unplayedCounts = fullUnplayedCountsByPodcastID
-            var inProgressCounts = fullInProgressCountsByPodcastID
+            let counts = try await LibraryDirectoryCountLoader.countsByPodcastID(
+                podcastIDs: podcastIDs,
+                needsUnplayed: needsUnplayed,
+                needsInProgress: needsInProgress,
+                context: modelContext
+            )
 
+            guard !Task.isCancelled else {
+                isLoadingFullDirectoryCounts = false
+                return
+            }
             if needsUnplayed {
-                unplayedCounts = try await LibraryDirectoryCountLoader.unplayedCountsByPodcastID(
-                    podcastIDs: podcastIDs,
-                    context: modelContext
-                )
+                fullUnplayedCountsByPodcastID = counts.unplayedByPodcastID
                 didLoadFullUnplayedCounts = true
             }
-
-            guard !Task.isCancelled else {
-                isLoadingFullDirectoryCounts = false
-                return
-            }
-
             if needsInProgress {
-                inProgressCounts = try await LibraryDirectoryCountLoader.inProgressCountsByPodcastID(
-                    podcastIDs: podcastIDs,
-                    context: modelContext
-                )
+                fullInProgressCountsByPodcastID = counts.inProgressByPodcastID
                 didLoadFullInProgressCounts = true
             }
-
-            guard !Task.isCancelled else {
-                isLoadingFullDirectoryCounts = false
-                return
-            }
-            fullUnplayedCountsByPodcastID = unplayedCounts
-            fullInProgressCountsByPodcastID = inProgressCounts
             isLoadingFullDirectoryCounts = false
         } catch {
             if needsUnplayed {

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1737,6 +1737,49 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func libraryDirectoryCountLoaderCombinesUnplayedAndInProgressCounts() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let kept = Podcast(title: "Kept", feedURL: URL(string: "https://example.com/kept-combined.xml")!)
+        let second = Podcast(title: "Second", feedURL: URL(string: "https://example.com/second-combined.xml")!)
+        let unsubscribed = Podcast(title: "Ignored", feedURL: URL(string: "https://example.com/ignored-combined.xml")!)
+        unsubscribed.isSubscribed = false
+
+        context.insert(kept)
+        context.insert(second)
+        context.insert(unsubscribed)
+
+        let keptFresh = Episode(title: "Kept Fresh", pubDate: .now, audioURL: URL(string: "https://example.com/kept-combined-fresh.mp3")!, podcast: kept)
+        let keptStarted = Episode(title: "Kept Started", pubDate: .now, audioURL: URL(string: "https://example.com/kept-combined-started.mp3")!, podcast: kept)
+        keptStarted.playedPosition = 120
+        let keptPlayed = Episode(title: "Kept Played", pubDate: .now, audioURL: URL(string: "https://example.com/kept-combined-played.mp3")!, podcast: kept)
+        keptPlayed.isPlayed = true
+        let secondStarted = Episode(title: "Second Started", pubDate: .now, audioURL: URL(string: "https://example.com/second-combined-started.mp3")!, podcast: second)
+        secondStarted.playedPosition = 90
+        let ignoredStarted = Episode(title: "Ignored Started", pubDate: .now, audioURL: URL(string: "https://example.com/ignored-combined-started.mp3")!, podcast: unsubscribed)
+        ignoredStarted.playedPosition = 60
+
+        [keptFresh, keptStarted, keptPlayed, secondStarted, ignoredStarted].forEach(context.insert)
+        try context.save()
+
+        let counts = try await LibraryDirectoryCountLoader.countsByPodcastID(
+            podcastIDs: [kept.id, second.id, unsubscribed.id],
+            needsUnplayed: true,
+            needsInProgress: true,
+            context: context
+        )
+
+        #expect(counts.unplayedByPodcastID[kept.id] == 2)
+        #expect(counts.unplayedByPodcastID[second.id] == 1)
+        #expect(counts.unplayedByPodcastID[unsubscribed.id] == nil)
+        #expect(counts.inProgressByPodcastID[kept.id] == 1)
+        #expect(counts.inProgressByPodcastID[second.id] == 1)
+        #expect(counts.inProgressByPodcastID[unsubscribed.id] == nil)
+    }
+
+    @Test
+    @MainActor
     func libraryDirectoryCountLoaderReturnsEmptyCountsForEmptyPodcastIDs() async throws {
         let container = try makeContainer()
         let context = container.mainContext
@@ -1756,6 +1799,26 @@ struct OffScriptTests {
 
         #expect(unplayedCounts.isEmpty)
         #expect(inProgressCounts.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func libraryDirectoryCombinedCountLoaderReturnsEmptyCountsForEmptyPodcastIDs() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let podcast = Podcast(title: "Ignored", feedURL: URL(string: "https://example.com/ignored-combined-empty.xml")!)
+        context.insert(podcast)
+        context.insert(Episode(title: "Ignored Fresh", pubDate: .now, audioURL: URL(string: "https://example.com/ignored-combined-empty.mp3")!, podcast: podcast))
+        try context.save()
+
+        let counts = try await LibraryDirectoryCountLoader.countsByPodcastID(
+            podcastIDs: [],
+            needsUnplayed: true,
+            needsInProgress: true,
+            context: context
+        )
+
+        #expect(counts == .empty)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a combined `LibraryDirectoryCountLoader.countsByPodcastID` API that derives unplayed and in-progress count families from one scoped episode fetch
- update full directory count loading so `ATTN` and other count-driven modes no longer scan overlapping episode sets twice
- add regression coverage for combined counts and empty input behavior
- update the changelog under Library performance

Refs #107.

## Verification
- SENTRY_DSN= ci_scripts/ci_post_clone.sh
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination "platform=iOS Simulator,OS=latest,name=iPhone 17 Pro" -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO (90 tests passed)

## Notes
- This is still main-actor SwiftData work; the next larger step is moving count/snapshot work to a background context or denormalized count cache. This patch removes the duplicate full scan first.