### PR TITLE
Log Spotlight indexer fetch failures instead of bare try?

### DIFF
--- a/OffScript/SpotlightIndexer.swift
+++ b/OffScript/SpotlightIndexer.swift
@@ -42,7 +42,18 @@ enum SpotlightIndexer {
         )
         descriptor.fetchLimit = maxEpisodesToIndex
 
-        guard let episodes = try? context.fetch(descriptor), !episodes.isEmpty else { return }
+        // CLAUDE.md bans bare `try?`. A SwiftData fetch failure here is
+        // non-fatal (we just skip indexing this run), but logging the
+        // error makes a recurring failure visible in sysdiagnose
+        // instead of silently degrading Spotlight discovery.
+        let episodes: [Episode]
+        do {
+            episodes = try context.fetch(descriptor)
+        } catch {
+            spotlightLogger.error("Spotlight episode fetch failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        guard !episodes.isEmpty else { return }
 
         // Stamp the last-indexed time before batching so a crash mid-run
         // doesn't cause a retry loop on the next launch.


### PR DESCRIPTION
## Summary
- CLAUDE.md bans bare \`try?\`. SpotlightIndexer.indexEpisodes had one on the SwiftData fetch.
- Convert to do/catch + spotlightLogger.error. Same pattern as #225 (now-playing artwork). Behavior unchanged on success.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)