### PR TITLE
44pt + isSelected for Settings recommendation-mode chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Settings recommendation-mode chips (Balanced / Lean Discovery / Stay Tuned) now meet 44pt tap target and announce the active mode to VoiceOver.** Were ~28pt visible. Added `frame(minHeight: 44)` and `accessibilityAddTraits(.isSelected)` so the highlighted chip is explicit to a11y users (background color alone wasn't enough).
 - **Settings `↻ REBUILD SIGNAL` and `× SIGN OUT` (entry) keys now meet the 44pt tap target floor.** Both were ~30pt visible (padding + 10pt label). Added `frame(minHeight: 44) + contentShape(Rectangle())`. The matching ↻ RETRY DOWNLOAD on episode detail and × DISMISS on the import strip already pass; this brings the two remaining Settings ones up to the same standard.
 - **Player rate picker (1×/1.25×/…) and sleep picker (5/15/30/45/60 MIN, × CANCEL, END OF EP) now meet the 44pt tap target floor.** Both grids were at 34pt minHeight — small enough to fat-finger across cells. Bumped to 44pt across the board, contentShape preserved.
 - **Home cold-start `+ ADD` and discovery `+ TUNE` keys now meet the 44pt tap target floor.** Both were ~30pt (padding + 10pt label only). Same fix shipped for SearchView starter chips in #226 — adds `frame(minHeight: 44) + contentShape(Rectangle())` without changing the visible button outline.

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -493,12 +493,16 @@ struct SettingsView: View {
 
     // MARK: recommendations
 
+    // RecommendationMode chips meet 44pt min-height and announce
+    // .isSelected to VoiceOver so the active mode is communicated
+    // explicitly (background color alone isn't enough for a11y).
     private var recommendationSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             TunerLabel(text: "RECOMMENDATIONS · TUNER", color: .offscriptSignalYellow)
 
             HStack(spacing: 8) {
                 ForEach(AppSettings.RecommendationMode.allCases, id: \.rawValue) { mode in
+                    let isSelected = recommendationMode == mode
                     Button {
                         withAnimation(.easeInOut(duration: 0.18)) {
                             recommendationMode = mode
@@ -507,16 +511,18 @@ struct SettingsView: View {
                     } label: {
                         TunerLabel(
                             text: mode.label,
-                            color: recommendationMode == mode ? .offscriptStudioBlack : .offscriptSignalYellow,
+                            color: isSelected ? .offscriptStudioBlack : .offscriptSignalYellow,
                             size: 9
                         )
-                        .frame(maxWidth: .infinity)
+                        .frame(maxWidth: .infinity, minHeight: 44)
                         .padding(.vertical, 10)
-                        .background(recommendationMode == mode ? Color.offscriptSignalYellow : Color.clear)
+                        .background(isSelected ? Color.offscriptSignalYellow : Color.clear)
                         .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("\(mode.label) recommendation mode")
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
                 }
             }
 


### PR DESCRIPTION
## Summary
- Settings recommendation-mode chips (Balanced / Lean Discovery / Stay Tuned) were ~28pt tall and signaled the active mode by background color only.
- Add \`frame(minHeight: 44) + contentShape(Rectangle())\` (HIG tap target) and \`accessibilityAddTraits(.isSelected)\` (VoiceOver communicates the active state explicitly, not just by color).

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)