### PR TITLE
Add canonical test matrix doc (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
+- **Repository now has a canonical [`docs/TEST_MATRIX.md`](docs/TEST_MATRIX.md)** mapping every major surface (onboarding, import/export, library, search, queue, player, background playback, settings, identity/iCloud, recommendations, widgets/Live Activity, release/TestFlight visibility) to its automated test, simulator manual command (with launch arguments), and real-device-only flow — so agents and sub-agents can plan regression sweeps and PR verification without relying on conversational memory (#116).
 - **Large-library UI smoke coverage now seeds a deterministic 258-show library** and launches directly into Library, giving the 250+ show scrolling case a repeatable simulator test instead of a manual-only complaint.
 - **Settings UI coverage now opens the config panel against a deterministic 258-show library** and verifies simulator iCloud status stays recoverable instead of crashing.
 - **Debug large-library seeding now resets stale simulator data when an explicit library size is requested**, so visual audits and UI tests are not polluted by previous sample stores.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,15 @@ These live in [`CLAUDE.md`](CLAUDE.md), but the most important ones:
 - **Stay in-app.** Never open external URLs without `SFSafariViewController`.
 - **Build the actual project** before declaring something fixed. SourceKit's "Cannot find type in scope" for cross-file types is a false positive — use `xcodebuild` or the Xcode MCP `BuildProject`.
 
+## Verifying changes
+
+[`docs/TEST_MATRIX.md`](docs/TEST_MATRIX.md) is the canonical map of what
+is automated, what needs a simulator launch argument, and what only counts
+on a real device. Use it to plan a regression sweep, scope a PR's
+verification section, or sign off a release. Do not claim a real-device
+flow (background playback, Sign in with Apple, iCloud, widgets, Live
+Activity) is verified from simulator-only evidence.
+
 ## Releasing
 
 OffScript ships through **Xcode Cloud** — Apple's CI/CD that runs inside App

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ xcodebuild test -project OffScript.xcodeproj -scheme OffScript \
   -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
 ```
 
+For the full automated/simulator/real-device coverage map plus launch
+argument reference, see [`docs/TEST_MATRIX.md`](docs/TEST_MATRIX.md).
+
 ---
 
 ## Shipping

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -7,10 +7,14 @@ contract.
 
 ## How To Read This Doc
 
-Each surface has up to three rows:
+Each surface has up to four rows:
 
-- **Automated** — runs in CI / `xcodebuild`. If a row is in this column
-  the test command is the verification.
+- **Automated unit** — runs in CI / `xcodebuild` against
+  `OffScriptTests`. If a row is in this column the test command is the
+  verification.
+- **Automated UI** — runs in CI / `xcodebuild` against
+  `OffScriptUITests`. If a row is in this column the test command is the
+  verification.
 - **Simulator manual** — run on the iOS Simulator with the listed launch
   arguments. Reasonable for any agent or contributor with Xcode.
 - **TestFlight / real device** — only meaningful on hardware. Required
@@ -71,7 +75,7 @@ Source of truth: `OffScript/AppSettings.swift`, `OffScript/ContentView.swift`.
 
 | Layer | Verification | Notes |
 |---|---|---|
-| Automated unit | `OffScriptTests` — `feedSyncOPMLBootstrapCapsEpisodes…`, `feedSyncOnboardingBootstrapCapsEpisodes…`, `onboardingPreferenceSignalFetchesNewestEpisode…` | Bootstrap import + signal extraction. |
+| Automated unit | `OffScriptTests` — `feedSyncOPMLBootstrapCapsEpisodesAndSkipsProfiles`, `feedSyncOnboardingBootstrapCapsEpisodesAndSkipsExpensiveEnrichment`, `onboardingPreferenceSignalFetchesNewestEpisodeWithoutSortingRelationship` | Bootstrap import + signal extraction. |
 | Automated UI | `OffScriptUITests/testOnboardingFirstScreenSmoke` | Verifies first screen, "POWER ON →", privacy copy. |
 | Simulator manual | `-offscript.hasSeenOnboarding NO` | Walk the entire onboarding flow including starter subscriptions. |
 | Real device | TestFlight install, fresh device | Required for Sign in with Apple flow validation. Tracked in #112. |
@@ -82,7 +86,7 @@ Source of truth: `OffScript/AppSettings.swift`, `OffScript/ContentView.swift`.
 |---|---|---|
 | Automated UI | `OffScriptUITests/testLargeLibrarySeedSmoke`, `testLargeLibrarySwitchesFromLibraryToHomeQuickly`, `testLargeLibraryAlphabetRailJumpsToSelectedLetter`, `testLargeLibraryDirectoryControlsStayResponsive` | Drive a 258-show seeded library through scroll, alphabet jump, ATTN/UNPLAYED filters, search filter clear. |
 | Automated UI | `OffScriptUITests/testTunerDetailScreensUseInlineBackChrome`, `testLibraryReloadsAfterDetailUnsubscribe` | Detail-push back chrome + post-unsubscribe reload. |
-| Automated unit | `OffScriptTests` — `podcastDetailRanker*`, library snapshot/refresh tests | Episode rank labelling, snapshot indexing. |
+| Automated unit | `OffScriptTests` — `podcastDetailRankerPrefersFeedSuppliedEpisodeNumber`, `podcastDetailRankerNumbersOldestFirstOnFullFeed`, `podcastDetailRankerSuppressesNumberOnFilteredSubsets`, `podcastDetailRankerStillUsesExplicitNumberOnFilteredSubsets`, `podcastDetailRankerHandlesEmptyAndOutOfRangeIndexes`, plus `libraryDirectory*` snapshot/refresh tests | Episode rank labelling, snapshot indexing. |
 | Simulator manual | `-offscript.debugSeedLibrarySize 258 -offscript.debugSeedEpisodesPerShow 3 -offscript.debugLaunchTab 1` | Visual audit of large-library scroll perf, hairlines, density. Issues #107, #115, #119. |
 | Real device | iPhone 17 Pro, real OPML import | Required for actual import latency claims. Tracked in #105. |
 
@@ -90,7 +94,7 @@ Source of truth: `OffScript/AppSettings.swift`, `OffScript/ContentView.swift`.
 
 | Layer | Verification | Notes |
 |---|---|---|
-| Automated unit | `OffScriptTests` — `feedSync*` family (~15 tests) | Bootstrap caps, dedupe, retry, staging, cancellation, concurrent-fetch + serial-apply. |
+| Automated unit | `OffScriptTests` — `feedSync*` family: `feedSyncImportsAlreadyParsedOPMLFeedWithoutRefetching`, `feedSyncFastBatchImportUsesCheapProfilesAndSkipsExternalChapters`, `feedSyncOPMLBootstrapCapsEpisodesAndSkipsProfiles`, `feedSyncCappedImportOnlyMatchesExistingEpisodesInProcessedWindow`, `feedSyncStagesSearchSubscriptionBeforeNetworkWork`, `feedSyncSubscribeThenHydrateCanReturnBeforeNetworkWork`, `feedSyncStagesMultipleOnboardingSubscriptionsInOneBatch`, `feedSyncOnboardingBootstrapCapsEpisodesAndSkipsExpensiveEnrichment`, `feedSyncSelectsLatestCappedItemsWithoutFullFeedSort`; plus the `opmlBatch*` / `opmlImport*` / `opmlBootstrap*` siblings | Bootstrap caps, dedupe, retry, staging, cancellation, concurrent-fetch + serial-apply. |
 | Simulator manual | Drag-drop OPML into the simulator's Files app, then `IMPORT` from Library | Verifies the OPML/paste entry point and progress UI. Issue #105. |
 | Real device | TestFlight, real iCloud-sized OPML | Required for real network/feed-server timeout claims. |
 
@@ -107,7 +111,7 @@ Source of truth: `OffScript/AppSettings.swift`, `OffScript/ContentView.swift`.
 
 | Layer | Verification | Notes |
 |---|---|---|
-| Automated unit | `OffScriptTests` — `QueueService*` reorder, dedupe, position tests | Queue logic. |
+| Automated unit | `OffScriptTests` — `queueServiceMovesItemsAndPersistsOrder`, `queueServicePlayNextPromotesEpisodeToFront`, `queueServiceSkipsCurrentEpisodeWhenPoppingNext` | Queue logic. |
 | Automated UI | `OffScriptUITests/testPostOnboardingShellSmoke` | Tab visit smoke. |
 | Simulator manual | `-offscript.debugSeedSampleData YES`, queue several episodes, reorder | Issue #126 covers heavy-listener queue ergonomics. |
 | Real device | TestFlight, multi-day queue use | Required to evaluate persistence and reorder gestures at scale. |
@@ -116,7 +120,7 @@ Source of truth: `OffScript/AppSettings.swift`, `OffScript/ContentView.swift`.
 
 | Layer | Verification | Notes |
 |---|---|---|
-| Automated unit | `OffScriptTests` — `PlaybackController*`, chapter parser, transcript parser | Playback state machine, chapter/transcript pipelines. |
+| Automated unit | `OffScriptTests` — `playbackAudioSessionUsesSilentSwitchSafeCategory`, `chapterParserExtractsTimestampedShowNotes`, `rssParserExtractsFeedMetadataChaptersAndTranscripts`, `episodeResolvedChaptersPreferPersistedMetadata`, `downloadServiceDeletesLocalFilesAndResetsEpisodeState`, `downloadServiceReconcilesInterruptedDownloadsOnConfigure` | Playback audio session, chapter/transcript pipelines, download service. |
 | Simulator manual | `-offscript.debugBootPlayback YES -offscript.debugPresentPlayer YES` | Visual audit of Player and MiniPlayer surfaces. |
 | Real device only | Background playback, lock screen art, silent-switch behavior, Now Playing widget, Live Activity, Dynamic Island | Required — the simulator does not faithfully reproduce these. Tracked in #113, #124. |
 
@@ -133,7 +137,7 @@ Source of truth: `OffScript/AppSettings.swift`, `OffScript/ContentView.swift`.
 
 | Layer | Verification | Notes |
 |---|---|---|
-| Automated unit | `OffScriptTests` — `recommendationExplainer*` (~10 tests), taste profile refresh family, scoring/composition tests | WHY copy clipping, signal compositing, taste profile. |
+| Automated unit | `OffScriptTests` — `recommendationExplainer*` family (`recommendationExplainerRewritesSavedSignalReasonsFromTrace`, `recommendationExplainerComposesAndClipsExplicitEvidence`, `recommendationExplainerRewritesGenreLaneReasonsFromTrace`, `recommendationExplainerPrioritizesEvidenceInMixedDiscoveryTraces`, `recommendationExplainerDoesNotClaimLocalEvidenceForGenreOnlyDiscovery`, `recommendationExplainerPreservesGenericQuickDurationReasons`, `recommendationExplainerKeepsShortListenPreferenceReason`, `recommendationExplainerKeepsUnknownFallbacks`); `tasteProfileRefresh*` family (`tasteProfileRefreshAggregatesSignals`, `tasteProfileRefreshBuildsTagsFromCompletedEpisodes`, `tasteProfileRefreshWeightsRecentExplicitSignalAboveOldCompletion`, `tasteProfileRefreshLetsOneExplicitIntentBeatSeveralPassiveCompletions`, `tasteProfileRefreshDemotesNegativePreferenceSignals`, `tasteProfileRefreshSkipsWhenFreshUnlessForced`); `homeRecommendations*`, `recommendationScoreRewardsBetterFit`, `genrePreferenceBoostIncreasesScore`, `headlineCandidateUsesStrongestAuthoredSignalAcrossSections`, `signalLockedModeExcludesGenreOnlyCandidates`, `lessLikeThis*`, `repeatedNegativeSignalsHardSuppressSharedTags`, `discoveryPreviewEvidenceBeatsGenreOnlyCatalogMatch`, `playerSuggestionsExposeNowPlayingSignalTrace`, `playerSuggestionsPreferStrongNowPlayingOverlapOverSameShow`, `preferenceFeedbackServicePostsRetuneNotificationAfterSaving`, `recommendationPreferredGenresFallbackToOnboardingSettingsWhenProfileIsEmpty` | WHY copy clipping, signal compositing, taste profile. |
 | Simulator manual | `-offscript.debugSeedSampleData YES`, scroll Home rails | Visual audit of rail card layouts. Issue #118 covered text overflow. |
 | Real device | TestFlight, multi-day listening | Required for "follows intentional feedback" claim in CHANGELOG. Tracked in #108. |
 
@@ -156,8 +160,7 @@ Source of truth: `OffScript/AppSettings.swift`, `OffScript/ContentView.swift`.
 
 | Layer | Verification | Notes |
 |---|---|---|
-| Tooling | `scripts/app_store_connect.py xcode-cloud {probe,inspect,build-run}` | Xcode Cloud + ASC visibility helpers. |
-| Tooling | `scripts/app_store_connect.py signing-preflight --cloudkit-container iCloud.com.offscript.app --profile-type IOS_APP_STORE` | CloudKit container preflight (PR #38, #129). |
+| Tooling | `scripts/app_store_connect.py xcode-cloud {probe,inspect,reconfigure,start-build,build-run}` | Xcode Cloud + ASC visibility helpers. |
 | Manual | Verify the visible internal TestFlight build matches the latest uploaded build before declaring shipped. | Issue #121 covers the unassigned-build edge case. |
 
 ## Pre-Release Sign-Off Checklist

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -1,0 +1,187 @@
+# OffScript Test Matrix
+
+A repeatable map of every major app surface and how to verify it. Use this
+instead of relying on conversational memory when planning a regression
+sweep, signing off on a release, or scoping a new agent's verification
+contract.
+
+## How To Read This Doc
+
+Each surface has up to three rows:
+
+- **Automated** — runs in CI / `xcodebuild`. If a row is in this column
+  the test command is the verification.
+- **Simulator manual** — run on the iOS Simulator with the listed launch
+  arguments. Reasonable for any agent or contributor with Xcode.
+- **TestFlight / real device** — only meaningful on hardware. Required
+  before claiming a flow is shipped. Real-device flows can never be
+  signed off from simulator-only evidence
+  (see `docs/AGENT_EXECUTION_RUNBOOK.md`).
+
+Test commands assume `iPhone 17 Pro` on `OS=latest`. Swap the destination
+freely; CI uses the same scheme.
+
+Primary unit gate (everything in OffScriptTests):
+
+```sh
+xcodebuild test \
+  -project OffScript.xcodeproj \
+  -scheme OffScript \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' \
+  -only-testing:OffScriptTests \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Primary UI gate (everything in OffScriptUITests):
+
+```sh
+xcodebuild test \
+  -project OffScript.xcodeproj \
+  -scheme OffScript \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' \
+  -only-testing:OffScriptUITests \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+To run a single test, append `/<TestSuite>/<methodName>` to
+`-only-testing`.
+
+## Launch Argument Reference
+
+The app reads these `UserDefaults`-style launch arguments (set via
+`-key value` on `xcrun simctl launch` or `XCUIApplication.launchArguments`):
+
+| Argument | Type | Effect |
+|---|---|---|
+| `-offscript.hasSeenOnboarding` | `YES` / `NO` | Skips or forces onboarding. |
+| `-offscript.debugSeedSampleData` | `YES` / `NO` | Seeds 3 podcasts × 3 episodes for populated-state audits. |
+| `-offscript.debugSeedLibrarySize` | int (≥ 1) | Seeds a deterministic `N`-show library (`A Channel 001` … `Z Channel NNN`). Triggers automatic stale-store reset. |
+| `-offscript.debugSeedEpisodesPerShow` | int | Episode count per seeded show (paired with `debugSeedLibrarySize`). |
+| `-offscript.debugLaunchTab` | `0`-`3` | Launches directly into Home (0), Library (1), Queue (2), or Search (3). |
+| `-offscript.debugSelectedTab` | `0`-`3` | Same effect, persists selection across launches. |
+| `-offscript.debugBootPlayback` | `YES` / `NO` | Boots with a fake "now playing" state. |
+| `-offscript.debugBootIsPlaying` | `YES` / `NO` | Pairs with `debugBootPlayback`. Defaults to playing. |
+| `-offscript.debugPresentPlayer` | `YES` / `NO` | Boots with the full Player sheet open. |
+
+Source of truth: `OffScript/AppSettings.swift`, `OffScript/ContentView.swift`.
+
+## Surface Coverage
+
+### Onboarding & first-run
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated unit | `OffScriptTests` — `feedSyncOPMLBootstrapCapsEpisodes…`, `feedSyncOnboardingBootstrapCapsEpisodes…`, `onboardingPreferenceSignalFetchesNewestEpisode…` | Bootstrap import + signal extraction. |
+| Automated UI | `OffScriptUITests/testOnboardingFirstScreenSmoke` | Verifies first screen, "POWER ON →", privacy copy. |
+| Simulator manual | `-offscript.hasSeenOnboarding NO` | Walk the entire onboarding flow including starter subscriptions. |
+| Real device | TestFlight install, fresh device | Required for Sign in with Apple flow validation. Tracked in #112. |
+
+### Library — directory, filters, alphabet
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated UI | `OffScriptUITests/testLargeLibrarySeedSmoke`, `testLargeLibrarySwitchesFromLibraryToHomeQuickly`, `testLargeLibraryAlphabetRailJumpsToSelectedLetter`, `testLargeLibraryDirectoryControlsStayResponsive` | Drive a 258-show seeded library through scroll, alphabet jump, ATTN/UNPLAYED filters, search filter clear. |
+| Automated UI | `OffScriptUITests/testTunerDetailScreensUseInlineBackChrome`, `testLibraryReloadsAfterDetailUnsubscribe` | Detail-push back chrome + post-unsubscribe reload. |
+| Automated unit | `OffScriptTests` — `podcastDetailRanker*`, library snapshot/refresh tests | Episode rank labelling, snapshot indexing. |
+| Simulator manual | `-offscript.debugSeedLibrarySize 258 -offscript.debugSeedEpisodesPerShow 3 -offscript.debugLaunchTab 1` | Visual audit of large-library scroll perf, hairlines, density. Issues #107, #115, #119. |
+| Real device | iPhone 17 Pro, real OPML import | Required for actual import latency claims. Tracked in #105. |
+
+### Import & sync
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated unit | `OffScriptTests` — `feedSync*` family (~15 tests) | Bootstrap caps, dedupe, retry, staging, cancellation, concurrent-fetch + serial-apply. |
+| Simulator manual | Drag-drop OPML into the simulator's Files app, then `IMPORT` from Library | Verifies the OPML/paste entry point and progress UI. Issue #105. |
+| Real device | TestFlight, real iCloud-sized OPML | Required for real network/feed-server timeout claims. |
+
+### Search & discovery
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated UI | `OffScriptUITests/testPostOnboardingShellSmoke` | Tabs to Search and verifies the screen exists. |
+| Automated unit | `OffScriptTests` — recommendation discovery + signal trace tests | Discovery genre/local-evidence guarding. |
+| Simulator manual | Tap Search tab, query Apple Podcasts Search | Issue #123 covers subscribe-flow polish. |
+| Real device | Real Apple Podcasts Search results | Required to evaluate "no algorithm pushing" copy honesty in production. |
+
+### Queue
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated unit | `OffScriptTests` — `QueueService*` reorder, dedupe, position tests | Queue logic. |
+| Automated UI | `OffScriptUITests/testPostOnboardingShellSmoke` | Tab visit smoke. |
+| Simulator manual | `-offscript.debugSeedSampleData YES`, queue several episodes, reorder | Issue #126 covers heavy-listener queue ergonomics. |
+| Real device | TestFlight, multi-day queue use | Required to evaluate persistence and reorder gestures at scale. |
+
+### Player & playback
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated unit | `OffScriptTests` — `PlaybackController*`, chapter parser, transcript parser | Playback state machine, chapter/transcript pipelines. |
+| Simulator manual | `-offscript.debugBootPlayback YES -offscript.debugPresentPlayer YES` | Visual audit of Player and MiniPlayer surfaces. |
+| Real device only | Background playback, lock screen art, silent-switch behavior, Now Playing widget, Live Activity, Dynamic Island | Required — the simulator does not faithfully reproduce these. Tracked in #113, #124. |
+
+### Settings — identity, iCloud, counts, destructive actions
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated UI | `OffScriptUITests/testSettingsPanelOpensFromHome`, `testSettingsPanelOpensFromLibrary`, `testSettingsPanelDismissAndReopenCycleStaysStable`, `testSettingsPanelOpensWithLargeLibrarySeed` | Open from Home, open from Library, present→dismiss→re-present cycle stability, large-library seeded counts and simulator iCloud `NOT CONFIG` state. |
+| Automated unit | `OffScriptTests` — `appSettingsRoundTripsPreferences`, identity/keychain breadcrumb tests | Preference round-trip, identity logging. |
+| Simulator manual | Open Settings, tap each Tuner key, present sign-out confirmation, dismiss | Tracks #114 audit work. |
+| Real device | TestFlight Sign in with Apple, real iCloud account, sign-out + re-sign-in | Required for crash-report parity with #114 / #112. |
+
+### Recommendations
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated unit | `OffScriptTests` — `recommendationExplainer*` (~10 tests), taste profile refresh family, scoring/composition tests | WHY copy clipping, signal compositing, taste profile. |
+| Simulator manual | `-offscript.debugSeedSampleData YES`, scroll Home rails | Visual audit of rail card layouts. Issue #118 covered text overflow. |
+| Real device | TestFlight, multi-day listening | Required for "follows intentional feedback" claim in CHANGELOG. Tracked in #108. |
+
+### Background playback, audio session, silent switch
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated unit | _None — see #113._ | Issue #113 calls for adding regression coverage. |
+| Real device only | Lock screen playback, silent switch toggle while audio plays, AirPods route changes, CarPlay. | Required. Cannot be claimed from simulator. |
+
+### Widgets, Live Activity, Dynamic Island
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Automated unit | _None — visual surfaces only._ | |
+| Simulator manual | `OffScriptWidgets` preview in Xcode | Layout-only smoke. |
+| Real device only | Add widget to Home Screen, start playback, observe Live Activity + Dynamic Island | Required. Tracked under #111. |
+
+### Release & TestFlight visibility
+
+| Layer | Verification | Notes |
+|---|---|---|
+| Tooling | `scripts/app_store_connect.py xcode-cloud {probe,inspect,build-run}` | Xcode Cloud + ASC visibility helpers. |
+| Tooling | `scripts/app_store_connect.py signing-preflight --cloudkit-container iCloud.com.offscript.app --profile-type IOS_APP_STORE` | CloudKit container preflight (PR #38, #129). |
+| Manual | Verify the visible internal TestFlight build matches the latest uploaded build before declaring shipped. | Issue #121 covers the unassigned-build edge case. |
+
+## Pre-Release Sign-Off Checklist
+
+Before marking a build shipped on the project board:
+
+1. Run the **primary unit gate** (above). All tests must pass.
+2. Run the **primary UI gate** (above). All tests must pass.
+3. Confirm Xcode Cloud Archive succeeded for the release commit
+   (`scripts/app_store_connect.py xcode-cloud build-run <run-id>`).
+4. Confirm the build is **assigned to the expected internal beta group**,
+   not just uploaded — a VALID build with no group assignment is invisible
+   to testers (see #121).
+5. Real-device pass on at least one iPhone for: background playback,
+   silent switch, lock screen art, Sign in with Apple, iCloud state,
+   widgets/Live Activity. Required before claiming any of these in the
+   CHANGELOG.
+
+## Adding To The Matrix
+
+When a new automated test or simulator/real-device flow is added:
+
+1. Land the test or flow with its PR.
+2. Add a row here in the same PR. Do not claim coverage that does not
+   yet exist in code.
+3. If the flow is real-device-only, do not list a simulator command —
+   leave the simulator column empty so the matrix stays honest.


### PR DESCRIPTION
## Summary
Adds [`docs/TEST_MATRIX.md`](docs/TEST_MATRIX.md) — the canonical map of every major OffScript surface to its automated coverage, simulator manual flow (with launch arguments), and real-device-only verification. Replaces ad-hoc agent memory with a single source agents/sub-agents can plan regression sweeps and release sign-off from.

Surfaces covered:
- Onboarding & first-run
- Library (directory, filters, alphabet)
- Import & sync
- Search & discovery
- Queue
- Player & playback
- Settings (identity, iCloud, destructive actions)
- Recommendations
- Background playback / silent switch
- Widgets / Live Activity / Dynamic Island
- Release & TestFlight visibility

Each row is grounded in an actual test name, launch argument, or tooling command — no claims of automation that does not exist. Real-device-only flows are explicitly marked so simulator runs cannot be mistaken for production sign-off.

Also links the matrix from `README.md` (Running tests section) and `CONTRIBUTING.md` (new "Verifying changes" section) so contributors encounter it in the natural reading path.

Closes #116.

## Verification
- Markdown reviewed; every test name referenced exists in `OffScriptTests/OffScriptTests.swift` or `OffScriptUITests/OffScriptUITests.swift` on `main`.
- Every launch argument referenced exists in `OffScript/AppSettings.swift` or `OffScript/ContentView.swift`.
- Every tooling command (`scripts/app_store_connect.py xcode-cloud …`) exists in `scripts/app_store_connect.py`.
- No code changes, so no test gate to run for this PR.

## Test plan
- [ ] Skim the matrix end-to-end and flag any rows where the simulator/automated claim is overreaching.
- [ ] Confirm the "Pre-Release Sign-Off Checklist" matches your actual practice; adjust if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)