### PR TITLE
Add debugWipeLibrary arg + Library empty-state UI smoke (#177, #115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 ## [Unreleased]
 
 ### Added — UI QA swarm coverage
+- **New `-offscript.debugWipeLibrary YES` launch arg wipes the SwiftData store before seeding** so UI tests that need a guaranteed-empty Library or Queue can launch deterministically regardless of prior simulator state. Documented in `docs/TEST_MATRIX.md`. Closes #177.
+- **Library empty state now has UI smoke coverage** that asserts `● NO CHANNELS TUNED` and "Your library is empty" render on a freshly-wiped store, pinning the day-one Library experience against future header refactors (#115).
 - **Queue empty state now has UI smoke coverage** that launches directly into the Queue tab on a fresh install, asserts `● QUEUE EMPTY`, the "Nothing queued yet" headline, and the `→ EXPLORE SHOWS` escape hatch render — pinning the empty-state copy heavy listeners hit on day one against future Queue refactors (#126).
 - **Settings sign-out confirmation now has UI smoke coverage** that opens Settings, taps the destructive sign-out toggle when present, asserts the `CONFIRM · SIGN OUT` panel appears, cancels it, and verifies Settings stays alive and the runner stays foregrounded — pinning the destructive-dialog dismiss path against the build-51 class of Settings crashes (#114).
 - **Podcast detail load errors now expose a `↻ RETRY` Tuner key** instead of just a static red `LOAD ERROR · …` label, so a user who hit a transient SwiftData fetch failure on the channel detail page can recover without backing out and re-entering (#115).

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -358,8 +358,15 @@ private extension ContentView {
     /// (and optionally -offscript.debugSeedLibrarySize 250) to populate a
     /// deterministic library for visual/performance audits without onboarding.
     /// No-ops once data exists.
+    ///
+    /// Pass -offscript.debugWipeLibrary YES (without a seed arg) to wipe the
+    /// store at launch. Used by UI tests that need a guaranteed-empty
+    /// Library/Queue tab (#177).
     func configureDebugSeedDataIfNeeded() {
         let defaults = UserDefaults.standard
+        if defaults.bool(forKey: "offscript.debugWipeLibrary") {
+            resetDebugLibrary()
+        }
         let requestedLibrarySize = max(0, defaults.integer(forKey: "offscript.debugSeedLibrarySize"))
         guard defaults.bool(forKey: "offscript.debugSeedSampleData") || requestedLibrarySize > 0 else { return }
 

--- a/OffScriptUITests/OffScriptUITests.swift
+++ b/OffScriptUITests/OffScriptUITests.swift
@@ -150,6 +150,23 @@ final class OffScriptUITests: XCTestCase {
     }
 
     @MainActor
+    func testLibraryShowsEmptyStateOnFreshLaunch() throws {
+        // #115 acceptance: Library empty/loading/error states must be
+        // clear. Uses the debugWipeLibrary launch arg (#177) to guarantee
+        // the simulator boots into an empty store regardless of prior
+        // seeded test runs.
+        let app = makeApp(hasSeenOnboarding: true, debugLaunchTab: 1, debugWipeLibrary: true)
+        app.launch()
+
+        XCTAssertTrue(app.screen("LibraryScreen").waitForExistence(timeout: 12))
+
+        XCTAssertTrue(app.staticTexts["● NO CHANNELS TUNED"].waitForExistence(timeout: 6),
+                      "Library empty-state eyebrow missing. Hierarchy:\n\(app.debugDescription)")
+        XCTAssertTrue(app.staticTexts["Your library is empty"].waitForExistence(timeout: 4),
+                      "Library empty-state headline missing. Hierarchy:\n\(app.debugDescription)")
+    }
+
+    @MainActor
     func testQueueShowsEmptyStateOnFreshLaunch() throws {
         // #126 acceptance: Queue UI under empty/small/large states needs
         // pinned coverage. The empty state lives in QueueView.emptyState
@@ -386,7 +403,8 @@ final class OffScriptUITests: XCTestCase {
         hasSeenOnboarding: Bool,
         debugLibrarySize: Int = 0,
         debugEpisodesPerShow: Int = 0,
-        debugLaunchTab: Int = 0
+        debugLaunchTab: Int = 0,
+        debugWipeLibrary: Bool = false
     ) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments += [
@@ -399,7 +417,9 @@ final class OffScriptUITests: XCTestCase {
             "-offscript.debugSeedEpisodesPerShow",
             String(debugEpisodesPerShow),
             "-offscript.debugLaunchTab",
-            String(debugLaunchTab)
+            String(debugLaunchTab),
+            "-offscript.debugWipeLibrary",
+            debugWipeLibrary ? "YES" : "NO"
         ]
         return app
     }

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -61,6 +61,7 @@ The app reads these `UserDefaults`-style launch arguments (set via
 | `-offscript.debugSeedSampleData` | `YES` / `NO` | Seeds 3 podcasts × 3 episodes for populated-state audits. |
 | `-offscript.debugSeedLibrarySize` | int (≥ 1) | Seeds a deterministic `N`-show library (`A Channel 001` … `Z Channel NNN`). Triggers automatic stale-store reset. |
 | `-offscript.debugSeedEpisodesPerShow` | int | Episode count per seeded show (paired with `debugSeedLibrarySize`). |
+| `-offscript.debugWipeLibrary` | `YES` / `NO` | Wipes the SwiftData store at launch (DEBUG builds only). Used by UI tests that need a guaranteed-empty Library/Queue tab regardless of prior simulator state. |
 | `-offscript.debugLaunchTab` | `0`-`3` | Launches directly into Home (0), Library (1), Queue (2), or Search (3). |
 | `-offscript.debugSelectedTab` | `0`-`3` | Same effect, persists selection across launches. |
 | `-offscript.debugBootPlayback` | `YES` / `NO` | Boots with a fake "now playing" state. |


### PR DESCRIPTION
## Summary
UI tests that need a guaranteed-empty Library/Queue tab couldn't reliably get one — the existing `debugLargeLibraryNeedsReset` only fires when `requestedLibrarySize > 0`, and a fresh-install scenario has no equivalent setup. Adds a new launch argument `-offscript.debugWipeLibrary YES` that calls the existing `resetDebugLibrary()` once at launch (DEBUG builds only) before any seeding logic.

`testLibraryShowsEmptyStateOnFreshLaunch` uses the new arg to assert the Library empty-state copy (`● NO CHANNELS TUNED` + "Your library is empty") renders deterministically — closes the empty/loading/error states acceptance bullet from #115.

Documented the new arg in `docs/TEST_MATRIX.md` next to the other `debugSeed*` args. Source-of-truth comment in `ContentView.swift` references this PR.

Closes #177. Refs #115.

## Verification
- `xcodebuild test ... -only-testing:OffScriptUITests/OffScriptUITests/testLibraryShowsEmptyStateOnFreshLaunch ...` — passes.
- The arg is no-op when set to `NO` or absent (existing tests still pass).

## Test plan
- [ ] Run the new test on a simulator that previously had a 258-show seeded library — empty state still renders on launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)