### PR TITLE
Add per-feed ↻ REFRESH key to PodcastDetail header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **PodcastDetail header now exposes a `↻ REFRESH` key** that re-syncs just that one feed. Previously the only path to refresh a single show was pull-to-refresh on the Library tab (which hits every feed). Useful for a user looking at one show who wants the latest episodes without re-syncing 50 feeds. Also bumps the existing `→ WEBSITE` key to 44pt min-height so the action row reads as a uniform bar.
 - **QueueLeadStrip `→ PLAY` / `→ RESUME` and `× REMOVE` keys now meet 44pt tap target.** Were ~32pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` pattern applied across the app.
 - **Episode detail `↻ RETRY DOWNLOAD` key now meets 44pt tap target.** Was ~30pt (padding + 10pt label).
 - **Settings recommendation-mode chips (Balanced / Lean Discovery / Stay Tuned) now meet 44pt tap target and announce the active mode to VoiceOver.** Were ~28pt visible. Added `frame(minHeight: 44)` and `accessibilityAddTraits(.isSelected)` so the highlighted chip is explicit to a11y users (background color alone wasn't enough).

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -2554,6 +2554,8 @@ private struct PodcastDetailTunerHeader: View {
     let episodeCount: Int
     @State private var showUnsubscribeConfirmation = false
     @State private var safariURL: IdentifiableURL?
+    @State private var isRefreshing = false
+    private let syncService = FeedSyncService()
 
     /// Same definition as LibraryDirectoryRow.hasSyncFailure (#206).
     /// Either a failure count > 0 or a `failed` syncStatus flips the
@@ -2631,14 +2633,44 @@ private struct PodcastDetailTunerHeader: View {
                     Button {
                         safariURL = IdentifiableURL(url: url)
                     } label: {
+                        // Bumped to 44pt min-height alongside the new
+                        // ↻ REFRESH key so the row reads as a uniform
+                        // action bar.
                         TunerLabel(text: "→ WEBSITE", color: .offscriptSignalYellow, size: 10)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 9)
+                            .frame(minHeight: 44)
                             .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Open \(podcast.title) website")
                 }
+
+                // Per-feed refresh — pull-to-refresh on Library only
+                // works from that tab, and the SYNC key on Library
+                // refreshes EVERY feed. A user looking at one show who
+                // wants the latest episodes shouldn't have to bounce
+                // back to Library and re-sync 50 feeds.
+                Button {
+                    Task { await refreshFeed() }
+                } label: {
+                    TunerLabel(
+                        text: isRefreshing ? "○ REFRESHING…" : "↻ REFRESH",
+                        color: .offscriptSignalYellow,
+                        size: 10
+                    )
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 9)
+                    .frame(minHeight: 44)
+                    .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(isRefreshing)
+                .accessibilityLabel("Refresh \(podcast.title) feed")
+                .accessibilityIdentifier("PodcastDetailRefreshFeed")
+
                 Spacer()
             }
             .padding(.top, 4)
@@ -2654,6 +2686,22 @@ private struct PodcastDetailTunerHeader: View {
 
             Rectangle().fill(Color.offscriptHairline).frame(height: 1)
                 .padding(.top, 6)
+        }
+    }
+
+    @MainActor
+    private func refreshFeed() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        do {
+            try await syncService.sync(
+                podcast: podcast,
+                in: modelContext,
+                options: .standard()
+            )
+        } catch {
+            libraryLogger.error("PodcastDetail refresh feed failed for '\(podcast.title, privacy: .public)': \(error.localizedDescription, privacy: .public)")
         }
     }
 


### PR DESCRIPTION
## Summary
- Only path to refresh a single feed was pull-to-refresh on Library (which hits every feed). A user on one show who wants the latest episodes shouldn't have to re-sync 50.
- Add \`↻ REFRESH\` key in the action row that calls \`FeedSyncService.sync(podcast:in:options:)\` directly with \`.standard()\` options. Local \`isRefreshing\` state shows \`○ REFRESHING…\` while in flight.
- Also bumps the existing \`→ WEBSITE\` key to 44pt min-height for action-row uniformity.

## Test plan
- [x] \`xcodebuild build\` clean
- [ ] Manual: open a podcast detail, tap \`↻ REFRESH\`, verify state flips to \`○ REFRESHING…\` then back

🤖 Generated with [Claude Code](https://claude.com/claude-code)