### PR TITLE
Add Queue empty-state UI smoke (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
+- **Queue empty state now has UI smoke coverage** that launches directly into the Queue tab on a fresh install, asserts `● QUEUE EMPTY`, the "Nothing queued yet" headline, and the `→ EXPLORE SHOWS` escape hatch render — pinning the empty-state copy heavy listeners hit on day one against future Queue refactors (#126).
 - **Settings sign-out confirmation now has UI smoke coverage** that opens Settings, taps the destructive sign-out toggle when present, asserts the `CONFIRM · SIGN OUT` panel appears, cancels it, and verifies Settings stays alive and the runner stays foregrounded — pinning the destructive-dialog dismiss path against the build-51 class of Settings crashes (#114).
 - **Podcast detail load errors now expose a `↻ RETRY` Tuner key** instead of just a static red `LOAD ERROR · …` label, so a user who hit a transient SwiftData fetch failure on the channel detail page can recover without backing out and re-entering (#115).
 - **Library Import key now has UI smoke coverage** that taps the IMPORT affordance from a launched Library tab, asserts the `IMPORT · ADD CHANNELS` sheet appears, and verifies tapping `Close import` returns to Library — pinning the OPML/paste-URL entry point against header refactors (#115).

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -150,6 +150,27 @@ final class OffScriptUITests: XCTestCase {
     }
 
     @MainActor
+    func testQueueShowsEmptyStateOnFreshLaunch() throws {
+        // #126 acceptance: Queue UI under empty/small/large states needs
+        // pinned coverage. The empty state lives in QueueView.emptyState
+        // and reads `● QUEUE EMPTY` + "Nothing queued yet" + an EXPLORE
+        // SHOWS escape hatch. A user with no subscriptions on a fresh
+        // install lands here, so it has to be readable and the EXPLORE
+        // key has to route somewhere useful.
+        let app = makeApp(hasSeenOnboarding: true, debugLaunchTab: 2)
+        app.launch()
+
+        XCTAssertTrue(app.screen("QueueScreen").waitForExistence(timeout: 12))
+
+        XCTAssertTrue(app.staticTexts["● QUEUE EMPTY"].waitForExistence(timeout: 6),
+                      "Queue empty-state eyebrow missing. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.staticTexts["Nothing queued yet"].waitForExistence(timeout: 4),
+                      "Queue empty-state headline missing. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.staticTexts.containing(labelContaining: "EXPLORE SHOWS").waitForExistence(timeout: 4),
+                      "Queue empty-state escape hatch missing. Hierarchy:\n\(app.debugDescription)")
+    }
+
+    @MainActor
     func testSettingsPanelOpensWithLargeLibrarySeed() throws {
         let app = makeApp(hasSeenOnboarding: true, debugLibrarySize: 258, debugEpisodesPerShow: 3)
         app.launch()


### PR DESCRIPTION
## Summary
Issue #126 calls for auditing Queue UI under empty / small / large states. The empty state — what every fresh-install user sees on day one — had no UI test pinning its copy.

`testQueueShowsEmptyStateOnFreshLaunch`:
- Launches with `hasSeenOnboarding=true, debugLaunchTab=2` so the app boots straight into Queue without any seeded items.
- Asserts the `● QUEUE EMPTY` eyebrow, "Nothing queued yet" headline, and `→ EXPLORE SHOWS` escape hatch are all present.

Refs #126. Sibling PR #157 already pinned the lead-strip current-state behavior, and existing unit coverage (`QueueService.add` / `move` / `playNext` / `orderedItems`) covers ordering. This PR closes the empty-state acceptance bullet.

## Verification
- `xcodebuild test ... -only-testing:OffScriptUITests/OffScriptUITests/testQueueShowsEmptyStateOnFreshLaunch ...` — passes.
- No production code change.

## Test plan
- [ ] On a real fresh install: open the Queue tab without queueing anything — copy reads as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)