### PR TITLE
Add pull-to-refresh to Library + PodcastDetail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Library and PodcastDetail now respond to pull-to-refresh** — the native iOS swipe-down gesture re-syncs every subscribed feed (Library) or just the one open feed (PodcastDetail). Reuses the same `syncSubscriptions()` / `FeedSyncService.sync(podcast:)` paths as the existing SYNC and ↻ REFRESH keys, so the LibrarySyncResult chip surfaces the outcome consistently regardless of which trigger fired.
 - **PodcastDetail header now exposes a `↻ REFRESH` key** that re-syncs just that one feed. Previously the only path to refresh a single show was pull-to-refresh on the Library tab (which hits every feed). Useful for a user looking at one show who wants the latest episodes without re-syncing 50 feeds. Also bumps the existing `→ WEBSITE` key to 44pt min-height so the action row reads as a uniform bar.
 - **QueueLeadStrip `→ PLAY` / `→ RESUME` and `× REMOVE` keys now meet 44pt tap target.** Were ~32pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` pattern applied across the app.
 - **Episode detail `↻ RETRY DOWNLOAD` key now meets 44pt tap target.** Was ~30pt (padding + 10pt label).

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -1016,6 +1016,13 @@ struct LibraryView: View {
                 .padding(.top, OffScriptTheme.rootContentTopPadding)
                 .padding(.bottom, 90)
             }
+            // Pull-to-refresh — native iOS gesture for re-syncing
+            // every subscribed feed. Reuses the same path as the SYNC
+            // header key, so the LibrarySyncResult chip surfaces the
+            // outcome consistently regardless of which trigger fired.
+            .refreshable {
+                await syncSubscriptions()
+            }
         }
     }
 
@@ -2273,6 +2280,7 @@ struct PodcastDetailView: View {
     @State private var hasMoreEpisodes = false
     @State private var loadError: String?
     @State private var searchLoadTask: Task<Void, Never>?
+    private let syncService = FeedSyncService()
 
     init(podcast: Podcast) {
         self.podcast = podcast
@@ -2402,6 +2410,21 @@ struct PodcastDetailView: View {
             .padding(.bottom, 90)
         }
         .background(Color.offscriptStudioBlack.ignoresSafeArea())
+        // Pull-to-refresh — native iOS gesture for re-syncing this
+        // single feed without bouncing back to Library. Companion to
+        // the new ↻ REFRESH key in the PodcastDetail header from #238.
+        .refreshable {
+            do {
+                try await syncService.sync(
+                    podcast: podcast,
+                    in: modelContext,
+                    options: .standard()
+                )
+            } catch {
+                libraryLogger.error("PodcastDetail pull-to-refresh failed for '\(podcast.title, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+            }
+            loadEpisodes(resetLimit: false)
+        }
         .accessibilityIdentifier("PodcastDetailScreen")
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- Native iOS swipe-down was missing on the two list-of-feeds surfaces. Only path was the SYNC button (Library) or the new ↻ REFRESH key (PodcastDetail).
- Add \`.refreshable\` on both ScrollViews. Library reuses \`syncSubscriptions()\` so the LibrarySyncResult chip surfaces the outcome. PodcastDetail re-syncs just the open feed via \`FeedSyncService.sync(podcast:)\` then reloads the episode list.

## Test plan
- [x] \`xcodebuild build\` clean
- [ ] Manual: pull-to-refresh on Library → all feeds re-sync, chip shows result
- [ ] Manual: pull-to-refresh on PodcastDetail → just that feed re-syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)