### PR TITLE
Show ● SYNC FAILED chip on PodcastDetail header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Podcast detail header now flags `● SYNC FAILED`** when the feed has a non-zero failure count or `syncStatus == "failed"`. Mirrors the Library directory row chip from #206 — even when a user has navigated into a podcast detail page, they can see at a glance that the feed is unhealthy without flipping back to the Library scope filter.
 - **Library directory empty state now exposes a `× CLEAR FILTER` recovery key** when an active scope (NEEDS SYNC, etc.) or search query collapsed the list to zero. Mirrors the PodcastDetail clear-filter affordance shipped in #208 — one-tap reset to scope `.all` and empty query instead of having to scroll back up to find the right control.
 - **Playback rate picker now offers a `0.75×` slow option** in both the per-podcast Player picker and the Settings default-rate picker. Useful for language learners, dense or technical content, and accessibility — the previous floor was `1.0×`.
 - **Player `WHAT'S NEXT · ON YOUR FREQUENCY` rows now expose a `+` queue key alongside `▶` play** so a listener can stack a suggested episode without interrupting current playback. Mirrors the play+queue affordance pair on Library / PodcastDetail episode rows. Hides when the suggestion is already queued so the row doesn't render a no-op.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -2555,11 +2555,27 @@ private struct PodcastDetailTunerHeader: View {
     @State private var showUnsubscribeConfirmation = false
     @State private var safariURL: IdentifiableURL?
 
+    /// Same definition as LibraryDirectoryRow.hasSyncFailure (#206).
+    /// Either a failure count > 0 or a `failed` syncStatus flips the
+    /// chip on so the user knows the feed went bad without having to
+    /// flip Library scope to NEEDS SYNC.
+    private var hasSyncFailure: Bool {
+        podcast.syncFailureCount > 0 || podcast.syncStatus == "failed"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack {
+            HStack(spacing: 8) {
                 TunerLabel(text: "CHANNEL · DETAIL", color: .offscriptSignalYellow)
                 Spacer()
+                if hasSyncFailure {
+                    // Mirror the Library directory `● SYNC FAILED`
+                    // chip (#206). Surfacing it on the detail header
+                    // tells the user the feed went bad even when the
+                    // subscription is technically still active.
+                    TunerLabel(text: "● SYNC FAILED", color: .offscriptFnRecord)
+                        .accessibilityIdentifier("PodcastDetailSyncFailed")
+                }
                 TunerLabel(text: podcast.isSubscribed ? "● SUBSCRIBED" : "○ UNSUBSCRIBED",
                            color: podcast.isSubscribed ? .offscriptFnMode : .offscriptSoftPaper)
             }


### PR DESCRIPTION
## Summary
- PodcastDetail header showed `● SUBSCRIBED` / `○ UNSUBSCRIBED` but not the feed's sync state. A podcast whose feed had been failing looked healthy unless the user flipped back to Library's NEEDS SYNC scope.
- Renders `● SYNC FAILED` in \`offscriptFnRecord\` next to the subscribed badge when \`podcast.syncFailureCount > 0\` OR \`syncStatus == "failed"\`. Mirrors the Library directory row chip from #206.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)