### PR TITLE
Label QueueView lead-strip and clear-all buttons (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
+- **Queue lead-strip `→ PLAY` / `× REMOVE` actions and the list `× CLEAR ALL` key now expose explicit VoiceOver labels** that include the episode title (or queued-episode count for the bulk clear), so the queue surface no longer reads ambiguous "Button" / mono visible text only (#127).
 - **Large-library UI smoke coverage now seeds a deterministic 258-show library** and launches directly into Library, giving the 250+ show scrolling case a repeatable simulator test instead of a manual-only complaint.
 - **Settings UI coverage now opens the config panel against a deterministic 258-show library** and verifies simulator iCloud status stays recoverable instead of crashing.
 - **Debug large-library seeding now resets stale simulator data when an explicit library size is requested**, so visual audits and UI tests are not polluted by previous sample stores.

--- a/OffScript/QueueView.swift
+++ b/OffScript/QueueView.swift
@@ -106,6 +106,7 @@ struct QueueView: View {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Clear all \(orderedItems.count) queued episodes")
                 }
             }
 
@@ -236,6 +237,7 @@ private struct QueueLeadStrip: View {
                         .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Play next queued episode \(item.episode.title)")
 
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -249,6 +251,7 @@ private struct QueueLeadStrip: View {
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Remove \(item.episode.title) from queue")
 
                 Spacer()
             }


### PR DESCRIPTION
## Summary
QueueLeadStrip's `→ PLAY` and `× REMOVE` keys, plus the queue list's `× CLEAR ALL` key, had no explicit \`accessibilityLabel\`. Adds intentional labels per action that include the episode title (or queued-episode count for the bulk clear) so VoiceOver users can disambiguate which queued item each action targets.

| Button | Label |
|---|---|
| Lead-strip `→ PLAY` | `Play next queued episode <title>` |
| Lead-strip `× REMOVE` | `Remove <title> from queue` |
| List `× CLEAR ALL` | `Clear all <count> queued episodes` |

Existing per-row labels (`Play <title>`, `Move up`, `Move down`, `Remove from queue`) are unchanged.

Refs #127. Mirrors the labelling pattern from #153 (Episode Detail) and #154 (Search).

## Verification
- \`xcodebuild test ... -only-testing:OffScriptTests\` — passes.
- No behavior change for sighted users.

## Test plan
- [ ] VoiceOver on a real device: open Queue with multiple items, swipe through the lead strip and clear-all key — each button reads one intentional label that names the targeted episode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)