### PR TITLE
Combine EpisodeDetail FROM CHANNEL chip for VoiceOver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **EpisodeDetail `FROM CHANNEL` chip now reads as one VoiceOver action** — `Open <podcast title> channel`. Was multi-stop (`From Channel`, podcast title, `chevron.right`). Hides the decorative chevron and combines the rest via `accessibilityElement(children: .ignore)`.
 - **Decorative chevrons on PodcastShelfRow and Settings rate-picker disclosure now hidden from VoiceOver.** The "ChevronRight" / "ChevronUp" SF symbol names were leaking into a11y readback as noise alongside the meaningful row labels.
 - **TunerReadout (Episode detail's `DUR / POS / STATE` hero readouts) now reads as one VoiceOver element per readout** — `Duration 38 minutes` instead of separate `Duration`, `38`, `minutes` stops. Combines tag + value + optional unit via `accessibilityElement(children: .ignore)`. Same pattern as the Library and Settings stats fixes from #245 and #246.
 - **Library header stats (SHOWS / VISIBLE / UNPLAYED / IN PROGRESS) now read as one VoiceOver element per stat** — same fix as the Settings stats row from #245.

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -534,11 +534,14 @@ struct EpisodeDetailView: View {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(Color.offscriptSoftPaper)
+                    .accessibilityHidden(true)
             }
             .padding(10)
             .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Open \(episode.podcast.title) channel")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Multi-stop a11y readback collapsed into one Open <title> channel label.
- Decorative chevron hidden.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)