### PR TITLE
Add Library + reopen-cycle Settings smoke coverage (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
+- **Settings UI coverage now opens the config panel from the Library tab** in addition to the existing Home entry point, locking in the Library Settings open path that the build 51 crash report flagged (#114).
+- **Settings UI coverage now drives a present → dismiss → re-present cycle** to surface SwiftUI sheet lifecycle crashes that only appear after a Settings sheet has been opened, dismissed, and reopened (#114).
 - **Large-library UI smoke coverage now seeds a deterministic 258-show library** and launches directly into Library, giving the 250+ show scrolling case a repeatable simulator test instead of a manual-only complaint.
 - **Settings UI coverage now opens the config panel against a deterministic 258-show library** and verifies simulator iCloud status stays recoverable instead of crashing.
 - **Debug large-library seeding now resets stale simulator data when an explicit library size is requested**, so visual audits and UI tests are not polluted by previous sample stores.

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -56,6 +56,61 @@ final class OffScriptUITests: XCTestCase {
     }
 
     @MainActor
+    func testSettingsPanelOpensFromLibrary() throws {
+        // Settings has its own button in LibraryTunerHeader. Build 51 saw a
+        // Settings crash specifically when opened from Library, so the
+        // Library entry point gets its own smoke beyond the Home one above.
+        let app = makeApp(hasSeenOnboarding: true, debugLaunchTab: 1)
+        app.launch()
+
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 12))
+
+        let openSettings = app.buttons["Open settings"].firstMatch
+        XCTAssertTrue(openSettings.waitForExistence(timeout: 8), "Library Open settings button missing. Hierarchy:\n\(app.debugDescription)")
+        for _ in 0..<4 where !openSettings.isHittable {
+            app.swipeDown()
+        }
+        XCTAssertTrue(openSettings.isHittable, "Library Open settings button not hittable. Hierarchy:\n\(app.debugDescription)")
+        openSettings.tap()
+
+        let settingsLabel = app.staticTexts["SETTINGS · CONFIG PANEL"]
+        XCTAssertTrue(settingsLabel.waitForExistence(timeout: 10), "Settings panel did not appear from Library. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.buttons["Close settings"].waitForExistence(timeout: 5))
+
+        app.buttons["Close settings"].tap()
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 8), "Closing Settings did not return to Library. Hierarchy:\n\(app.debugDescription)")
+    }
+
+    @MainActor
+    func testSettingsPanelDismissAndReopenCycleStaysStable() throws {
+        // Build 51 reports were on the Settings sheet itself, but a recurring
+        // class of SwiftUI sheet crashes shows up only after a present →
+        // dismiss → re-present cycle (state-restoration races, double
+        // dismiss). Run that cycle and assert the panel is still healthy.
+        let app = makeApp(hasSeenOnboarding: true)
+        app.launch()
+
+        XCTAssertTrue(app.screen("HomeScreen").waitForExistence(timeout: 10))
+
+        for cycle in 0..<3 {
+            let openSettings = app.buttons["Open settings"].firstMatch
+            XCTAssertTrue(openSettings.waitForExistence(timeout: 8), "Open settings missing on cycle \(cycle). Hierarchy:\n\(app.debugDescription)")
+            openSettings.tap()
+
+            let settingsLabel = app.staticTexts["SETTINGS · CONFIG PANEL"]
+            XCTAssertTrue(settingsLabel.waitForExistence(timeout: 8), "Settings did not appear on cycle \(cycle). Hierarchy:\n\(app.debugDescription)")
+
+            let closeSettings = app.buttons["Close settings"]
+            XCTAssertTrue(closeSettings.waitForExistence(timeout: 5))
+            closeSettings.tap()
+
+            XCTAssertTrue(app.screen("HomeScreen").waitForExistence(timeout: 8), "Home did not return on cycle \(cycle). Hierarchy:\n\(app.debugDescription)")
+        }
+
+        XCTAssertEqual(app.state, .runningForeground, "App was not running in the foreground after Settings reopen cycles — likely a crash in the Settings sheet lifecycle.")
+    }
+
+    @MainActor
     func testSettingsPanelOpensWithLargeLibrarySeed() throws {
         let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 258, debugEpisodesPerShow: 3)
         app.launch()


### PR DESCRIPTION
## Summary
Settings was reported crashing on build 51. The existing UI smoke covered opening Settings from Home but not the Library entry point or the present → dismiss → re-present sheet lifecycle that often surfaces SwiftUI sheet-state crashes.

- **testSettingsPanelOpensFromLibrary** — launches into Library, taps the Library `Open settings` button, asserts the panel appears, then taps `Close settings` and asserts Library is restored cleanly.
- **testSettingsPanelDismissAndReopenCycleStaysStable** — opens, dismisses, and reopens Settings three times from Home, asserting `app.state == .runningForeground` after the cycle. A crash inside the Settings sheet lifecycle would drop the runner and fail this check.

Crash hypothesis (for the issue's audit ask): build 51 reports involved Settings opened from Library. The Library and Home open paths share `SettingsView()` but differ in modal-presentation context. These tests pin the Library path so future regressions surface in CI rather than in TestFlight crash reports.

Refs #114. Owner-action items in the issue (Sentry/MetricKit review) remain open.

## Verification
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO` — passes (101 tests, unchanged).
- `xcodebuild test-without-building ... -only-testing:OffScriptUITests/OffScriptUITests/testSettingsPanelOpensFromLibrary -only-testing:OffScriptUITests/OffScriptUITests/testSettingsPanelDismissAndReopenCycleStaysStable` — both new UI tests pass on iPhone 17 Pro / iOS latest.

## Test plan
- [ ] Manual on a real device: open Settings from the Library tab, dismiss with `DONE`, reopen — no crash.
- [ ] Manual: present sign-out confirmation, dismiss, present again — no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)