### PR TITLE
Hide root tab navigation bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Root Home, Library, Queue, and Search tabs now hide native empty navigation bars** so the top-of-app spacing is governed by the iOS safe area plus the 2pt Tuner inset instead of an invisible reserved nav bar.
 - **Shared Tuner labels, tags, and readouts now scale through Dynamic Type metrics** while preserving the mono instrument-panel vocabulary.
 - **The custom Tuner tab shell now keeps visited tab stacks alive** so returning from Library to Home does not rebuild the Home recommendation feed on every tab switch.
 - **Compact Tuner keys now keep their visual size but expose 44pt hit targets** across Library, Player, Queue, Search, downloads, and episode detail actions.

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -87,6 +87,7 @@ struct EpisodeDetailView: View {
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
+        .toolbar(.visible, for: .navigationBar)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -520,7 +520,7 @@ private struct HomeEmptyState: View {
                 .lineSpacing(2)
 
             NavigationLink {
-                SearchView()
+                SearchView(hidesRootNavigationBar: false)
             } label: {
                 HStack {
                     TunerLabel(text: "→ BROWSE SEARCH", color: .offscriptSignalYellow, size: 11)

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -105,6 +105,7 @@ struct HomeView: View {
         .background(Color.offscriptStudioBlack.ignoresSafeArea())
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -993,7 +993,7 @@ struct LibraryView: View {
                 .lineSpacing(2)
 
             NavigationLink {
-                SearchView()
+                SearchView(hidesRootNavigationBar: false)
             } label: {
                 HStack {
                     TunerLabel(text: "→ FIND SHOWS", color: .offscriptSignalYellow, size: 11)
@@ -2094,6 +2094,7 @@ struct PodcastDetailView: View {
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
+        .toolbar(.visible, for: .navigationBar)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -778,6 +778,7 @@ struct LibraryView: View {
         .accessibilityIdentifier("LibraryScreen")
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)

--- a/OffScript/QueueView.swift
+++ b/OffScript/QueueView.swift
@@ -70,7 +70,7 @@ struct QueueView: View {
                 .lineSpacing(2)
 
             NavigationLink {
-                SearchView()
+                SearchView(hidesRootNavigationBar: false)
             } label: {
                 HStack {
                     TunerLabel(text: "→ EXPLORE SHOWS", color: .offscriptSignalYellow, size: 11)

--- a/OffScript/QueueView.swift
+++ b/OffScript/QueueView.swift
@@ -51,6 +51,7 @@ struct QueueView: View {
         .accessibilityIdentifier("QueueScreen")
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -76,6 +76,7 @@ struct SearchView: View {
         .accessibilityIdentifier("SearchScreen")
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -9,6 +9,7 @@ private let searchLogger = Logger(subsystem: "com.offscript", category: "Search"
 struct SearchView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var podcasts: [Podcast]
+    let hidesRootNavigationBar: Bool
     @AppStorage("offscript.recentSearches") private var recentSearchesStorage = ""
     @State private var query = ""
     @State private var isSearchActive = false
@@ -21,6 +22,10 @@ struct SearchView: View {
     private let searchService = PodcastSearchService()
     private let syncService = FeedSyncService()
     private let starterTopics = ["Tech", "News", "Comedy", "Design", "Business", "Culture"]
+
+    init(hidesRootNavigationBar: Bool = true) {
+        self.hidesRootNavigationBar = hidesRootNavigationBar
+    }
 
     private var subscribedFeedURLs: Set<String> {
         Set(podcasts.filter(\.isSubscribed).map { $0.feedURL.absoluteString })
@@ -76,7 +81,7 @@ struct SearchView: View {
         .accessibilityIdentifier("SearchScreen")
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar(.hidden, for: .navigationBar)
+        .toolbar(hidesRootNavigationBar ? .hidden : .visible, for: .navigationBar)
         .toolbarBackground(Color.offscriptStudioBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)


### PR DESCRIPTION
## Summary
- hide the native navigation bar on Home, Library, Queue, and Search root tabs
- keep root spacing controlled by the authored Tuner safe-area padding instead of an empty iOS navigation bar reservation
- update the changelog for the Dynamic Island/top-of-app spacing pass

## Verification
- xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination "platform=iOS Simulator,OS=latest,name=iPhone 17 Pro" -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO

## Notes
- This keeps system safe areas intact while removing the extra blank navigation chrome from the root tabs.