### PR TITLE
Add Library Import key UI smoke (#115)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"e2d2b628-c4f2-4250-b6a3-3ca89d6a3321","pid":24002,"procStart":"Fri May  1 00:19:05 2026","acquiredAt":1777599009879}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
+- **Library Import key now has UI smoke coverage** that taps the IMPORT affordance from a launched Library tab, asserts the `IMPORT · ADD CHANNELS` sheet appears, and verifies tapping `Close import` returns to Library — pinning the OPML/paste-URL entry point against header refactors (#115).
 - **Hero recommendation card play/queue keys, hero feedback chips (LIKE/MORE/LESS/HIDE), and the starter-pick `+ ADD` row now expose explicit VoiceOver labels** that include the episode or pick title, so the home recommendation surface no longer falls back to the visible mono text and decorative arrow glyphs (#127).
 - **LibraryView buttons now expose explicit VoiceOver labels** for the channel directory rows, scope/sort/density mode keys, episode filter chips, podcast detail website/cancel keys, per-row play/queue keys, and the `+ LOAD 100 MORE` pager so VoiceOver users can disambiguate every action by show or episode title (#127).
 - **Settings playback-rate reset, signal rebuild, sign-out, and the sign-out confirmation Cancel/Confirm pair now exposes explicit VoiceOver labels** with hint copy on the destructive sign-out action, so destructive Settings flows can be operated with VoiceOver without guessing what each Tuner key does (#127).

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -132,11 +132,7 @@ final class OffScriptUITests: XCTestCase {
 
         XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 12))
 
-        let importKey = app.buttons["Import podcasts"].firstMatch
-        XCTAssertTrue(importKey.waitForExistence(timeout: 8), "Library Import key missing. Hierarchy:\n\(app.debugDescription)")
-        for _ in 0..<3 where !importKey.isHittable { app.swipeDown() }
-        XCTAssertTrue(importKey.isHittable, "Library Import key not hittable. Hierarchy:\n\(app.debugDescription)")
-        importKey.tap()
+        tapWhenReady(app.buttons["Import podcasts"].firstMatch, in: app, name: "Library Import key")
 
         let importHeader = app.staticTexts["IMPORT · ADD CHANNELS"]
         XCTAssertTrue(importHeader.waitForExistence(timeout: 10), "Import sheet did not appear. Hierarchy:\n\(app.debugDescription)")

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -126,6 +126,27 @@ final class OffScriptUITests: XCTestCase {
     }
 
     @MainActor
+    func testLibraryImportKeyOpensImportSheet() throws {
+        let app = makeApp(hasSeenOnboarding: true, debugLaunchTab: 1)
+        app.launch()
+
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 12))
+
+        let importKey = app.buttons["Import podcasts"].firstMatch
+        XCTAssertTrue(importKey.waitForExistence(timeout: 8), "Library Import key missing. Hierarchy:\n\(app.debugDescription)")
+        for _ in 0..<3 where !importKey.isHittable { app.swipeDown() }
+        XCTAssertTrue(importKey.isHittable, "Library Import key not hittable. Hierarchy:\n\(app.debugDescription)")
+        importKey.tap()
+
+        let importHeader = app.staticTexts["IMPORT · ADD CHANNELS"]
+        XCTAssertTrue(importHeader.waitForExistence(timeout: 10), "Import sheet did not appear. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.buttons["Close import"].waitForExistence(timeout: 5))
+
+        app.buttons["Close import"].tap()
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 8), "Closing Import did not return to Library. Hierarchy:\n\(app.debugDescription)")
+    }
+
+    @MainActor
     func testLargeLibrarySeedSmoke() throws {
         let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 258, debugEpisodesPerShow: 3, debugLaunchTab: 1)
         app.launch()


### PR DESCRIPTION
## Summary
The IMPORT key in `LibraryTunerHeader` is the OPML/paste-URL entry point — the most-asked-for missing feature when users build a library from scratch (per the inline comment in `LibraryView.swift:1588`). There was no UI test pinning its visibility, so a header refactor could quietly bury it without CI catching it.

`testLibraryImportKeyOpensImportSheet`:
- Launches into Library tab.
- Asserts the `Import podcasts` button exists and is hittable.
- Taps it; asserts `IMPORT · ADD CHANNELS` sheet appears and `Close import` is present.
- Taps `Close import`; asserts the Library screen is restored.

Refs #115. Mirrors the Settings smoke pattern from PR #150.

## Verification
- `xcodebuild test ... -only-testing:OffScriptUITests/OffScriptUITests/testLibraryImportKeyOpensImportSheet ...` — passes (`** TEST SUCCEEDED **`).
- No production-code change; UI test addition only.

## Test plan
- [ ] Spot-check on a real device that the IMPORT button is reachable in the Library header at the AX5 Dynamic Type size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)