### PR TITLE
Bring Player chapter row to 44pt tap target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Player chapter row (`tap-to-seek`) now meets 44pt tap target.** Was ~33pt visible. Same `frame(minHeight: 44)` fix.
 - **EpisodeTranslationView `→ TRANSLATE TO …` key now meets 44pt tap target.** Was ~30pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` pattern.
 - **Speech transcription panel action button now meets 44pt tap target.** Was ~30pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` fix applied across the app.
 - **Home now responds to pull-to-refresh** with the same `loadSections(manual:)` path as the existing retune key in HomeTunerHeader. Mirrors the Library / PodcastDetail pull-to-refresh shipped in #239 so the standard iOS swipe-down works on every list-of-content surface in the app.

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -347,6 +347,7 @@ struct PlayerView: View {
                     .monospacedDigit()
             }
             .padding(.vertical, 10)
+            .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Each tap-to-seek chapter row was ~33pt — below HIG.
- Add \`frame(minHeight: 44)\`.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)