### PR TITLE
Hide decorative chevrons from VoiceOver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Decorative chevrons on PodcastShelfRow and Settings rate-picker disclosure now hidden from VoiceOver.** The "ChevronRight" / "ChevronUp" SF symbol names were leaking into a11y readback as noise alongside the meaningful row labels.
 - **TunerReadout (Episode detail's `DUR / POS / STATE` hero readouts) now reads as one VoiceOver element per readout** — `Duration 38 minutes` instead of separate `Duration`, `38`, `minutes` stops. Combines tag + value + optional unit via `accessibilityElement(children: .ignore)`. Same pattern as the Library and Settings stats fixes from #245 and #246.
 - **Library header stats (SHOWS / VISIBLE / UNPLAYED / IN PROGRESS) now read as one VoiceOver element per stat** — same fix as the Settings stats row from #245.
 - **Settings stats block (SUBSCRIBED / EPISODES / UNPLAYED / QUEUED + EXPLICIT / COMPLETED / TAGS) now reads as a single VoiceOver element per stat** — `12 subscribed` instead of `12, SUBSCRIBED` as two separate stops. Combines the value and label via `.accessibilityElement(children: .ignore)`.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -2241,6 +2241,7 @@ private struct PodcastShelfRow: View {
             Image(systemName: "chevron.right")
                 .font(.system(size: 11, weight: .bold))
                 .foregroundStyle(Color.offscriptSignalYellow)
+                .accessibilityHidden(true)
         }
         .padding(.vertical, isCompact ? 7 : 10)
     }

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -240,6 +240,7 @@ struct SettingsView: View {
                         Image(systemName: isDefaultRatePickerExpanded ? "chevron.up" : "chevron.down")
                             .font(.system(size: 10, weight: .bold))
                             .foregroundStyle(Color.offscriptSignalYellow)
+                            .accessibilityHidden(true)
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)


### PR DESCRIPTION
## Summary
- PodcastShelfRow chevron.right and Settings rate-picker disclosure chevron leaked SF Symbol names ("ChevronRight" / "ChevronUp") to VoiceOver as noise.
- Add \`.accessibilityHidden(true)\` on both. Button labels are unaffected.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)