### PR TITLE
Combine Settings stat value+label for VoiceOver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Settings stats block (SUBSCRIBED / EPISODES / UNPLAYED / QUEUED + EXPLICIT / COMPLETED / TAGS) now reads as a single VoiceOver element per stat** — `12 subscribed` instead of `12, SUBSCRIBED` as two separate stops. Combines the value and label via `.accessibilityElement(children: .ignore)`.
 - **PodcastDetail `+ LOAD 100 MORE` pager key now meets 44pt tap target.** Was ~34pt visible.
 - **Player chapter row (`tap-to-seek`) now meets 44pt tap target.** Was ~33pt visible. Same `frame(minHeight: 44)` fix.
 - **EpisodeTranslationView `→ TRANSLATE TO …` key now meets 44pt tap target.** Was ~30pt visible. Same `frame(minHeight: 44) + contentShape(Rectangle())` pattern.

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -165,6 +165,11 @@ struct SettingsView: View {
                 .minimumScaleFactor(0.65)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        // Combine the value+label pair into one accessibility element
+        // so VoiceOver reads "12 SUBSCRIBED" once instead of "12,
+        // SUBSCRIBED" as two separate stops.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(value) \(label.lowercased())")
     }
 
     private var divider: some View {


### PR DESCRIPTION
## Summary
- Each Settings stat (SUBSCRIBED / EPISODES / UNPLAYED / QUEUED + EXPLICIT / COMPLETED / TAGS) read as two separate VoiceOver stops.
- Combine via \`accessibilityElement(children: .ignore)\` so it reads as one \`"12 subscribed"\` stop per stat.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)