### PR TITLE
Move Library directory refresh off main actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Changed — Library performance
 - **The subscribed-show directory fetch now runs through the Library SwiftData model actor** so opening or refreshing a 250+ show Library returns value snapshots to the UI actor instead of fetching the podcast table on first paint.
+- **Library Tuner sync now batches subscribed-feed refreshes** so a 250+ show Library overlaps slow feed network requests and avoids one SwiftData podcast lookup per subscription before refreshing counts.
 - **Library activation summary queries now run through the Library SwiftData model actor** and return only visible rail episode IDs to the UI actor, reducing first-paint contention for large subscribed libraries.
 - **Count-driven Library directory badges now load through a SwiftData model actor** so exact per-show unplayed/in-progress counts no longer materialize large episode sets on the main UI actor for 250+ show libraries.
 - **Home activation now skips the full taste-profile rebuild on normal tab switches** and scores from the last saved profile plus fresh local feedback rows, reducing Library-to-Home lag for 250+ show libraries while preserving manual Retune refresh behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Settings and Library import sheets no longer sit inside empty native navigation hosts**, reducing stray iOS navigation chrome while keeping the authored Tuner headers and inline DONE keys.
 
 ### Changed — Library performance
+- **The subscribed-show directory fetch now runs through the Library SwiftData model actor** so opening or refreshing a 250+ show Library returns value snapshots to the UI actor instead of fetching the podcast table on first paint.
 - **Library activation summary queries now run through the Library SwiftData model actor** and return only visible rail episode IDs to the UI actor, reducing first-paint contention for large subscribed libraries.
 - **Count-driven Library directory badges now load through a SwiftData model actor** so exact per-show unplayed/in-progress counts no longer materialize large episode sets on the main UI actor for 250+ show libraries.
 - **Home activation now skips the full taste-profile rebuild on normal tab switches** and scores from the last saved profile plus fresh local feedback rows, reducing Library-to-Home lag for 250+ show libraries while preserving manual Retune refresh behavior.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -498,17 +498,6 @@ nonisolated enum LibraryDirectoryOrganizer {
 }
 
 @MainActor
-enum LibraryDirectorySnapshotLoader {
-    static func subscribedPodcasts(in context: ModelContext) throws -> [LibraryDirectoryPodcast] {
-        let descriptor = FetchDescriptor<Podcast>(
-            predicate: #Predicate<Podcast> { $0.isSubscribed },
-            sortBy: [SortDescriptor(\Podcast.title)]
-        )
-        return try context.fetch(descriptor).map(LibraryDirectoryPodcast.init(podcast:))
-    }
-}
-
-@MainActor
 enum LibraryDirectoryCountLoader {
     static func countsByPodcastID(
         podcastIDs: [UUID],
@@ -692,6 +681,8 @@ struct LibraryView: View {
 
     let isActive: Bool
     let onOpenSettings: () -> Void
+
+    private static let subscriptionIDFetchChunkSize = 400
 
     private let syncService = FeedSyncService()
     @State private var isImportPresented = false
@@ -1197,14 +1188,29 @@ struct LibraryView: View {
 
     @MainActor
     private func subscribedPodcasts(withIDs ids: [UUID]) throws -> [Podcast] {
-        let requestedIDs = Set(ids)
-        guard !requestedIDs.isEmpty else { return [] }
-        let descriptor = FetchDescriptor<Podcast>(
-            predicate: #Predicate<Podcast> {
-                requestedIDs.contains($0.id) && $0.isSubscribed
+        var podcastsByID: [UUID: Podcast] = [:]
+        var startIndex = ids.startIndex
+        while startIndex < ids.endIndex {
+            let endIndex = ids.index(
+                startIndex,
+                offsetBy: Self.subscriptionIDFetchChunkSize,
+                limitedBy: ids.endIndex
+            ) ?? ids.endIndex
+            let chunkIDs = Set(ids[startIndex..<endIndex])
+            if !chunkIDs.isEmpty {
+                let descriptor = FetchDescriptor<Podcast>(
+                    predicate: #Predicate<Podcast> {
+                        chunkIDs.contains($0.id) && $0.isSubscribed
+                    }
+                )
+                let chunkPodcasts = try modelContext.fetch(descriptor)
+                for podcast in chunkPodcasts {
+                    podcastsByID[podcast.id] = podcast
+                }
             }
-        )
-        return try modelContext.fetch(descriptor)
+            startIndex = endIndex
+        }
+        return ids.compactMap { podcastsByID[$0] }
     }
 
     @MainActor

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -567,6 +567,16 @@ enum LibraryDirectoryCountLoader {
 
 @ModelActor
 actor LibraryDirectoryCountStore {
+    func subscribedPodcasts() throws -> [LibraryDirectoryPodcast] {
+        let descriptor = FetchDescriptor<Podcast>(
+            predicate: #Predicate<Podcast> { $0.isSubscribed },
+            sortBy: [SortDescriptor(\Podcast.title)]
+        )
+        let podcasts = try modelContext.fetch(descriptor)
+        try Task.checkCancellation()
+        return podcasts.map(LibraryDirectoryPodcast.init(podcast:))
+    }
+
     func episodeSummary() throws -> LibraryEpisodeSummary {
         let countDescriptor = FetchDescriptor<Episode>(
             predicate: #Predicate<Episode> { $0.podcast.isSubscribed && !$0.isPlayed }
@@ -705,6 +715,7 @@ struct LibraryView: View {
     @State private var isLoadingFullDirectoryCounts = false
     @State private var summaryLoadTask: Task<Void, Never>?
     @State private var fullCountLoadTask: Task<Void, Never>?
+    @State private var directoryPodcastLoadTask: Task<Void, Never>?
     @State private var directorySnapshotTask: Task<Void, Never>?
     @State private var directoryQueryTask: Task<Void, Never>?
     @State private var selectedPodcastID: UUID?
@@ -1094,28 +1105,41 @@ struct LibraryView: View {
     @MainActor
     private func loadDirectoryPodcasts(force: Bool = false) {
         guard force || !didLoadDirectoryPodcasts else { return }
+        directoryPodcastLoadTask?.cancel()
+        let modelContainer = modelContext.container
         let interval = OffScriptPerformanceLog.begin(
             "library.directory.fetch",
             metadata: "force=\(force)"
         )
-        do {
-            directoryPodcasts = try LibraryDirectorySnapshotLoader.subscribedPodcasts(in: modelContext)
-            didLoadDirectoryPodcasts = true
-            rebuildDirectorySnapshot()
-            OffScriptPerformanceLog.end(
-                interval,
-                metadata: "podcasts=\(directoryPodcasts.count) force=\(force)"
-            )
-        } catch {
-            directoryPodcasts = []
-            didLoadDirectoryPodcasts = true
-            cachedDirectorySnapshot = .empty
-            didBuildDirectorySnapshot = true
-            OffScriptPerformanceLog.end(
-                interval,
-                metadata: "podcasts=0 force=\(force) failed=true"
-            )
-            libraryLogger.error("Library directory snapshot load failed: \(error.localizedDescription, privacy: .public)")
+        directoryPodcastLoadTask = Task { @MainActor in
+            do {
+                let store = LibraryDirectoryCountStore(modelContainer: modelContainer)
+                let podcasts = try await store.subscribedPodcasts()
+                guard !Task.isCancelled else {
+                    OffScriptPerformanceLog.end(
+                        interval,
+                        metadata: "force=\(force) cancelled=true"
+                    )
+                    return
+                }
+                directoryPodcasts = podcasts
+                didLoadDirectoryPodcasts = true
+                rebuildDirectorySnapshot()
+                OffScriptPerformanceLog.end(
+                    interval,
+                    metadata: "podcasts=\(directoryPodcasts.count) force=\(force)"
+                )
+            } catch {
+                directoryPodcasts = []
+                didLoadDirectoryPodcasts = true
+                cachedDirectorySnapshot = .empty
+                didBuildDirectorySnapshot = true
+                OffScriptPerformanceLog.end(
+                    interval,
+                    metadata: "podcasts=0 force=\(force) failed=true"
+                )
+                libraryLogger.error("Library directory snapshot load failed: \(error.localizedDescription, privacy: .public)")
+            }
         }
     }
 
@@ -1153,6 +1177,7 @@ struct LibraryView: View {
     private func cancelDeferredLibraryWork() {
         summaryLoadTask?.cancel()
         fullCountLoadTask?.cancel()
+        directoryPodcastLoadTask?.cancel()
         directorySnapshotTask?.cancel()
         directoryQueryTask?.cancel()
     }

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -1196,6 +1196,18 @@ struct LibraryView: View {
     }
 
     @MainActor
+    private func subscribedPodcasts(withIDs ids: [UUID]) throws -> [Podcast] {
+        let requestedIDs = Set(ids)
+        guard !requestedIDs.isEmpty else { return [] }
+        let descriptor = FetchDescriptor<Podcast>(
+            predicate: #Predicate<Podcast> {
+                requestedIDs.contains($0.id) && $0.isSubscribed
+            }
+        )
+        return try modelContext.fetch(descriptor)
+    }
+
+    @MainActor
     private func loadLibraryEpisodeSummary() {
         startLibraryEpisodeSummaryLoad(deferWhileImporting: false)
     }
@@ -1470,13 +1482,34 @@ struct LibraryView: View {
         isSyncingLibrary = true
         defer { isSyncingLibrary = false }
         let podcastIDs = subscribedPodcastIDs
-        for podcastID in podcastIDs {
-            guard let podcast = podcast(withID: podcastID) else { continue }
-            do {
-                try await syncService.sync(podcast: podcast, in: modelContext)
-            } catch {
-                libraryLogger.error("Pull-to-refresh sync failed for '\(podcast.title, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+        guard !podcastIDs.isEmpty else { return }
+        let interval = OffScriptPerformanceLog.begin(
+            "library.sync",
+            metadata: "podcasts=\(podcastIDs.count)"
+        )
+        do {
+            let podcasts = try subscribedPodcasts(withIDs: podcastIDs)
+            let results = await syncService.sync(
+                podcasts: podcasts,
+                in: modelContext,
+                options: .standard()
+            )
+            let failures = results.filter { !$0.isSuccess }
+            for result in failures {
+                if let error = result.error {
+                    libraryLogger.error("Pull-to-refresh sync failed for '\(result.podcast.title, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+                }
             }
+            OffScriptPerformanceLog.end(
+                interval,
+                metadata: "podcasts=\(podcasts.count) failed=\(failures.count)"
+            )
+        } catch {
+            OffScriptPerformanceLog.end(
+                interval,
+                metadata: "podcasts=\(podcastIDs.count) failed=true"
+            )
+            libraryLogger.error("Pull-to-refresh sync setup failed: \(error.localizedDescription, privacy: .public)")
         }
         loadDirectoryPodcasts(force: true)
         loadLibraryEpisodeSummary()

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1831,30 +1831,6 @@ struct OffScriptTests {
 
     @Test
     @MainActor
-    func libraryDirectorySnapshotLoaderBuildsValueRowsWithoutLiveQueryInvalidation() throws {
-        let container = try makeContainer()
-        let context = container.mainContext
-        let subscribed = Podcast(title: "Subscribed Show", feedURL: URL(string: "https://example.com/subscribed.xml")!)
-        subscribed.author = "Signal Desk"
-        subscribed.categories = ["Technology", "Design"]
-        subscribed.latestPubDate = Date(timeIntervalSince1970: 400)
-        let unsubscribed = Podcast(title: "Ignored Show", feedURL: URL(string: "https://example.com/ignored.xml")!)
-        unsubscribed.isSubscribed = false
-        context.insert(subscribed)
-        context.insert(unsubscribed)
-        try context.save()
-
-        let snapshots = try LibraryDirectorySnapshotLoader.subscribedPodcasts(in: context)
-
-        #expect(snapshots.map(\.id) == [subscribed.id])
-        #expect(snapshots.first?.title == "Subscribed Show")
-        #expect(snapshots.first?.author == "Signal Desk")
-        #expect(snapshots.first?.categories == ["Technology", "Design"])
-        #expect(snapshots.first?.latestPubDate == Date(timeIntervalSince1970: 400))
-    }
-
-    @Test
-    @MainActor
     func libraryDirectoryCountStoreLoadsSubscribedPodcastSnapshots() async throws {
         let container = try makeContainer()
         let context = container.mainContext

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1855,6 +1855,31 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func libraryDirectoryCountStoreLoadsSubscribedPodcastSnapshots() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let subscribed = Podcast(title: "Actor Directory", feedURL: URL(string: "https://example.com/actor-directory.xml")!)
+        subscribed.author = "Signal Desk"
+        subscribed.categories = ["Technology", "Design"]
+        subscribed.latestPubDate = Date(timeIntervalSince1970: 400)
+        let unsubscribed = Podcast(title: "Actor Ignored", feedURL: URL(string: "https://example.com/actor-ignored-directory.xml")!)
+        unsubscribed.isSubscribed = false
+        context.insert(subscribed)
+        context.insert(unsubscribed)
+        try context.save()
+
+        let store = LibraryDirectoryCountStore(modelContainer: container)
+        let snapshots = try await store.subscribedPodcasts()
+
+        #expect(snapshots.map(\.id) == [subscribed.id])
+        #expect(snapshots.first?.title == "Actor Directory")
+        #expect(snapshots.first?.author == "Signal Desk")
+        #expect(snapshots.first?.categories == ["Technology", "Design"])
+        #expect(snapshots.first?.latestPubDate == Date(timeIntervalSince1970: 400))
+    }
+
+    @Test
+    @MainActor
     func libraryDirectoryCountLoaderBucketsSubscribedShowCountsInScopedFetches() async throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- fetch subscribed Library directory rows through the Library SwiftData model actor and publish value snapshots back to the UI actor
- batch the Library Tuner sync action through FeedSyncService.sync(podcasts:) so large libraries overlap slow feed requests instead of refreshing every show serially
- update the changelog for the large-library performance path

## Verification
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination "platform=iOS Simulator,OS=latest,name=iPhone 17 Pro" -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO

## Notes
- Built on top of main after PR #141 was merged.
- Uses existing SwiftData-safe batch sync behavior: network fetches overlap, model mutation stays serialized on the app actor.