### PR TITLE
Remove unused isSearchActive state from SearchView

### DIFF
--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -12,7 +12,6 @@ struct SearchView: View {
     let hidesRootNavigationBar: Bool
     @AppStorage("offscript.recentSearches") private var recentSearchesStorage = ""
     @State private var query = ""
-    @State private var isSearchActive = false
     @State private var results: [PodcastSearchResult] = []
     @State private var isSearching = false
     /// Per-row in-flight import set keyed by `PodcastSearchResult.id`.


### PR DESCRIPTION
## Summary
- \`@State private var isSearchActive = false\` was declared in \`SearchView\` but never read or written anywhere. Dead state declaration.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)