### PR TITLE
Rotate discovery rail reason templates across adjacent cards (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **`PodcastDetailView.loadEpisodes` now emits an `OffScriptPerformanceLog` signpost** (`podcast.detail.loadEpisodes`) tagged with podcast title, requested limit, row count, total matching count, and `hasMore`, so future scroll regressions are measurable in Instruments and OSLog (#169).
 
 ### Changed — recommendation quality
+- **Discovery rail reason copy now varies across adjacent cards by avoiding the previous card's chosen RecommendationExplainer source bucket** — a rail of three cards all backed by `latest episode` no longer reads as `LATEST EPISODES OVERLAP YOUR <noun> SIGNAL` repeated three times. The second/third card falls back to the next-strongest signal in its trace (e.g. tag match → topic overlap → show affinity), so the rail reads as authored signal instead of a template loop (#179).
 - **Home recommendations now fetch targeted candidates from explicitly liked and completed shows outside the global recency window**, so large high-volume libraries cannot bury older high-signal follow-ups before scoring.
 - **Home recommendations now compose multiple local evidence signals instead of stopping at the first matching rule**, so explicit topic feedback and “more from this show” reinforce one authored recommendation rather than competing as generic ranking buckets.
 - **Recommendation reason copy now has deterministic rail-length clipping for combined evidence**, keeping long show/topic explanations inside Tuner cards.

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -629,8 +629,9 @@ private struct TunerDiscoveryRail: View {
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 10) {
-                    ForEach(section.discoveryResults) { scored in
-                        discoveryCard(scored)
+                    let rotated = Self.rotatedReasons(for: section.discoveryResults)
+                    ForEach(Array(section.discoveryResults.enumerated()), id: \.element.id) { idx, scored in
+                        discoveryCard(scored, displayReason: rotated[idx])
                     }
                 }
                 .padding(.horizontal, OffScriptTheme.pagePadding)
@@ -646,15 +647,36 @@ private struct TunerDiscoveryRail: View {
         }
     }
 
-    private func discoveryCard(_ scored: ScoredDiscoveryResult) -> some View {
+    /// Pre-pass that varies the chosen RecommendationExplainer source
+    /// across adjacent rail cards so a discovery rail of cards all backed
+    /// by the same source bucket (e.g. `latest episode`) doesn't read as
+    /// a Mad Libs template (#179). When two adjacent cards' top-priority
+    /// source matches, the second card falls back to its next-best signal.
+    static func rotatedReasons(for results: [ScoredDiscoveryResult]) -> [String] {
+        var output: [String] = []
+        output.reserveCapacity(results.count)
+        var previousSource: String?
+        for scored in results {
+            let sources = scored.signalTrace
+                .filter { $0.label.caseInsensitiveCompare("source") == .orderedSame }
+                .map { $0.value.lowercased() }
+            let chosen = RecommendationExplainer.authoredSource(from: sources, excluding: previousSource)
+            let reason = RecommendationExplainer.authoredReason(
+                fallback: scored.explanation,
+                signals: scored.signalTrace,
+                avoidingSource: previousSource
+            )
+            output.append(reason)
+            previousSource = chosen
+        }
+        return output
+    }
+
+    private func discoveryCard(_ scored: ScoredDiscoveryResult, displayReason: String) -> some View {
         let result = scored.result
         let key = result.feedURL.normalizedFeedKey
         let isAdded = addedIDs.contains(key) || subscribedFeedURLs.contains(key)
         let isImporting = importingID == key
-        let displayReason = RecommendationExplainer.authoredReason(
-            fallback: scored.explanation,
-            signals: scored.signalTrace
-        )
 
         return VStack(alignment: .leading, spacing: 8) {
             OffScriptArtworkView(url: result.artworkURL, cornerRadius: 3)

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -652,22 +652,21 @@ private struct TunerDiscoveryRail: View {
     /// by the same source bucket (e.g. `latest episode`) doesn't read as
     /// a Mad Libs template (#179). When two adjacent cards' top-priority
     /// source matches, the second card falls back to its next-best signal.
+    /// `authoredReasonWithSource` returns both the rendered copy and the
+    /// bucket the explainer ultimately picked, so this loop has a single
+    /// source of truth for the selection — no duplicate logic to drift.
     static func rotatedReasons(for results: [ScoredDiscoveryResult]) -> [String] {
         var output: [String] = []
         output.reserveCapacity(results.count)
         var previousSource: String?
         for scored in results {
-            let sources = scored.signalTrace
-                .filter { $0.label.caseInsensitiveCompare("source") == .orderedSame }
-                .map { $0.value.lowercased() }
-            let chosen = RecommendationExplainer.authoredSource(from: sources, excluding: previousSource)
-            let reason = RecommendationExplainer.authoredReason(
+            let result = RecommendationExplainer.authoredReasonWithSource(
                 fallback: scored.explanation,
                 signals: scored.signalTrace,
                 avoidingSource: previousSource
             )
-            output.append(reason)
-            previousSource = chosen
+            output.append(result.copy)
+            previousSource = result.chosenSource
         }
         return output
     }

--- a/OffScript/RecommendationExplainer.swift
+++ b/OffScript/RecommendationExplainer.swift
@@ -36,7 +36,15 @@ enum RecommendationExplainer {
     /// Deterministic copy pass for the synchronous UI path. This uses the
     /// same signal trace that produced the score, so Home and Player can show
     /// authored WHY copy without waiting on FoundationModels availability.
-    static func authoredReason(fallback: String, signals: [RecommendationSignal]) -> String {
+    ///
+    /// Pass `avoidingSource` to skip a specific source bucket when the caller
+    /// has already rendered a card with that bucket — used by the Home
+    /// discovery rail to vary copy across adjacent cards (#179).
+    static func authoredReason(
+        fallback: String,
+        signals: [RecommendationSignal],
+        avoidingSource: String? = nil
+    ) -> String {
         var lookup: [String: String] = [:]
         for signal in signals {
             let key = signal.label.lowercased()
@@ -47,7 +55,7 @@ enum RecommendationExplainer {
         let sources = signals
             .filter { $0.label.caseInsensitiveCompare("source") == .orderedSame }
             .map { $0.value.lowercased() }
-        let source = authoredSource(from: sources)
+        let source = authoredSource(from: sources, excluding: avoidingSource?.lowercased())
 
         if sources.contains("explicit signal"),
            sources.contains("show intent"),
@@ -179,7 +187,10 @@ enum RecommendationExplainer {
         }
     }
 
-    private static func authoredSource(from sources: [String]) -> String? {
+    /// Picks the highest-priority source bucket present in `sources`, with an
+    /// optional `excluding` parameter that skips a specific bucket so the
+    /// discovery rail can vary copy across adjacent cards.
+    static func authoredSource(from sources: [String], excluding: String? = nil) -> String? {
         let priority = [
             "queue",
             "resume",
@@ -202,7 +213,13 @@ enum RecommendationExplainer {
             "available",
             "discovery"
         ]
-        return priority.first { sources.contains($0) } ?? sources.first
+        if let chosen = priority.first(where: { sources.contains($0) && $0 != excluding }) {
+            return chosen
+        }
+        // Either every priority match was excluded, or no priority match
+        // exists. Fall back to the next non-excluded source, then the first
+        // raw source if even that is empty.
+        return sources.first(where: { $0 != excluding }) ?? sources.first
     }
 
     private static func joinedList(_ value: String) -> String {

--- a/OffScript/RecommendationExplainer.swift
+++ b/OffScript/RecommendationExplainer.swift
@@ -33,18 +33,40 @@ private struct RephraseResult {
 enum RecommendationExplainer {
     private static var cache: [UUID: String] = [:]
 
+    /// The result of running the deterministic explainer: the user-visible
+    /// copy string plus the source bucket the explainer ultimately picked.
+    /// Callers that walk a rail and want to vary copy across adjacent cards
+    /// pass the previous result's `chosenSource` as the next call's
+    /// `avoidingSource` — see `TunerDiscoveryRail.rotatedReasons` (#179).
+    struct AuthoredReason: Equatable {
+        let copy: String
+        let chosenSource: String?
+    }
+
     /// Deterministic copy pass for the synchronous UI path. This uses the
     /// same signal trace that produced the score, so Home and Player can show
     /// authored WHY copy without waiting on FoundationModels availability.
     ///
-    /// Pass `avoidingSource` to skip a specific source bucket when the caller
-    /// has already rendered a card with that bucket — used by the Home
-    /// discovery rail to vary copy across adjacent cards (#179).
+    /// Convenience overload — returns just the copy string. Use
+    /// `authoredReasonWithSource(...)` when you need to thread the chosen
+    /// source through to a sibling call.
     static func authoredReason(
         fallback: String,
         signals: [RecommendationSignal],
         avoidingSource: String? = nil
     ) -> String {
+        authoredReasonWithSource(fallback: fallback, signals: signals, avoidingSource: avoidingSource).copy
+    }
+
+    /// Same as `authoredReason(...)` but returns both the user-visible copy
+    /// and the source bucket the explainer picked. Single source of truth
+    /// for the bucket-selection logic, so a rail caller can thread the
+    /// chosen source forward without re-deriving it.
+    static func authoredReasonWithSource(
+        fallback: String,
+        signals: [RecommendationSignal],
+        avoidingSource: String? = nil
+    ) -> AuthoredReason {
         var lookup: [String: String] = [:]
         for signal in signals {
             let key = signal.label.lowercased()
@@ -55,7 +77,18 @@ enum RecommendationExplainer {
         let sources = signals
             .filter { $0.label.caseInsensitiveCompare("source") == .orderedSame }
             .map { $0.value.lowercased() }
-        let source = authoredSource(from: sources, excluding: avoidingSource?.lowercased())
+        let avoid = avoidingSource?.lowercased()
+        let source = authoredSource(from: sources, excluding: avoid)
+        let copy = renderCopy(fallback: fallback, sources: sources, lookup: lookup, source: source)
+        return AuthoredReason(copy: copy, chosenSource: source)
+    }
+
+    private static func renderCopy(
+        fallback: String,
+        sources: [String],
+        lookup: [String: String],
+        source: String?
+    ) -> String {
 
         if sources.contains("explicit signal"),
            sources.contains("show intent"),
@@ -213,13 +246,15 @@ enum RecommendationExplainer {
             "available",
             "discovery"
         ]
-        if let chosen = priority.first(where: { sources.contains($0) && $0 != excluding }) {
+        guard let excluded = excluding else {
+            return priority.first(where: sources.contains) ?? sources.first
+        }
+        if let chosen = priority.first(where: { sources.contains($0) && $0 != excluded }) {
             return chosen
         }
-        // Either every priority match was excluded, or no priority match
-        // exists. Fall back to the next non-excluded source, then the first
-        // raw source if even that is empty.
-        return sources.first(where: { $0 != excluding }) ?? sources.first
+        // Every priority match (if any) was the excluded bucket. Fall back
+        // to the first non-excluded raw source, then the first raw source.
+        return sources.first(where: { $0 != excluded }) ?? sources.first
     }
 
     private static func joinedList(_ value: String) -> String {

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1497,6 +1497,49 @@ struct OffScriptTests {
     }
 
     @Test
+    func recommendationExplainerSwapsTemplateWhenAvoidingPriorSource() {
+        // Two adjacent rail cards both backed by the latest-episode signal
+        // would render the same "Latest episodes overlap your X signal"
+        // template. The avoidingSource overload routes the second card
+        // to the next-best source on its trace.
+        let signals: [RecommendationSignal] = [
+            RecommendationSignal(label: "source", value: "latest episode"),
+            RecommendationSignal(label: "source", value: "tag match"),
+            RecommendationSignal(label: "tags", value: "audio craft")
+        ]
+
+        let primary = RecommendationExplainer.authoredReason(
+            fallback: "fallback",
+            signals: signals
+        )
+        let avoiding = RecommendationExplainer.authoredReason(
+            fallback: "fallback",
+            signals: signals,
+            avoidingSource: "latest episode"
+        )
+
+        #expect(primary == "Latest episodes overlap your audio craft signal")
+        #expect(avoiding == "Tuned to your saved audio craft signal")
+    }
+
+    @Test
+    func recommendationExplainerSourceExclusionFallsBackToFirstAvailable() {
+        // When the avoided source is the only priority match, fall back to
+        // any remaining source from the trace rather than returning nil.
+        let result = RecommendationExplainer.authoredSource(
+            from: ["latest episode", "editor"],
+            excluding: "latest episode"
+        )
+        #expect(result == "editor")
+    }
+
+    @Test
+    func recommendationExplainerSourceExclusionReturnsNilOnEmptyTrace() {
+        let result = RecommendationExplainer.authoredSource(from: [], excluding: "latest episode")
+        #expect(result == nil)
+    }
+
+    @Test
     func recommendationExplainerKeepsUnknownFallbacks() {
         let fallback = "Special editorial pick"
 


### PR DESCRIPTION
## Summary
A discovery rail of N cards all backed by the same `RecommendationExplainer` source bucket (commonly `latest episode`) rendered the same template N times — `LATEST EPISODES OVERLAP YOUR <noun> SIGNAL` repeated with only the noun varying. The screenshot in #179 shows this with two visible cards leading with the same phrase. That reads as a Mad Libs / algorithmic template loop, exactly the voice `CLAUDE.md` warns against.

### What changes
- **`RecommendationExplainer.authoredSource(from:excluding:)`** — new public overload that skips a given source bucket and falls back to the next priority match (then any remaining trace source).
- **`RecommendationExplainer.authoredReason(fallback:signals:avoidingSource:)`** — new public overload that threads the avoiding-source through the priority lookup.
- **`TunerDiscoveryRail.rotatedReasons(for:)`** — pre-pass that walks the scored results in display order, tracking the previously-chosen source and passing it as `avoidingSource` for the next card.

The display loop now reads `let rotated = Self.rotatedReasons(for: section.discoveryResults)` and passes the per-card reason in.

### Three new unit tests
- Two cards backed by `latest episode + tag match` render different copy when the second avoids `latest episode`.
- Source exclusion falls back to the first available source when the avoided one is the only priority match.
- Source exclusion returns `nil` on an empty trace.

Closes #179.

## Verification
- `xcodebuild test ... -only-testing:OffScriptTests CODE_SIGNING_ALLOWED=NO` — passes (104 tests).

## Test plan
- [ ] Open Home with a discovery rail where 2+ scored results share a top-priority source bucket (e.g. all `latest episode`). Their reason copy should now lead with different verbs (the second card switches to its next-best signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)