### PR TITLE
Bring SpeechTranscriptionPanel action button to 44pt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Speech transcription panel action button now meets 44pt tap target.** Was ~30pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` fix applied across the app.
 - **Home now responds to pull-to-refresh** with the same `loadSections(manual:)` path as the existing retune key in HomeTunerHeader. Mirrors the Library / PodcastDetail pull-to-refresh shipped in #239 so the standard iOS swipe-down works on every list-of-content surface in the app.
 - **Library and PodcastDetail now respond to pull-to-refresh** — the native iOS swipe-down gesture re-syncs every subscribed feed (Library) or just the one open feed (PodcastDetail). Reuses the same `syncSubscriptions()` / `FeedSyncService.sync(podcast:)` paths as the existing SYNC and ↻ REFRESH keys, so the LibrarySyncResult chip surfaces the outcome consistently regardless of which trigger fired.
 - **PodcastDetail header now exposes a `↻ REFRESH` key** that re-syncs just that one feed. Previously the only path to refresh a single show was pull-to-refresh on the Library tab (which hits every feed). Useful for a user looking at one show who wants the latest episodes without re-syncing 50 feeds. Also bumps the existing `→ WEBSITE` key to 44pt min-height so the action row reads as a uniform bar.

--- a/OffScript/SpeechTranscriptionPanel.swift
+++ b/OffScript/SpeechTranscriptionPanel.swift
@@ -158,7 +158,9 @@ struct SpeechTranscriptionPanel: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
+            .frame(minHeight: 44)
             .overlay(Rectangle().stroke(color.opacity(disabled ? 0.4 : 1.0), lineWidth: 1))
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(disabled)


### PR DESCRIPTION
## Summary
- Panel's action button (\`→ GENERATE TRANSCRIPT\` / \`→ SHOW TRANSCRIPT\` / etc.) was ~30pt — below HIG.
- Add \`frame(minHeight: 44) + contentShape(Rectangle())\`.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)