### PR TITLE
Bring PodcastDetail + LOAD 100 MORE to 44pt tap target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **PodcastDetail `+ LOAD 100 MORE` pager key now meets 44pt tap target.** Was ~34pt visible.
 - **Player chapter row (`tap-to-seek`) now meets 44pt tap target.** Was ~33pt visible. Same `frame(minHeight: 44)` fix.
 - **EpisodeTranslationView `→ TRANSLATE TO …` key now meets 44pt tap target.** Was ~30pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` pattern.
 - **Speech transcription panel action button now meets 44pt tap target.** Was ~30pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` fix applied across the app.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -2390,6 +2390,8 @@ struct PodcastDetailView: View {
                                         .padding(.vertical, 12)
                                     Spacer()
                                 }
+                                .frame(minHeight: 44)
+                                .contentShape(Rectangle())
                             }
                             .buttonStyle(.plain)
                             .accessibilityLabel("Load 100 more episodes")


### PR DESCRIPTION
## Summary
- + LOAD 100 MORE pager was ~34pt — below HIG.
- Add \`frame(minHeight: 44) + contentShape(Rectangle())\`.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)