### PR TITLE
Combine Library header stats for VoiceOver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Library header stats (SHOWS / VISIBLE / UNPLAYED / IN PROGRESS) now read as one VoiceOver element per stat** — same fix as the Settings stats row from #245.
 - **Settings stats block (SUBSCRIBED / EPISODES / UNPLAYED / QUEUED + EXPLICIT / COMPLETED / TAGS) now reads as a single VoiceOver element per stat** — `12 subscribed` instead of `12, SUBSCRIBED` as two separate stops. Combines the value and label via `.accessibilityElement(children: .ignore)`.
 - **PodcastDetail `+ LOAD 100 MORE` pager key now meets 44pt tap target.** Was ~34pt visible.
 - **Player chapter row (`tap-to-seek`) now meets 44pt tap target.** Was ~33pt visible. Same `frame(minHeight: 44)` fix.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -1797,6 +1797,11 @@ private struct LibraryTunerHeader: View {
                 .monospacedDigit()
             TunerLabel(text: label, color: .offscriptSoftPaper, size: 8)
         }
+        // Combine the value+label so VoiceOver reads "12 shows" once
+        // instead of "12, SHOWS" as two separate stops. Same fix as
+        // the Settings stats row (#245).
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(value) \(label.lowercased())")
     }
 }
 


### PR DESCRIPTION
## Summary
- Library header stats (SHOWS / VISIBLE / UNPLAYED / IN PROGRESS) read as separate value+label VoiceOver stops.
- Combine via \`accessibilityElement(children: .ignore)\`. Same fix as #245 for Settings stats.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)