### PR TITLE
Label Episode Detail action + feedback buttons for VoiceOver (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
+- **Episode Detail action and feedback buttons now expose explicit VoiceOver labels** (`Play <title>` / `Resume <title>` / `Now playing <title>`, `Add <title> to queue` / `Already queued`, `Retry download for <title>`, `Like <title>` / `Liked`, `Not for me — show fewer episodes like <title>` / `Marked not for me`) and decorative SF Symbols inside those buttons are now hidden from accessibility, so VoiceOver reads one intentional label per action instead of the icon name plus the mono visible text (#127).
 - **Large-library UI smoke coverage now seeds a deterministic 258-show library** and launches directly into Library, giving the 250+ show scrolling case a repeatable simulator test instead of a manual-only complaint.
 - **Settings UI coverage now opens the config panel against a deterministic 258-show library** and verifies simulator iCloud status stays recoverable instead of crashing.
 - **Debug large-library seeding now resets stale simulator data when an explicit library size is requested**, so visual audits and UI tests are not polluted by previous sample stores.

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -202,7 +202,9 @@ struct EpisodeDetailView: View {
                 PlaybackController.shared.play(episode, in: modelContext)
             } label: {
                 HStack(spacing: 6) {
-                    Image(systemName: "play.fill").font(.system(size: 10))
+                    Image(systemName: "play.fill")
+                        .font(.system(size: 10))
+                        .accessibilityHidden(true)
                     Text(isCurrentlyPlaying ? "NOW PLAYING"
                          : episode.playedPosition > 0 ? "RESUME" : "PLAY")
                 }
@@ -217,6 +219,11 @@ struct EpisodeDetailView: View {
             }
             .buttonStyle(.plain)
             .disabled(isCurrentlyPlaying)
+            .accessibilityLabel(
+                isCurrentlyPlaying
+                    ? "Now playing \(episode.title)"
+                    : (episode.playedPosition > 0 ? "Resume \(episode.title)" : "Play \(episode.title)")
+            )
 
             Button {
                 withAnimation { try? QueueService.add(episode, in: modelContext) }
@@ -224,6 +231,7 @@ struct EpisodeDetailView: View {
                 HStack(spacing: 4) {
                     Image(systemName: episode.isQueued ? "checkmark" : "plus")
                         .font(.system(size: 9))
+                        .accessibilityHidden(true)
                     Text(episode.isQueued ? "QUEUED" : "QUEUE")
                 }
                 .font(.system(size: 9, weight: .semibold, design: .monospaced))
@@ -237,6 +245,7 @@ struct EpisodeDetailView: View {
             }
             .buttonStyle(.plain)
             .disabled(episode.isQueued)
+            .accessibilityLabel(episode.isQueued ? "Already queued" : "Add \(episode.title) to queue")
 
             DownloadButton(episode: episode)
 
@@ -288,6 +297,7 @@ struct EpisodeDetailView: View {
                             .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Retry download for \(episode.title)")
                 }
             }
             .padding(.vertical, 12)
@@ -382,6 +392,7 @@ struct EpisodeDetailView: View {
                     HStack(spacing: 6) {
                         Image(systemName: feedbackGiven == .like ? "hand.thumbsup.fill" : "hand.thumbsup")
                             .font(.system(size: 10))
+                            .accessibilityHidden(true)
                         Text("LIKE")
                     }
                     .font(.system(size: 10, weight: .bold, design: .monospaced))
@@ -396,6 +407,7 @@ struct EpisodeDetailView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(feedbackGiven != nil)
+                .accessibilityLabel(feedbackGiven == .like ? "Liked" : "Like \(episode.title)")
 
                 Button {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -407,6 +419,7 @@ struct EpisodeDetailView: View {
                     HStack(spacing: 6) {
                         Image(systemName: feedbackGiven == .lessLikeThis ? "hand.thumbsdown.fill" : "hand.thumbsdown")
                             .font(.system(size: 10))
+                            .accessibilityHidden(true)
                         Text("NOT FOR ME")
                     }
                     .font(.system(size: 10, weight: .semibold, design: .monospaced))
@@ -420,6 +433,7 @@ struct EpisodeDetailView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(feedbackGiven != nil)
+                .accessibilityLabel(feedbackGiven == .lessLikeThis ? "Marked not for me" : "Not for me — show fewer episodes like \(episode.title)")
 
                 Spacer()
             }

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -407,7 +407,13 @@ struct EpisodeDetailView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(feedbackGiven != nil)
-                .accessibilityLabel(feedbackGiven == .like ? "Liked" : "Like \(episode.title)")
+                .accessibilityLabel(
+                    feedbackGiven == .like
+                        ? "Liked"
+                        : (feedbackGiven == .lessLikeThis
+                            ? "Feedback already given: marked not for me"
+                            : "Like \(episode.title)")
+                )
 
                 Button {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -433,7 +439,13 @@ struct EpisodeDetailView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(feedbackGiven != nil)
-                .accessibilityLabel(feedbackGiven == .lessLikeThis ? "Marked not for me" : "Not for me — show fewer episodes like \(episode.title)")
+                .accessibilityLabel(
+                    feedbackGiven == .lessLikeThis
+                        ? "Marked not for me"
+                        : (feedbackGiven == .like
+                            ? "Feedback already given: liked"
+                            : "Not for me — show fewer episodes like \(episode.title)")
+                )
 
                 Spacer()
             }


### PR DESCRIPTION
## Summary
EpisodeDetailView's primary action row (PLAY/RESUME, QUEUE, RETRY DOWNLOAD) and feedback row (LIKE, NOT FOR ME) had no explicit `accessibilityLabel` calls, so VoiceOver users heard the SF Symbol name concatenated with the mono visible text — e.g. "play.fill PLAY", "hand.thumbsdown NOT FOR ME". Adds intentional one-shot labels per action and marks the decorative symbols `accessibilityHidden(true)` so the icon name no longer leaks into the spoken label.

Each label includes the episode title for cross-row uniqueness when the user is browsing a list of detail pages, matching the pattern already used in `CardComponents.swift` and the rail cards.

| Button | Label (active state) | Label (after action / disabled) |
|---|---|---|
| PLAY / RESUME / NOW PLAYING | `Play <title>` / `Resume <title>` | `Now playing <title>` |
| QUEUE | `Add <title> to queue` | `Already queued` |
| RETRY DOWNLOAD | `Retry download for <title>` | (button hidden when not failed) |
| LIKE | `Like <title>` | `Liked` |
| NOT FOR ME | `Not for me — show fewer episodes like <title>` | `Marked not for me` |

Refs #127. One surface group per the issue's scope contract — Home, Library, Search, Queue, Settings, and Player still have a11y rough edges that belong in their own follow-up PRs.

## Verification
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO` — 100/100 passes.
- No behavior change for sighted users; only the VoiceOver accessibility tree is affected.

## Test plan
- [ ] VoiceOver on a real device: open an episode detail page, swipe through the action row and feedback row — each button reads one intentional label without the SF Symbol name leaking.
- [ ] Disabled state: tap LIKE then swipe back to it — VoiceOver reads "Liked, button, dimmed" instead of the active label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)