### PR TITLE
Normalize logger subsystems to com.offscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Episode Detail feedback now uses the same retune notification path as Home cards** so likes and `NOT FOR ME` taps refresh recommendations consistently across entry points.
 - **Discovery genre matches now stay low-confidence until backed by local evidence** such as latest-episode tag overlap, topic matches, show affinity, or feed freshness, and genre-only WHY copy no longer claims local evidence.
 
+### Fixed — observability hygiene
+- **`BackgroundFeedRefresh`, `CrashReporter`, `MetricKitReporter`, and `OffScriptApp` SwiftData loggers now use the `com.offscript` subsystem** like every other logger in the app — they were inconsistently using a bare `OffScript` subsystem, which meant `Console.app` filters on `subsystem:com.offscript` silently dropped those four important categories (background refresh, crash reporter, MetricKit, SwiftData container init/migration). Per the design bible's "Logger convention: `Logger(subsystem: \"com.offscript\", category: \"ServiceName\")`" rule.
+
 ### Fixed — silent failure paths
 - **Background feed refresh, deep-link episode lookup, `deleteAllDownloads`, `resumeQueuedDownloadsIfNeeded`, and `reconcilePersistedDownloads` now log the underlying SwiftData fetch error** instead of dropping it via bare `try?` — so a failed background refresh, a broken episode deep link, or a download lifecycle hiccup leaves a real OSLog entry (`BackgroundRefresh` at `.warning`, `DeepLink` and `DownloadService` at `.error`) instead of disappearing silently.
 - **`modelContext.save()` calls on the played-state toggle (CardComponents) and the debug seed/reset paths (ContentView) no longer swallow errors via bare `try?`** — they now use `do/catch` with category-scoped OSLog (`CardComponents`, `App`) so SwiftData save failures during sample/large-library seeding or a played-state flip surface as real log lines.

--- a/OffScript/BackgroundFeedRefresh.swift
+++ b/OffScript/BackgroundFeedRefresh.swift
@@ -6,7 +6,7 @@ import SwiftData
 enum BackgroundFeedRefresh {
     static let taskIdentifier = "com.offscript.feed-refresh"
     private static let minimumInterval: TimeInterval = 30 * 60 // 30 minutes
-    private static let logger = Logger(subsystem: "OffScript", category: "BackgroundRefresh")
+    private static let logger = Logger(subsystem: "com.offscript", category: "BackgroundRefresh")
 
     // MARK: - Scheduling
 

--- a/OffScript/CrashReporter.swift
+++ b/OffScript/CrashReporter.swift
@@ -41,7 +41,7 @@ enum SentryEnvironmentResolver {
 /// Sentry's native crash handler always wins.
 @MainActor
 enum CrashReporter {
-    private static let logger = Logger(subsystem: "OffScript", category: "CrashReporter")
+    private static let logger = Logger(subsystem: "com.offscript", category: "CrashReporter")
 
     /// Read at launch. Empty / placeholder DSNs (e.g. on a CI build that
     /// didn't get the secret) skip Sentry init entirely so crash-on-init

--- a/OffScript/MetricKitReporter.swift
+++ b/OffScript/MetricKitReporter.swift
@@ -22,7 +22,7 @@ import Sentry
 final class MetricKitReporter: NSObject, MXMetricManagerSubscriber {
     static let shared = MetricKitReporter()
 
-    private let logger = Logger(subsystem: "OffScript", category: "MetricKit")
+    private let logger = Logger(subsystem: "com.offscript", category: "MetricKit")
 
     /// Call once on launch (after CrashReporter.configure so Sentry is up).
     func configure() {

--- a/OffScript/OffScriptApp.swift
+++ b/OffScript/OffScriptApp.swift
@@ -28,7 +28,7 @@ final class OffScriptAppDelegate: NSObject, UIApplicationDelegate {
 @main
 struct OffScriptApp: App {
     @UIApplicationDelegateAdaptor(OffScriptAppDelegate.self) private var appDelegate
-    private static let logger = Logger(subsystem: "OffScript", category: "SwiftData")
+    private static let logger = Logger(subsystem: "com.offscript", category: "SwiftData")
 
     init() {
         // Crash + perf telemetry. Sentry first so its hooks are installed


### PR DESCRIPTION
## Summary
Spotted while addressing the Copilot review on #173: four loggers were using a bare `OffScript` subsystem instead of the standard `com.offscript` mandated by `CLAUDE.md` ("Logger convention: `Logger(subsystem: "com.offscript", category: "ServiceName")`").

| File | Category |
|---|---|
| `BackgroundFeedRefresh.swift` | `BackgroundRefresh` |
| `CrashReporter.swift` | `CrashReporter` |
| `MetricKitReporter.swift` | `MetricKit` |
| `OffScriptApp.swift` | `SwiftData` |

These are the four most important categories for debugging from logs (background refresh, crash reporter, MetricKit ingestion, SwiftData container init/migration). With the bare `OffScript` subsystem, anyone filtering `Console.app` on `subsystem:com.offscript` silently dropped them.

No behavior change; OSLog category strings are unchanged.

## Verification
- `xcodebuild test ... -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO` — passes.
- `grep -r 'Logger(subsystem: "OffScript"' OffScript/` returns nothing post-change.

## Test plan
- [ ] In `Console.app` (or `log stream --predicate 'subsystem == "com.offscript"'`), confirm `BackgroundRefresh`, `CrashReporter`, `MetricKit`, and `SwiftData` categories now appear in the same stream as the other 30+ existing OffScript categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)