### PR TITLE
Replace bare try? on modelContext.save() with do/catch + OSLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Discovery genre matches now stay low-confidence until backed by local evidence** such as latest-episode tag overlap, topic matches, show affinity, or feed freshness, and genre-only WHY copy no longer claims local evidence.
 
 ### Fixed — silent failure paths
+- **`modelContext.save()` calls on the played-state toggle (CardComponents) and the debug seed/reset paths (ContentView) no longer swallow errors via bare `try?`** — they now use `do/catch` with category-scoped OSLog (`CardComponents`, `App`) so SwiftData save failures during sample/large-library seeding or a played-state flip surface as real log lines.
 - **`QueueService.add` calls in CardComponents, EpisodeDetailView, and the debug-boot queue seeder no longer swallow errors via bare `try?`** — they now use `do/catch` with category-scoped OSLog (`CardComponents`, `EpisodeDetail`, `App`) so a failed enqueue surfaces as a real log line instead of disappearing. Per the design bible's "NEVER use bare try?" rule.
 
 ### Fixed — onboarding, import, and sync UI honesty

--- a/OffScript/CardComponents.swift
+++ b/OffScript/CardComponents.swift
@@ -380,6 +380,7 @@ struct EpisodeCompactCard: View {
             episode.playedPosition = episode.duration ?? episode.playedPosition
             episode.lastPlayedAt = .now
         }
-        try? modelContext.save()
+        do { try modelContext.save() }
+        catch { cardLogger.error("Played-state save failed: \(error.localizedDescription, privacy: .public)") }
     }
 }

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -427,7 +427,8 @@ private extension ContentView {
             }
         }
 
-        try? modelContext.save()
+        do { try modelContext.save() }
+        catch { appLogger.error("Debug sample seed save failed: \(error.localizedDescription, privacy: .public)") }
     }
 
     private func debugLargeLibraryNeedsReset(
@@ -449,13 +450,17 @@ private extension ContentView {
     }
 
     private func resetDebugLibrary() {
-        for episode in (try? modelContext.fetch(FetchDescriptor<Episode>())) ?? [] {
-            modelContext.delete(episode)
+        do {
+            for episode in try modelContext.fetch(FetchDescriptor<Episode>()) {
+                modelContext.delete(episode)
+            }
+            for podcast in try modelContext.fetch(FetchDescriptor<Podcast>()) {
+                modelContext.delete(podcast)
+            }
+            try modelContext.save()
+        } catch {
+            appLogger.error("Debug library reset failed: \(error.localizedDescription, privacy: .public)")
         }
-        for podcast in (try? modelContext.fetch(FetchDescriptor<Podcast>())) ?? [] {
-            modelContext.delete(podcast)
-        }
-        try? modelContext.save()
     }
 
     private func seedLargeDebugLibrary(showCount: Int, episodesPerShow: Int) {
@@ -492,7 +497,8 @@ private extension ContentView {
                 modelContext.insert(episode)
             }
         }
-        try? modelContext.save()
+        do { try modelContext.save() }
+        catch { appLogger.error("Debug large-library seed save failed: \(error.localizedDescription, privacy: .public)") }
     }
 
     /// Read launch args / UserDefaults that may arrive as Int, NSNumber,


### PR DESCRIPTION
## Summary
Follow-up to #171. Four `modelContext.save()` call sites used bare `try?` and silently swallowed SwiftData save errors:

| Site | Logger |
|---|---|
| `CardComponents.swift` `togglePlayedState` (used by `EpisodeCompactCard` PLAYED toggle) | `cardLogger` (`CardComponents`) |
| `ContentView.swift` `seedSampleData` | `appLogger` (`App`) |
| `ContentView.swift` `resetDebugLibrary` | `appLogger` (also unwraps the surrounding `try?` fetches into the same `do/catch` so fetch failures get logged too) |
| `ContentView.swift` `seedLargeDebugLibrary` | `appLogger` |

Read-only `try?` sites with a sensible default (`fetchCount ?? 0`, optional `.first`) are left alone — those aren't silencing real errors, they're returning the correct fallback for an empty store.

Per `CLAUDE.md` "Error handling" rule.

## Verification
- `xcodebuild test ... -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO` — passes.

## Test plan
- [ ] Force a SwiftData save failure (corrupt store) and observe the new log lines under `Console.app` filtering on `subsystem:com.offscript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)