### PR TITLE
Move Library summary load off main actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Settings and Library import sheets no longer sit inside empty native navigation hosts**, reducing stray iOS navigation chrome while keeping the authored Tuner headers and inline DONE keys.
 
 ### Changed — Library performance
+- **Library activation summary queries now run through the Library SwiftData model actor** and return only visible rail episode IDs to the UI actor, reducing first-paint contention for large subscribed libraries.
 - **Count-driven Library directory badges now load through a SwiftData model actor** so exact per-show unplayed/in-progress counts no longer materialize large episode sets on the main UI actor for 250+ show libraries.
 - **Home activation now skips the full taste-profile rebuild on normal tab switches** and scores from the last saved profile plus fresh local feedback rows, reducing Library-to-Home lag for 250+ show libraries while preserving manual Retune refresh behavior.
 - **Library directory snapshots now build off the main actor and cancel stale work** so large `#-Z` filter/sort/index rebuilds do not keep blocking Library scrolling or the Library-to-Home tab transition.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -1238,10 +1238,27 @@ struct LibraryView: View {
                 return
             }
 
+            var combinedEpisodeIDs = summary.freshEpisodeIDs
+            var seenEpisodeIDs = Set(combinedEpisodeIDs)
+            for episodeID in summary.inProgressEpisodeIDs where seenEpisodeIDs.insert(episodeID).inserted {
+                combinedEpisodeIDs.append(episodeID)
+            }
+            let hydratedEpisodes = try episodes(withIDs: combinedEpisodeIDs)
+            let episodesByID = Dictionary(uniqueKeysWithValues: hydratedEpisodes.map { ($0.id, $0) })
+            let hydratedFreshEpisodes = summary.freshEpisodeIDs.compactMap { episodesByID[$0] }
+            let hydratedInProgressEpisodes = summary.inProgressEpisodeIDs.compactMap { episodesByID[$0] }
+            guard !Task.isCancelled else {
+                OffScriptPerformanceLog.end(
+                    interval,
+                    metadata: "podcasts=\(podcastIDs.count) cancelled=true"
+                )
+                return
+            }
+
             unplayedEpisodeCount = summary.unplayedCount
-            freshEpisodes = try episodes(withIDs: summary.freshEpisodeIDs)
+            freshEpisodes = hydratedFreshEpisodes
             inProgressEpisodeCount = summary.inProgressCount
-            inProgressEpisodes = try episodes(withIDs: summary.inProgressEpisodeIDs)
+            inProgressEpisodes = hydratedInProgressEpisodes
             freshUnplayedCountsByPodcastID = summary.freshUnplayedCountsByPodcastID
             freshInProgressCountsByPodcastID = summary.freshInProgressCountsByPodcastID
             if directoryNeedsFullCounts {

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -162,6 +162,24 @@ nonisolated struct LibraryDirectoryCounts: Equatable, Sendable {
     static let empty = LibraryDirectoryCounts(unplayedByPodcastID: [:], inProgressByPodcastID: [:])
 }
 
+nonisolated struct LibraryEpisodeSummary: Equatable, Sendable {
+    let unplayedCount: Int
+    let inProgressCount: Int
+    let freshEpisodeIDs: [UUID]
+    let inProgressEpisodeIDs: [UUID]
+    let freshUnplayedCountsByPodcastID: [UUID: Int]
+    let freshInProgressCountsByPodcastID: [UUID: Int]
+
+    static let empty = LibraryEpisodeSummary(
+        unplayedCount: 0,
+        inProgressCount: 0,
+        freshEpisodeIDs: [],
+        inProgressEpisodeIDs: [],
+        freshUnplayedCountsByPodcastID: [:],
+        freshInProgressCountsByPodcastID: [:]
+    )
+}
+
 private struct LibraryDirectorySnapshotInputs: Equatable, Sendable {
     let podcasts: [LibraryDirectoryPodcast]
     let query: String
@@ -549,6 +567,43 @@ enum LibraryDirectoryCountLoader {
 
 @ModelActor
 actor LibraryDirectoryCountStore {
+    func episodeSummary() throws -> LibraryEpisodeSummary {
+        let countDescriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed }
+        )
+        var freshDescriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed },
+            sortBy: [SortDescriptor(\Episode.pubDate, order: .reverse)]
+        )
+        freshDescriptor.fetchLimit = 10
+        let inProgressDescriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed && $0.playedPosition > 0 }
+        )
+        var inProgressPageDescriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed && $0.playedPosition > 0 },
+            sortBy: [SortDescriptor(\Episode.lastPlayedAt, order: .reverse)]
+        )
+        inProgressPageDescriptor.fetchLimit = 8
+
+        let unplayedCount = try modelContext.fetchCount(countDescriptor)
+        try Task.checkCancellation()
+        let freshEpisodes = try modelContext.fetch(freshDescriptor)
+        try Task.checkCancellation()
+        let inProgressCount = try modelContext.fetchCount(inProgressDescriptor)
+        try Task.checkCancellation()
+        let inProgressEpisodes = try modelContext.fetch(inProgressPageDescriptor)
+        try Task.checkCancellation()
+
+        return LibraryEpisodeSummary(
+            unplayedCount: unplayedCount,
+            inProgressCount: inProgressCount,
+            freshEpisodeIDs: freshEpisodes.map(\.id),
+            inProgressEpisodeIDs: inProgressEpisodes.map(\.id),
+            freshUnplayedCountsByPodcastID: Dictionary(freshEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +),
+            freshInProgressCountsByPodcastID: Dictionary(inProgressEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
+        )
+    }
+
     func countsByPodcastID(
         podcastIDs: [UUID],
         needsUnplayed: Bool,
@@ -1156,40 +1211,39 @@ struct LibraryView: View {
                 try? await Task.sleep(nanoseconds: 1_200_000_000)
                 guard !Task.isCancelled, !BatchImportService.shared.isRunning else { return }
             }
-            await refreshLibraryEpisodeSummary(podcastIDs: podcastIDs)
+            await refreshLibraryEpisodeSummary(
+                podcastIDs: podcastIDs,
+                modelContainer: modelContext.container
+            )
         }
     }
 
     @MainActor
-    private func refreshLibraryEpisodeSummary(podcastIDs: [UUID]) async {
+    private func refreshLibraryEpisodeSummary(
+        podcastIDs: [UUID],
+        modelContainer: ModelContainer
+    ) async {
         let interval = OffScriptPerformanceLog.begin(
             "library.summary",
             metadata: "podcasts=\(podcastIDs.count)"
         )
         do {
-            let countDescriptor = FetchDescriptor<Episode>(
-                predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed }
-            )
-            var freshDescriptor = FetchDescriptor<Episode>(
-                predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed },
-                sortBy: [SortDescriptor(\Episode.pubDate, order: .reverse)]
-            )
-            freshDescriptor.fetchLimit = 10
-            let inProgressDescriptor = FetchDescriptor<Episode>(
-                predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed && $0.playedPosition > 0 }
-            )
-            var inProgressPageDescriptor = FetchDescriptor<Episode>(
-                predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed && $0.playedPosition > 0 },
-                sortBy: [SortDescriptor(\Episode.lastPlayedAt, order: .reverse)]
-            )
-            inProgressPageDescriptor.fetchLimit = 8
+            let countStore = LibraryDirectoryCountStore(modelContainer: modelContainer)
+            let summary = try await countStore.episodeSummary()
+            guard !Task.isCancelled else {
+                OffScriptPerformanceLog.end(
+                    interval,
+                    metadata: "podcasts=\(podcastIDs.count) cancelled=true"
+                )
+                return
+            }
 
-            unplayedEpisodeCount = try modelContext.fetchCount(countDescriptor)
-            freshEpisodes = try modelContext.fetch(freshDescriptor)
-            inProgressEpisodeCount = try modelContext.fetchCount(inProgressDescriptor)
-            inProgressEpisodes = try modelContext.fetch(inProgressPageDescriptor)
-            freshUnplayedCountsByPodcastID = Dictionary(freshEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
-            freshInProgressCountsByPodcastID = Dictionary(inProgressEpisodes.map { ($0.podcast.id, 1) }, uniquingKeysWith: +)
+            unplayedEpisodeCount = summary.unplayedCount
+            freshEpisodes = try episodes(withIDs: summary.freshEpisodeIDs)
+            inProgressEpisodeCount = summary.inProgressCount
+            inProgressEpisodes = try episodes(withIDs: summary.inProgressEpisodeIDs)
+            freshUnplayedCountsByPodcastID = summary.freshUnplayedCountsByPodcastID
+            freshInProgressCountsByPodcastID = summary.freshInProgressCountsByPodcastID
             if directoryNeedsFullCounts {
                 startFullDirectoryCountLoad(
                     podcastIDs: podcastIDs,
@@ -1218,6 +1272,18 @@ struct LibraryView: View {
             )
             libraryLogger.error("Library summary load failed: \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    @MainActor
+    private func episodes(withIDs ids: [UUID]) throws -> [Episode] {
+        guard !ids.isEmpty else { return [] }
+        let requestedIDs = Set(ids)
+        let descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { requestedIDs.contains($0.id) }
+        )
+        let episodes = try modelContext.fetch(descriptor)
+        let episodesByID = Dictionary(uniqueKeysWithValues: episodes.map { ($0.id, $0) })
+        return ids.compactMap { episodesByID[$0] }
     }
 
     @MainActor

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1976,7 +1976,7 @@ struct OffScriptTests {
 
     @Test
     @MainActor
-    func libraryDirectoryCountStoreBuildsSummaryWithoutMainContextEpisodeFetches() async throws {
+    func libraryDirectoryCountStoreBuildsSummaryForSubscribedPodcasts() async throws {
         let container = try makeContainer()
         let context = container.mainContext
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1976,6 +1976,67 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func libraryDirectoryCountStoreBuildsSummaryWithoutMainContextEpisodeFetches() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let subscribed = Podcast(title: "Summary Actor", feedURL: URL(string: "https://example.com/summary-actor.xml")!)
+        let unsubscribed = Podcast(title: "Summary Ignored", feedURL: URL(string: "https://example.com/summary-ignored.xml")!)
+        unsubscribed.isSubscribed = false
+        context.insert(subscribed)
+        context.insert(unsubscribed)
+
+        let olderFresh = Episode(
+            title: "Older Fresh",
+            pubDate: Date(timeIntervalSince1970: 100),
+            audioURL: URL(string: "https://example.com/older-fresh.mp3")!,
+            podcast: subscribed
+        )
+        let newestFresh = Episode(
+            title: "Newest Fresh",
+            pubDate: Date(timeIntervalSince1970: 300),
+            audioURL: URL(string: "https://example.com/newest-fresh.mp3")!,
+            podcast: subscribed
+        )
+        let inProgress = Episode(
+            title: "In Progress",
+            pubDate: Date(timeIntervalSince1970: 200),
+            audioURL: URL(string: "https://example.com/in-progress.mp3")!,
+            podcast: subscribed
+        )
+        inProgress.playedPosition = 120
+        inProgress.lastPlayedAt = Date(timeIntervalSince1970: 500)
+        let played = Episode(
+            title: "Played",
+            pubDate: Date(timeIntervalSince1970: 400),
+            audioURL: URL(string: "https://example.com/played.mp3")!,
+            podcast: subscribed
+        )
+        played.isPlayed = true
+        let ignoredFresh = Episode(
+            title: "Ignored Fresh",
+            pubDate: Date(timeIntervalSince1970: 600),
+            audioURL: URL(string: "https://example.com/ignored-summary.mp3")!,
+            podcast: unsubscribed
+        )
+
+        [olderFresh, newestFresh, inProgress, played, ignoredFresh].forEach(context.insert)
+        try context.save()
+
+        let countStore = LibraryDirectoryCountStore(modelContainer: container)
+        let summary = try await countStore.episodeSummary()
+
+        #expect(summary.unplayedCount == 3)
+        #expect(summary.inProgressCount == 1)
+        #expect(summary.freshEpisodeIDs.prefix(3) == [newestFresh.id, inProgress.id, olderFresh.id])
+        #expect(summary.inProgressEpisodeIDs == [inProgress.id])
+        #expect(summary.freshUnplayedCountsByPodcastID[subscribed.id] == 3)
+        #expect(summary.freshUnplayedCountsByPodcastID[unsubscribed.id] == nil)
+        #expect(summary.freshInProgressCountsByPodcastID[subscribed.id] == 1)
+    }
+
+    @Test
+    @MainActor
     func libraryDirectoryCountLoaderReturnsEmptyCountsForEmptyPodcastIDs() async throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- moves Library activation summary counts and visible rail ID selection into the Library SwiftData model actor
- hydrates only the bounded visible fresh/in-progress rail episodes back on the UI actor
- adds actor-backed summary coverage and changelog entry

## Validation
- `git diff --check`
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO` (96 tests)
