### PR TITLE
Bring QueueLeadStrip → PLAY / × REMOVE to 44pt tap target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **QueueLeadStrip `→ PLAY` / `→ RESUME` and `× REMOVE` keys now meet 44pt tap target.** Were ~32pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` pattern applied across the app.
 - **Episode detail `↻ RETRY DOWNLOAD` key now meets 44pt tap target.** Was ~30pt (padding + 10pt label).
 - **Settings recommendation-mode chips (Balanced / Lean Discovery / Stay Tuned) now meet 44pt tap target and announce the active mode to VoiceOver.** Were ~28pt visible. Added `frame(minHeight: 44)` and `accessibilityAddTraits(.isSelected)` so the highlighted chip is explicit to a11y users (background color alone wasn't enough).
 - **Settings `↻ REBUILD SIGNAL` and `× SIGN OUT` (entry) keys now meet the 44pt tap target floor.** Both were ~30pt visible (padding + 10pt label). Added `frame(minHeight: 44) + contentShape(Rectangle())`. The matching ↻ RETRY DOWNLOAD on episode detail and × DISMISS on the import strip already pass; this brings the two remaining Settings ones up to the same standard.

--- a/OffScript/QueueView.swift
+++ b/OffScript/QueueView.swift
@@ -294,6 +294,8 @@ private struct QueueTunerHeader: View {
 
 // MARK: - Lead strip
 
+// QueueLeadStrip's PLAY/RESUME + × REMOVE keys meet 44pt min-height
+// per HIG; matches the rest of the app's Tuner action-key vocabulary.
 private struct QueueLeadStrip: View {
     @Environment(\.modelContext) private var modelContext
     @ObservedObject private var player = PlaybackController.shared
@@ -374,7 +376,9 @@ private struct QueueLeadStrip: View {
                     )
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
+                    .frame(minHeight: 44)
                     .overlay(Rectangle().stroke(isCurrentlyPlaying ? Color.offscriptFnMode : Color.offscriptSignalYellow, lineWidth: 1))
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .disabled(isCurrentlyPlaying)
@@ -400,7 +404,9 @@ private struct QueueLeadStrip: View {
                     TunerLabel(text: "× REMOVE", color: .offscriptFnRecord, size: 11)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 10)
+                        .frame(minHeight: 44)
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Remove \(item.episode.title) from queue")


### PR DESCRIPTION
## Summary
- QueueLeadStrip's PLAY/RESUME and × REMOVE keys were ~32pt visible — below HIG's 44pt floor.
- Add \`frame(minHeight: 44) + contentShape(Rectangle())\`.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)