### PR TITLE
Bring episode detail ↻ RETRY DOWNLOAD to 44pt tap target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Episode detail `↻ RETRY DOWNLOAD` key now meets 44pt tap target.** Was ~30pt (padding + 10pt label).
 - **Settings recommendation-mode chips (Balanced / Lean Discovery / Stay Tuned) now meet 44pt tap target and announce the active mode to VoiceOver.** Were ~28pt visible. Added `frame(minHeight: 44)` and `accessibilityAddTraits(.isSelected)` so the highlighted chip is explicit to a11y users (background color alone wasn't enough).
 - **Settings `↻ REBUILD SIGNAL` and `× SIGN OUT` (entry) keys now meet the 44pt tap target floor.** Both were ~30pt visible (padding + 10pt label). Added `frame(minHeight: 44) + contentShape(Rectangle())`. The matching ↻ RETRY DOWNLOAD on episode detail and × DISMISS on the import strip already pass; this brings the two remaining Settings ones up to the same standard.
 - **Player rate picker (1×/1.25×/…) and sleep picker (5/15/30/45/60 MIN, × CANCEL, END OF EP) now meet the 44pt tap target floor.** Both grids were at 34pt minHeight — small enough to fat-finger across cells. Bumped to 44pt across the board, contentShape preserved.

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -346,7 +346,9 @@ struct EpisodeDetailView: View {
                         TunerLabel(text: "↻ RETRY DOWNLOAD", color: .offscriptFnRecord, size: 10)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 9)
+                            .frame(minHeight: 44)
                             .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Retry download for \(episode.title)")


### PR DESCRIPTION
## Summary
- Padding alone gave the retry-download key ~30pt visible — below HIG's 44pt floor.
- Add \`frame(minHeight: 44) + contentShape(Rectangle())\`.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)