### PR TITLE
Label SearchView buttons for VoiceOver (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
+- **Search topic chips, recent-search rows, the clear-recents key, and discovery result row buttons (`+ ADD TO LIBRARY`, `→ WEBSITE`) now expose explicit VoiceOver labels** that include the topic / search term / podcast title, so the search surface no longer surfaces ambiguous "Button" / `arrow.up.left` SF Symbol-name labels (#127).
 - **Large-library UI smoke coverage now seeds a deterministic 258-show library** and launches directly into Library, giving the 250+ show scrolling case a repeatable simulator test instead of a manual-only complaint.
 - **Settings UI coverage now opens the config panel against a deterministic 258-show library** and verifies simulator iCloud status stays recoverable instead of crashing.
 - **Debug large-library seeding now resets stale simulator data when an explicit library size is requested**, so visual audits and UI tests are not polluted by previous sample stores.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
-- **Search topic chips, recent-search rows, the clear-recents key, and discovery result row buttons (`+ ADD TO LIBRARY`, `→ WEBSITE`) now expose explicit VoiceOver labels** that include the topic / search term / podcast title, so the search surface no longer surfaces ambiguous "Button" / `arrow.up.left` SF Symbol-name labels (#127).
+- **Search topic chips, recent-search rows, the clear-recents key, and discovery result row buttons (`+ ADD TO LIBRARY`, `→ WEBSITE`) now expose explicit VoiceOver labels** that include the topic / search term / podcast title, so Search no longer exposes ambiguous "Button" / `arrow.up.left` SF Symbol-name labels (#127).
 - **Large-library UI smoke coverage now seeds a deterministic 258-show library** and launches directly into Library, giving the 250+ show scrolling case a repeatable simulator test instead of a manual-only complaint.
 - **Settings UI coverage now opens the config panel against a deterministic 258-show library** and verifies simulator iCloud status stays recoverable instead of crashing.
 - **Debug large-library seeding now resets stale simulator data when an explicit library size is requested**, so visual audits and UI tests are not polluted by previous sample stores.

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -334,6 +334,7 @@ private struct StarterTopicsSection: View {
                             .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Search for \(topic)")
                 }
             }
         }
@@ -357,6 +358,7 @@ private struct RecentSearchesSection: View {
                     TunerLabel(text: "× CLEAR", color: .offscriptFnRecord, size: 9)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Clear recent searches")
             }
 
             LazyVStack(spacing: 0) {
@@ -377,10 +379,12 @@ private struct RecentSearchesSection: View {
                             Image(systemName: "arrow.up.left")
                                 .font(.system(size: 10, weight: .semibold))
                                 .foregroundStyle(Color.offscriptSoftPaper)
+                                .accessibilityHidden(true)
                         }
                         .padding(.vertical, 10)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Search again for \(item)")
                     if idx < items.count - 1 {
                         Rectangle().fill(Color.offscriptHairline).frame(height: 1)
                     }
@@ -497,6 +501,11 @@ private struct SearchResultRow: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(isImporting || isAdded)
+                .accessibilityLabel(
+                    isAdded
+                        ? "\(result.title) is already in your library"
+                        : (isImporting ? "Adding \(result.title) to library" : "Add \(result.title) to library")
+                )
 
                 if let host = result.websiteURL {
                     Button {
@@ -510,6 +519,7 @@ private struct SearchResultRow: View {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Open \(result.title) website")
                 }
                 Spacer()
             }


### PR DESCRIPTION
## Summary
SearchView's topic chips, recent-search rows, the clear-recents key, and discovery result-row buttons (`+ ADD TO LIBRARY`, `→ WEBSITE`) had no explicit \`accessibilityLabel\` calls. VoiceOver fell back to the visible mono text — and in the recent-searches row, the literal `arrow.up.left` SF Symbol name leaked into the spoken label.

Adds intentional labels per action with topic / search term / podcast title for cross-row uniqueness, and marks the decorative `arrow.up.left` symbol \`accessibilityHidden(true)\`. Visual presentation is unchanged.

| Button | Label |
|---|---|
| Topic chip | `Search for <topic>` |
| Recent search row | `Search again for <query>` |
| `× CLEAR` recents | `Clear recent searches` |
| `+ ADD TO LIBRARY` | `Add <title> to library` / `Adding <title> to library` / `<title> is already in your library` |
| `→ WEBSITE` | `Open <title> website` |

Mirrors the Episode Detail labelling pattern from #153.

Refs #127. One surface group per the issue's scope contract — Library, Queue, Settings, and Player still have their own follow-up PRs.

## Verification
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO` — passes.
- No behavior change for sighted users; only the VoiceOver accessibility tree is affected.

## Test plan
- [ ] VoiceOver on a real device: open Search, swipe through topic chips, recent searches, and a result row — each button reads one intentional label without the SF Symbol name leaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)