### PR TITLE
Expand recommendation evidence candidate pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Podcast and episode detail pushes now use inline Tuner back keys** so Library and Home drill-down flows no longer fall back to native iOS back-button chrome.
 
 ### Changed — recommendation quality
+- **Home recommendations now fetch targeted candidates from explicitly liked and completed shows outside the global recency window**, so large high-volume libraries cannot bury older high-signal follow-ups before scoring.
 - **Home recommendations now compose multiple local evidence signals instead of stopping at the first matching rule**, so explicit topic feedback and “more from this show” reinforce one authored recommendation rather than competing as generic ranking buckets.
 - **Recommendation reason copy now has deterministic rail-length clipping for combined evidence**, keeping long show/topic explanations inside Tuner cards.
 - **Explicit “more like this” and like signals now carry substantially more weight than passive completions** so recommendations follow intentional user feedback instead of feeling like generic completion-based ranking.

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -233,10 +233,6 @@ final class RecommendationService {
                 SortDescriptor(\QueueItem.createdAt)
             ]
         ))
-        let inProgressEpisodes = try context.fetch(Self.inProgressCandidateDescriptor(limit: 120))
-            .filter { $0.podcast.isSubscribed }
-        let recentEpisodes = try context.fetch(Self.recentCandidateDescriptor(limit: 360))
-        let episodes = Self.uniqueEpisodes(queueItems.map(\.episode) + inProgressEpisodes + recentEpisodes)
 
         // Only fetch preference signals from the last 90 days to avoid loading stale history
         let signalCutoff = Calendar.current.date(byAdding: .day, value: -90, to: Date()) ?? .distantPast
@@ -246,6 +242,14 @@ final class RecommendationService {
         let playbackEvents = try context.fetch(FetchDescriptor<PlaybackEvent>(
             predicate: #Predicate<PlaybackEvent> { $0.date >= signalCutoff }
         ))
+        let inProgressEpisodes = try context.fetch(Self.inProgressCandidateDescriptor(limit: 120))
+            .filter { $0.podcast.isSubscribed }
+        let recentEpisodes = try context.fetch(Self.recentCandidateDescriptor(limit: 360))
+        let evidenceEpisodes = try context.fetch(Self.evidencePodcastCandidateDescriptor(
+            podcastIDs: Self.evidencePodcastIDs(preferences: preferences, playbackEvents: playbackEvents),
+            limit: 240
+        ))
+        let episodes = Self.uniqueEpisodes(queueItems.map(\.episode) + inProgressEpisodes + evidenceEpisodes + recentEpisodes)
         var profileEpisodeIDs = Set(episodes.map(\.id))
         profileEpisodeIDs.formUnion(preferences.map { $0.episode.id })
         profileEpisodeIDs.formUnion(playbackEvents.compactMap { $0.episode?.id })
@@ -938,10 +942,57 @@ final class RecommendationService {
         ))
     }
 
+    private static func evidencePodcastIDs(
+        preferences: [PreferenceSignal],
+        playbackEvents: [PlaybackEvent]
+    ) -> [UUID] {
+        var seen = Set<UUID>()
+        var ids: [UUID] = []
+
+        func append(_ id: UUID) {
+            guard !seen.contains(id) else { return }
+            seen.insert(id)
+            ids.append(id)
+        }
+
+        for preference in preferences
+        where (preference.action == .like || preference.action == .moreLikeThis)
+            && preference.episode.podcast.isSubscribed {
+            append(preference.episode.podcast.id)
+        }
+        for event in playbackEvents where event.kind == .completed {
+            guard let episode = event.episode, episode.podcast.isSubscribed else { continue }
+            append(episode.podcast.id)
+        }
+
+        return ids
+    }
+
     private static func recentCandidateDescriptor(limit: Int) -> FetchDescriptor<Episode> {
         var descriptor = FetchDescriptor<Episode>(
             predicate: #Predicate<Episode> {
                 $0.podcast.isSubscribed == true && $0.isPlayed == false
+            },
+            sortBy: [SortDescriptor(\Episode.pubDate, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return descriptor
+    }
+
+    private static func evidencePodcastCandidateDescriptor(podcastIDs: [UUID], limit: Int) -> FetchDescriptor<Episode> {
+        guard !podcastIDs.isEmpty else {
+            var descriptor = FetchDescriptor<Episode>(
+                predicate: #Predicate<Episode> { _ in false }
+            )
+            descriptor.fetchLimit = 0
+            return descriptor
+        }
+
+        var descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> {
+                podcastIDs.contains($0.podcast.id)
+                    && $0.podcast.isSubscribed == true
+                    && $0.isPlayed == false
             },
             sortBy: [SortDescriptor(\Episode.pubDate, order: .reverse)]
         )

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -762,6 +762,62 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func homeRecommendationsFetchExplicitShowCandidatesOutsideGlobalRecencyWindow() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let originalGenres = AppSettings.preferredGenres
+        AppSettings.preferredGenres = []
+        defer { AppSettings.preferredGenres = originalGenres }
+
+        let now = Date()
+        let likedShow = Podcast(title: "Deep Signal", feedURL: URL(string: "https://example.com/deep-signal.xml")!)
+        let noisyShow = Podcast(title: "Noisy Daily", feedURL: URL(string: "https://example.com/noisy-daily.xml")!)
+        likedShow.isSubscribed = true
+        noisyShow.isSubscribed = true
+        let seed = Episode(
+            title: "Episode You Liked",
+            pubDate: now.addingTimeInterval(-60 * 86_400),
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/deep-seed.mp3")!,
+            podcast: likedShow
+        )
+        seed.isPlayed = true
+        let earnedOlderEpisode = Episode(
+            title: "Older But Actually Relevant",
+            pubDate: now.addingTimeInterval(-45 * 86_400),
+            duration: 2_100,
+            audioURL: URL(string: "https://example.com/deep-earned.mp3")!,
+            podcast: likedShow
+        )
+
+        context.insert(likedShow)
+        context.insert(noisyShow)
+        context.insert(seed)
+        context.insert(earnedOlderEpisode)
+        context.insert(PreferenceSignal(action: .moreLikeThis, episode: seed))
+
+        for index in 0..<400 {
+            let episode = Episode(
+                title: "Noisy Fresh \(index)",
+                pubDate: now.addingTimeInterval(Double(-index) * 60),
+                duration: 1_800,
+                audioURL: URL(string: "https://example.com/noisy-\(index).mp3")!,
+                podcast: noisyShow
+            )
+            context.insert(episode)
+        }
+        try context.save()
+
+        let sections = try RecommendationService().homeSections(context: context, limit: 3)
+        let allEpisodes = sections.flatMap(\.episodes)
+        let section = try #require(sections.first(where: { $0.episodes.contains(where: { $0.id == earnedOlderEpisode.id }) }))
+
+        #expect(allEpisodes.contains(where: { $0.id == earnedOlderEpisode.id }))
+        #expect(section.signalTrace(for: earnedOlderEpisode).contains(RecommendationSignal(label: "source", value: "show intent")) == true)
+    }
+
+    @Test
+    @MainActor
     func preferenceFeedbackServicePostsRetuneNotificationAfterSaving() throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- fetch targeted candidate episodes from explicitly liked and completed shows in addition to queue/in-progress/global-recency pools
- keep existing recency caps but stop high-volume unrelated feeds from burying older high-signal show follow-ups before scoring
- add a 400-episode regression proving explicit-show candidates outside the global recency window still surface
- update the changelog under recommendation quality

Refs #108.

## Verification
- SENTRY_DSN= ci_scripts/ci_post_clone.sh
- git diff --check
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination "platform=iOS Simulator,OS=latest,name=iPhone 17 Pro" -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO (89 tests passed)