### PR TITLE
Stop tracking Claude scheduled-task state files

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"e2d2b628-c4f2-4250-b6a3-3ca89d6a3321","pid":24002,"procStart":"Fri May  1 00:19:05 2026","acquiredAt":1777599009879}

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ Config/AppStoreConnect.local.env
 
 # Claude worktrees + agent state
 .claude/worktrees/
+.claude/scheduled_tasks.lock
+.claude/scheduled_tasks.json
+.claude/projects/
 
 # Generated docs preview
 docs/stitch/


### PR DESCRIPTION
Squash merge of #164 leaked .claude/scheduled_tasks.lock into main because .gitignore only covered .claude/worktrees/. Untracks the file and adds .claude/scheduled_tasks.{lock,json} + .claude/projects/ to .gitignore so future agent state can't slip in the same way.