### PR TITLE
Add retry key to podcast-detail load-error strip (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
+- **Podcast detail load errors now expose a `↻ RETRY` Tuner key** instead of just a static red `LOAD ERROR · …` label, so a user who hit a transient SwiftData fetch failure on the channel detail page can recover without backing out and re-entering (#115).
 - **Library Import key now has UI smoke coverage** that taps the IMPORT affordance from a launched Library tab, asserts the `IMPORT · ADD CHANNELS` sheet appears, and verifies tapping `Close import` returns to Library — pinning the OPML/paste-URL entry point against header refactors (#115).
 - **Hero recommendation card play/queue keys, hero feedback chips (LIKE/MORE/LESS/HIDE), and the starter-pick `+ ADD` row now expose explicit VoiceOver labels** that include the episode or pick title, so the home recommendation surface no longer falls back to the visible mono text and decorative arrow glyphs (#127).
 - **LibraryView buttons now expose explicit VoiceOver labels** for the channel directory rows, scope/sort/density mode keys, episode filter chips, podcast detail website/cancel keys, per-row play/queue keys, and the `+ LOAD 100 MORE` pager so VoiceOver users can disambiguate every action by show or episode title (#127).

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -2135,8 +2135,22 @@ struct PodcastDetailView: View {
                 FilterRow(selection: $filter)
 
                 if let loadError {
-                    TunerLabel(text: "LOAD ERROR · \(loadError.uppercased())", color: .offscriptFnRecord)
-                        .fixedSize(horizontal: false, vertical: true)
+                    VStack(alignment: .leading, spacing: 8) {
+                        TunerLabel(text: "LOAD ERROR · \(loadError.uppercased())", color: .offscriptFnRecord)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Button {
+                            loadEpisodes(resetLimit: true)
+                        } label: {
+                            TunerLabel(text: "↻ RETRY", color: .offscriptSignalYellow, size: 10)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 8)
+                                .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                                .frame(minHeight: 44)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Retry loading episodes")
+                    }
                 }
 
                 if episodes.isEmpty {


### PR DESCRIPTION
## Summary
The podcast-detail load-error path rendered just a static red `LOAD ERROR · …` `TunerLabel` with no recovery action. A user who hit a transient SwiftData fetch failure had to back out of the detail screen and re-enter to retry.

Adds a sharp signal-yellow `↻ RETRY` Tuner key directly under the error label that calls `loadEpisodes(resetLimit: true)`. Includes an explicit VoiceOver label (`Retry loading episodes`) consistent with the recent #127 a11y pass and 44pt minimum hit target.

Refs #115. Addresses the issue's "Empty/loading/error states are clear" acceptance bullet for the channel detail surface.

## Verification
- `xcodebuild test ... -only-testing:OffScriptTests` — passes.
- Pure additive UI; no protocol or layout changes elsewhere.

## Test plan
- [ ] Force a load error (e.g., simulator memory pressure during fetch) and tap RETRY — episodes load if the underlying issue clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)