### PR TITLE
Bring translation CTA to 44pt tap target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **EpisodeTranslationView `→ TRANSLATE TO …` key now meets 44pt tap target.** Was ~30pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` pattern.
 - **Speech transcription panel action button now meets 44pt tap target.** Was ~30pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` fix applied across the app.
 - **Home now responds to pull-to-refresh** with the same `loadSections(manual:)` path as the existing retune key in HomeTunerHeader. Mirrors the Library / PodcastDetail pull-to-refresh shipped in #239 so the standard iOS swipe-down works on every list-of-content surface in the app.
 - **Library and PodcastDetail now respond to pull-to-refresh** — the native iOS swipe-down gesture re-syncs every subscribed feed (Library) or just the one open feed (PodcastDetail). Reuses the same `syncSubscriptions()` / `FeedSyncService.sync(podcast:)` paths as the existing SYNC and ↻ REFRESH keys, so the LibrarySyncResult chip surfaces the outcome consistently regardless of which trigger fired.

--- a/OffScript/EpisodeTranslationView.swift
+++ b/OffScript/EpisodeTranslationView.swift
@@ -81,7 +81,9 @@ struct EpisodeTranslationView: View {
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
+                    .frame(minHeight: 44)
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .padding(.top, 4)


### PR DESCRIPTION
## Summary
- \`→ TRANSLATE TO …\` button on \`EpisodeTranslationView\` was ~30pt — below HIG.
- Add \`frame(minHeight: 44) + contentShape(Rectangle())\`.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)