### PR TITLE
Move Library directory counts off main actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Settings and Library import sheets no longer sit inside empty native navigation hosts**, reducing stray iOS navigation chrome while keeping the authored Tuner headers and inline DONE keys.
 
 ### Changed — Library performance
+- **Count-driven Library directory badges now load through a SwiftData model actor** so exact per-show unplayed/in-progress counts no longer materialize large episode sets on the main UI actor for 250+ show libraries.
 - **Home activation now skips the full taste-profile rebuild on normal tab switches** and scores from the last saved profile plus fresh local feedback rows, reducing Library-to-Home lag for 250+ show libraries while preserving manual Retune refresh behavior.
 - **Library directory snapshots now build off the main actor and cancel stale work** so large `#-Z` filter/sort/index rebuilds do not keep blocking Library scrolling or the Library-to-Home tab transition.
 - **The Library `#-Z` selector now uses precomputed jump targets from the directory snapshot** instead of recalculating nearest sections inside every rail render, keeping 250+ show letter jumps responsive and state-consistent when filters change.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -558,6 +558,48 @@ enum LibraryDirectoryCountLoader {
     }
 }
 
+@ModelActor
+actor LibraryDirectoryCountStore {
+    func countsByPodcastID(
+        podcastIDs: [UUID],
+        needsUnplayed: Bool,
+        needsInProgress: Bool
+    ) throws -> LibraryDirectoryCounts {
+        let allowedPodcastIDs = Set(podcastIDs)
+        guard !allowedPodcastIDs.isEmpty, needsUnplayed || needsInProgress else { return .empty }
+        try Task.checkCancellation()
+
+        let descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> {
+                allowedPodcastIDs.contains($0.podcast.id)
+                    && $0.podcast.isSubscribed
+                    && !$0.isPlayed
+                    && (needsUnplayed || $0.playedPosition > 0)
+            }
+        )
+        let episodes = try modelContext.fetch(descriptor)
+        try Task.checkCancellation()
+
+        var unplayedCounts: [UUID: Int] = [:]
+        var inProgressCounts: [UUID: Int] = [:]
+        for episode in episodes {
+            let podcastID = episode.podcast.id
+            guard allowedPodcastIDs.contains(podcastID) else { continue }
+            if needsUnplayed {
+                unplayedCounts[podcastID, default: 0] += 1
+            }
+            if needsInProgress, episode.playedPosition > 0 {
+                inProgressCounts[podcastID, default: 0] += 1
+            }
+        }
+
+        return LibraryDirectoryCounts(
+            unplayedByPodcastID: needsUnplayed ? unplayedCounts : [:],
+            inProgressByPodcastID: needsInProgress ? inProgressCounts : [:]
+        )
+    }
+}
+
 private extension BatchImportService.Phase {
     var isRunning: Bool {
         if case .running = self { return true }
@@ -1200,11 +1242,13 @@ struct LibraryView: View {
         guard needsUnplayed || needsInProgress else { return }
         fullCountLoadTask?.cancel()
         isLoadingFullDirectoryCounts = true
+        let modelContainer = modelContext.container
         fullCountLoadTask = Task { @MainActor in
             await refreshFullDirectoryCounts(
                 podcastIDs: podcastIDs,
                 needsUnplayed: needsUnplayed,
-                needsInProgress: needsInProgress
+                needsInProgress: needsInProgress,
+                modelContainer: modelContainer
             )
         }
     }
@@ -1213,7 +1257,8 @@ struct LibraryView: View {
     private func refreshFullDirectoryCounts(
         podcastIDs: [UUID],
         needsUnplayed: Bool,
-        needsInProgress: Bool
+        needsInProgress: Bool,
+        modelContainer: ModelContainer
     ) async {
         let interval = OffScriptPerformanceLog.begin(
             "library.fullCounts",
@@ -1228,11 +1273,11 @@ struct LibraryView: View {
                 )
                 return
             }
-            let counts = try await LibraryDirectoryCountLoader.countsByPodcastID(
+            let countStore = LibraryDirectoryCountStore(modelContainer: modelContainer)
+            let counts = try await countStore.countsByPodcastID(
                 podcastIDs: podcastIDs,
                 needsUnplayed: needsUnplayed,
-                needsInProgress: needsInProgress,
-                context: modelContext
+                needsInProgress: needsInProgress
             )
 
             guard !Task.isCancelled else {

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -514,22 +514,11 @@ enum LibraryDirectoryCountLoader {
         await Task.yield()
         try Task.checkCancellation()
 
-        var unplayedCounts: [UUID: Int] = [:]
-        var inProgressCounts: [UUID: Int] = [:]
-        for episode in episodes {
-            let podcastID = episode.podcast.id
-            guard allowedPodcastIDs.contains(podcastID) else { continue }
-            if needsUnplayed {
-                unplayedCounts[podcastID, default: 0] += 1
-            }
-            if needsInProgress, episode.playedPosition > 0 {
-                inProgressCounts[podcastID, default: 0] += 1
-            }
-        }
-
-        return LibraryDirectoryCounts(
-            unplayedByPodcastID: needsUnplayed ? unplayedCounts : [:],
-            inProgressByPodcastID: needsInProgress ? inProgressCounts : [:]
+        return LibraryDirectoryCountBucketer.counts(
+            episodes: episodes,
+            allowedPodcastIDs: allowedPodcastIDs,
+            needsUnplayed: needsUnplayed,
+            needsInProgress: needsInProgress
         )
     }
 
@@ -580,6 +569,22 @@ actor LibraryDirectoryCountStore {
         let episodes = try modelContext.fetch(descriptor)
         try Task.checkCancellation()
 
+        return LibraryDirectoryCountBucketer.counts(
+            episodes: episodes,
+            allowedPodcastIDs: allowedPodcastIDs,
+            needsUnplayed: needsUnplayed,
+            needsInProgress: needsInProgress
+        )
+    }
+}
+
+private nonisolated enum LibraryDirectoryCountBucketer {
+    static func counts(
+        episodes: [Episode],
+        allowedPodcastIDs: Set<UUID>,
+        needsUnplayed: Bool,
+        needsInProgress: Bool
+    ) -> LibraryDirectoryCounts {
         var unplayedCounts: [UUID: Int] = [:]
         var inProgressCounts: [UUID: Int] = [:]
         for episode in episodes {

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1942,7 +1942,7 @@ struct OffScriptTests {
 
     @Test
     @MainActor
-    func libraryDirectoryCountStoreBucketsCountsOffMainContext() async throws {
+    func libraryDirectoryCountStoreBucketsSubscribedShowCounts() async throws {
         let container = try makeContainer()
         let context = container.mainContext
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1942,6 +1942,40 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func libraryDirectoryCountStoreBucketsCountsOffMainContext() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let kept = Podcast(title: "Actor Kept", feedURL: URL(string: "https://example.com/actor-kept.xml")!)
+        let ignored = Podcast(title: "Actor Ignored", feedURL: URL(string: "https://example.com/actor-ignored.xml")!)
+        ignored.isSubscribed = false
+
+        context.insert(kept)
+        context.insert(ignored)
+
+        let fresh = Episode(title: "Fresh", pubDate: .now, audioURL: URL(string: "https://example.com/actor-fresh.mp3")!, podcast: kept)
+        let started = Episode(title: "Started", pubDate: .now, audioURL: URL(string: "https://example.com/actor-started.mp3")!, podcast: kept)
+        started.playedPosition = 120
+        let ignoredFresh = Episode(title: "Ignored Fresh", pubDate: .now, audioURL: URL(string: "https://example.com/actor-ignored.mp3")!, podcast: ignored)
+
+        [fresh, started, ignoredFresh].forEach(context.insert)
+        try context.save()
+
+        let countStore = LibraryDirectoryCountStore(modelContainer: container)
+        let counts = try await countStore.countsByPodcastID(
+            podcastIDs: [kept.id, ignored.id],
+            needsUnplayed: true,
+            needsInProgress: true
+        )
+
+        #expect(counts.unplayedByPodcastID[kept.id] == 2)
+        #expect(counts.unplayedByPodcastID[ignored.id] == nil)
+        #expect(counts.inProgressByPodcastID[kept.id] == 1)
+        #expect(counts.inProgressByPodcastID[ignored.id] == nil)
+    }
+
+    @Test
+    @MainActor
     func libraryDirectoryCountLoaderReturnsEmptyCountsForEmptyPodcastIDs() async throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- moves exact per-show Library directory count loading into a SwiftData `@ModelActor`
- keeps the Library UI actor responsible only for state publication after count results return
- adds actor-backed coverage for subscribed/unsubscribed count bucketing
- updates the changelog under Library performance

## Validation
- `git diff --check`
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO` (95 tests)
