### PR TITLE
Skip taste refresh on Home activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Settings and Library import sheets no longer sit inside empty native navigation hosts**, reducing stray iOS navigation chrome while keeping the authored Tuner headers and inline DONE keys.
 
 ### Changed — Library performance
+- **Home activation now skips the full taste-profile rebuild on normal tab switches** and scores from the last saved profile plus fresh local feedback rows, reducing Library-to-Home lag for 250+ show libraries while preserving manual Retune refresh behavior.
 - **Library directory snapshots now build off the main actor and cancel stale work** so large `#-Z` filter/sort/index rebuilds do not keep blocking Library scrolling or the Library-to-Home tab transition.
 - **The Library `#-Z` selector now uses precomputed jump targets from the directory snapshot** instead of recalculating nearest sections inside every rail render, keeping 250+ show letter jumps responsive and state-consistent when filters change.
 - **Large Library rows now opt into SwiftUI equatable rendering** so unchanged channel rows avoid repaint churn while counts, filters, and import status update around them.

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -163,13 +163,21 @@ struct HomeView: View {
                 isRetuning = false
             }
         }
+        if !manual {
+            await Task.yield()
+            guard generation == loadGeneration, isActive else { return }
+        }
         do {
             let mode = AppSettings.recommendationMode
             let loadInterval = OffScriptPerformanceLog.begin(
                 "home.sections.fetch",
                 metadata: "mode=\(mode.rawValue)"
             )
-            let loaded = try recommendationService.homeSections(context: modelContext, mode: mode)
+            let loaded = try recommendationService.homeSections(
+                context: modelContext,
+                mode: mode,
+                refreshTasteProfile: manual
+            )
             OffScriptPerformanceLog.end(
                 loadInterval,
                 metadata: "mode=\(mode.rawValue) sections=\(loaded.count)"

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -186,6 +186,14 @@ final class RecommendationService {
         return primary.explanation
     }
 
+    static func effectivePreferredGenreTitles(for tasteProfile: UserTasteProfile?) -> [String] {
+        let profileGenres = tasteProfile?.preferredGenres ?? []
+        if !profileGenres.isEmpty {
+            return profileGenres
+        }
+        return AppSettings.preferredGenres.map(\.title)
+    }
+
     @MainActor
     func discoverySection(
         context: ModelContext,
@@ -195,7 +203,11 @@ final class RecommendationService {
         guard let tasteProfile = try? TasteProfileService.loadOrCreate(in: context) else { return nil }
 
         // Only show discovery if the user has some taste data
-        let hasData = !tasteProfile.topTags.isEmpty || !tasteProfile.preferredGenres.isEmpty
+        let preferredGenres = Self.effectivePreferredGenreTitles(for: tasteProfile)
+        if tasteProfile.preferredGenres.isEmpty, !preferredGenres.isEmpty {
+            tasteProfile.preferredGenres = preferredGenres
+        }
+        let hasData = !tasteProfile.topTags.isEmpty || !preferredGenres.isEmpty
         guard hasData else { return nil }
 
         let podcasts = (try? context.fetch(FetchDescriptor<Podcast>(
@@ -228,7 +240,12 @@ final class RecommendationService {
         refreshTasteProfile: Bool = true
     ) throws -> [HomeFeedSection] {
         if refreshTasteProfile {
-            try? TasteProfileService.refresh(in: context)
+            do {
+                try TasteProfileService.refresh(in: context)
+            } catch {
+                context.rollback()
+                NSLog("RecommendationService.homeSections: failed to refresh taste profile: \(String(describing: error))")
+            }
         }
         let queueItems = try context.fetch(FetchDescriptor<QueueItem>(
             sortBy: [
@@ -302,7 +319,7 @@ final class RecommendationService {
             completedShowCounts: completedShowCounts,
             explicitPositiveShowCounts: explicitPositiveShowCounts,
             queuedPositionByEpisodeID: queuedPositionByEpisodeID,
-            preferredGenres: Set((tasteProfile?.preferredGenres ?? AppSettings.preferredGenres.map(\.title)).map { $0.lowercased() }),
+            preferredGenres: Set(Self.effectivePreferredGenreTitles(for: tasteProfile).map { $0.lowercased() }),
             negativeTagWeights: negativeTagWeights,
             negativeShowWeights: negativeShowWeights
         )
@@ -723,7 +740,7 @@ final class RecommendationService {
             completedShowCounts: [:],
             explicitPositiveShowCounts: [:],
             queuedPositionByEpisodeID: [:],
-            preferredGenres: Set((tasteProfile?.preferredGenres ?? AppSettings.preferredGenres.map(\.title)).map { $0.lowercased() }),
+            preferredGenres: Set(Self.effectivePreferredGenreTitles(for: tasteProfile).map { $0.lowercased() }),
             negativeTagWeights: negativeTagWeights,
             negativeShowWeights: negativeShowWeights
         )

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -224,9 +224,12 @@ final class RecommendationService {
     func homeSections(
         context: ModelContext,
         mode: AppSettings.RecommendationMode = .balanced,
-        limit: Int = 6
+        limit: Int = 6,
+        refreshTasteProfile: Bool = true
     ) throws -> [HomeFeedSection] {
-        try? TasteProfileService.refresh(in: context)
+        if refreshTasteProfile {
+            try? TasteProfileService.refresh(in: context)
+        }
         let queueItems = try context.fetch(FetchDescriptor<QueueItem>(
             sortBy: [
                 SortDescriptor(\QueueItem.position),

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -878,6 +878,18 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func recommendationPreferredGenresFallbackToOnboardingSettingsWhenProfileIsEmpty() {
+        let originalGenres = AppSettings.preferredGenres
+        AppSettings.preferredGenres = [.technology, .newsAndPolitics]
+        defer { AppSettings.preferredGenres = originalGenres }
+
+        let emptyProfile = UserTasteProfile()
+
+        #expect(RecommendationService.effectivePreferredGenreTitles(for: emptyProfile) == ["Technology", "News & Politics"])
+    }
+
+    @Test
+    @MainActor
     func preferenceFeedbackServicePostsRetuneNotificationAfterSaving() throws {
         let container = try makeContainer()
         let context = container.mainContext

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -818,6 +818,66 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func homeRecommendationsCanSkipTasteProfileRefreshOnActivation() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let profile = UserTasteProfile()
+        profile.topTags = ["stale"]
+        profile.showAffinity = ["Known Show"]
+        profile.lastUpdatedAt = Date(timeIntervalSince1970: 100)
+
+        let podcast = Podcast(title: "Fresh Activation Signal", feedURL: URL(string: "https://example.com/fresh-activation.xml")!)
+        let seed = Episode(
+            title: "Completed Activation Seed",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/fresh-activation-seed.mp3")!,
+            podcast: podcast
+        )
+        seed.isPlayed = true
+        let candidate = Episode(
+            title: "Activation Candidate",
+            pubDate: .now,
+            duration: 1_800,
+            audioURL: URL(string: "https://example.com/fresh-activation-candidate.mp3")!,
+            podcast: podcast
+        )
+        let seedProfile = EpisodeProfile(episodeID: seed.id)
+        seedProfile.tags = ["activation"]
+        let candidateProfile = EpisodeProfile(episodeID: candidate.id)
+        candidateProfile.tags = ["activation"]
+
+        context.insert(profile)
+        context.insert(podcast)
+        context.insert(seed)
+        context.insert(candidate)
+        context.insert(seedProfile)
+        context.insert(candidateProfile)
+        context.insert(PlaybackEvent(kind: .completed, position: 1_800, episode: seed))
+        try context.save()
+
+        let sections = try RecommendationService().homeSections(
+            context: context,
+            limit: 3,
+            refreshTasteProfile: false
+        )
+
+        #expect(sections.flatMap(\.episodes).contains { $0.id == candidate.id })
+        #expect(profile.topTags == ["stale"])
+        #expect(profile.lastUpdatedAt == Date(timeIntervalSince1970: 100))
+
+        _ = try RecommendationService().homeSections(
+            context: context,
+            limit: 3,
+            refreshTasteProfile: true
+        )
+
+        #expect(profile.topTags.contains("activation"))
+    }
+
+    @Test
+    @MainActor
     func preferenceFeedbackServicePostsRetuneNotificationAfterSaving() throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- skip full taste-profile refresh on normal Home tab activation while keeping manual Retune as the explicit refresh path
- yield once before non-manual Home recommendation fetches so Library -> Home selection can commit before heavier work starts
- preserve onboarding preferred-genre signal when cached taste profiles are empty, including Discovery eligibility
- log and roll back taste-profile refresh failures instead of silently swallowing them

## Validation
- `git diff --check`
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO` (94 tests)
