### PR TITLE
Document agent-ready kanban routing

### DIFF
--- a/docs/AGENT_EXECUTION_RUNBOOK.md
+++ b/docs/AGENT_EXECUTION_RUNBOOK.md
@@ -47,7 +47,7 @@ Label prefilter for low-thinking candidates:
 gh issue list \
   --state open \
   --label "agent:low-thinking-ready" \
-  --search "-label:agent:senior-required"
+  --search '-label:"agent:senior-required"'
 ```
 
 Before launching the agent, confirm the issue is `Ready` in the OffScript

--- a/docs/AGENT_EXECUTION_RUNBOOK.md
+++ b/docs/AGENT_EXECUTION_RUNBOOK.md
@@ -29,6 +29,31 @@ An issue is ready for low-thinking implementation only if it has:
 If any of those are missing, first create a planning/docs PR or add an issue
 comment that turns the issue into an executable spec.
 
+## Kanban Routing Labels
+
+Use the project status and agent labels together. Status alone is not enough.
+
+- `agent:low-thinking-ready`: safe for a constrained implementation agent when
+  this runbook and the issue contract are followed.
+- `agent:needs-spec`: do not implement yet. First tighten acceptance criteria,
+  split the first slice, or add missing verification/non-goals.
+- `agent:senior-required`: do not assign to a low-thinking agent. These issues
+  need owner action, release/signing authority, real-device validation,
+  cross-surface product judgment, or broad architecture work.
+
+Label prefilter for low-thinking candidates:
+
+```sh
+gh issue list \
+  --state open \
+  --label "agent:low-thinking-ready" \
+  --search "-label:agent:senior-required"
+```
+
+Before launching the agent, confirm the issue is `Ready` in the OffScript
+project. Backlog issues with `agent:low-thinking-ready` are valid only when a
+senior/controller agent first selects a narrow slice from the issue contract.
+
 ## Branch And PR Workflow
 
 ```sh
@@ -46,8 +71,11 @@ Rules:
 5. Run the narrowest meaningful test first, then the full OffScript unit suite
    before PR.
 6. Open a PR with issue number, summary, verification, and changelog note.
-7. Let Copilot review the PR, address every actionable comment, rerun tests,
-   and merge only when checks are green or absent and merge state is clean.
+7. Let Copilot review the PR, address every actionable comment, and rerun
+   tests.
+8. Low-thinking agents stop at PR-ready. A senior/controller agent owns merge
+   authority because merging to `main` triggers Xcode Cloud/TestFlight and must
+   account for release state.
 
 ## Standard Verification
 
@@ -68,6 +96,10 @@ audio, lock screen, silent switch, Sign in with Apple, iCloud/CloudKit, and
 release visibility.
 
 ## Recommended Next Issues
+
+These are not the only runnable issues. They are the safest starting points for
+low-thinking implementation agents because the code areas, guardrails, and
+verification path are constrained.
 
 ### #105 Speed Up Large OPML Import
 
@@ -110,27 +142,6 @@ Non-goals:
 
 - do not reintroduce live `@Query` directory arrays at the root Library level;
 - do not replace the Tuner alphabet carousel with a default picker.
-
-### #108 Rebuild Recommendations Around Authored User Signal
-
-Best for product-quality agents. Start in:
-
-- `OffScript/RecommendationService.swift`
-- `OffScript/RecommendationExplainer.swift`
-- `OffScript/HomeView.swift`
-- `OffScriptTests/OffScriptTests.swift`
-
-Required proof:
-
-- fixtures covering explicit positive signal, negative signal, cold start,
-  genre-only discovery, and large seeded library behavior;
-- reason copy that does not say generic algorithm phrases;
-- no Home card overflow.
-
-Non-goals:
-
-- do not imply Apple Podcasts Search is a black-box recommendation engine;
-- do not let passive recency outrank explicit user feedback.
 
 ### #109 Complete Tuner UI Conformance Audit
 

--- a/docs/NEXT_IMPLEMENTATION_BACKLOG.md
+++ b/docs/NEXT_IMPLEMENTATION_BACKLOG.md
@@ -40,7 +40,7 @@ Label prefilter:
 gh issue list \
   --state open \
   --label "agent:low-thinking-ready" \
-  --search "-label:agent:senior-required"
+  --search '-label:"agent:senior-required"'
 ```
 
 After that prefilter, confirm the selected issue is `Ready` in the OffScript

--- a/docs/NEXT_IMPLEMENTATION_BACKLOG.md
+++ b/docs/NEXT_IMPLEMENTATION_BACKLOG.md
@@ -11,9 +11,17 @@ This backlog is safe for a senior autonomous agent that can inspect code,
 verify assumptions, and push PRs through Copilot review. It is not meant to be
 executed title-only.
 
+Every open roadmap issue now has an `Agent execution contract` in GitHub and
+one of these routing labels:
+
+- `agent:low-thinking-ready`: constrained implementation agents can work one
+  issue at a time by following the runbook.
+- `agent:needs-spec`: tighten the issue before implementation.
+- `agent:senior-required`: keep with a senior agent or owner-led workflow.
+
 For low-thinking implementation runs, start from
-[`docs/AGENT_EXECUTION_RUNBOOK.md`](AGENT_EXECUTION_RUNBOOK.md), pick one
-`Ready` issue, and require the agent to include:
+[`docs/AGENT_EXECUTION_RUNBOOK.md`](AGENT_EXECUTION_RUNBOOK.md), pick one issue
+with `agent:low-thinking-ready`, and require the agent to include:
 
 1. the issue number and lane;
 2. the exact files it expects to touch;
@@ -25,6 +33,64 @@ For low-thinking implementation runs, start from
 If an issue does not have enough context to identify files, acceptance
 criteria, verification, and non-goals, upgrade the issue first instead of
 starting implementation.
+
+Label prefilter:
+
+```sh
+gh issue list \
+  --state open \
+  --label "agent:low-thinking-ready" \
+  --search "-label:agent:senior-required"
+```
+
+After that prefilter, confirm the selected issue is `Ready` in the OffScript
+project. If it is still in Backlog, a senior/controller agent should either
+move it to Ready or define the first narrow slice before handing it to a
+low-thinking implementation agent.
+
+### Low-Thinking Ready Queue
+
+Use these for constrained implementation agents. Prefer the `Ready` items first;
+Backlog items are valid after selecting the first narrow slice from the issue
+contract.
+
+- #105 Speed up large OPML import for real libraries
+- #106 Reduce onboarding subscription latency
+- #107 Make Library performant with 250+ subscribed shows
+- #109 Complete full Tuner UI conformance audit
+- #114 Audit Settings crash reports and harden settings presentation
+- #115 Finish Library interaction polish
+- #116 Create a complete app test matrix
+- #118 Fix Home recommendation card text overflow
+- #123 Improve Search and discovery subscribe flow
+- #145 Fix podcast detail episode ordering
+- #126 Improve Queue workflows for heavy listeners
+- #127 Audit accessibility and Dynamic Type across Tuner UI
+
+### Senior Or Owner-Led Queue
+
+Do not give these to low-thinking agents without a senior wrapper because they
+touch release truth, Apple account/signing state, real-device behavior, broad
+product judgment, or cross-surface architecture.
+
+- #104 Fix release/build visibility source of truth
+- #108 Rebuild recommendations around authored user signal
+- #111 Expand Apple platform integrations and OLED polish
+- #112 Validate Sign in with Apple and iCloud/CloudKit paths
+- #113 Add regression coverage for background playback and silent switch behavior
+- #117 Improve release automation after PR merge
+- #120 Diagnose Xcode Cloud PrepareBuildForAppStoreConnect failures
+- #121 Handle uploaded but unassigned TestFlight builds
+- #124 Expand Player feature polish and reliability
+
+### Spec-First Queue
+
+These should become planning/spec PRs or tighter issue contracts before feature
+implementation starts.
+
+- #110 Redesign top chrome and safe-area usage
+- #119 Add Library power-user features for large collections
+- #125 Harden downloads and offline playback
 
 ## Immediate Release Lane
 
@@ -92,6 +158,7 @@ Turn Library into a power-user surface for large collections.
 - #115 Finish Library interaction polish
 - #119 Add Library power-user features for large collections
 - #123 Improve Search and discovery subscribe flow
+- #145 Fix podcast detail episode ordering
 
 ### Acceptance
 1. Alphabet #-Z carousel selection works reliably and jumps to the intended or
@@ -99,7 +166,9 @@ Turn Library into a power-user surface for large collections.
 2. Import, search, subscribe, duplicate-feed, and error states are clear.
 3. Large-library workflows include useful scopes, metadata signals, and bulk or
    repeated actions where appropriate.
-4. The Library stays visually Tuner-native and performant under real library
+4. Podcast detail episode ordering matches the show/feed chronology expected by
+   listeners and does not invert episode-number style feeds.
+5. The Library stays visually Tuner-native and performant under real library
    sizes.
 
 ## Tuner UI and Accessibility Lane
@@ -200,3 +269,4 @@ Give humans and agents a repeatable way to verify the app end to end.
 - #125 Harden downloads and offline playback
 - #126 Improve Queue workflows for heavy listeners
 - #127 Audit accessibility and Dynamic Type across Tuner UI
+- #145 Fix podcast detail episode ordering


### PR DESCRIPTION
## Summary
- document low-thinking, senior-required, and spec-first routing labels in the runbook
- make the low-thinking launch path a label prefilter plus project Ready check
- update the roadmap queue with issue #145 and explicit agent handoff guardrails

## Verification
- git diff --check
- subagent docs review

## Changelog
- Documentation/control-plane only; no app-facing changelog entry.