### PR TITLE
Combine Settings identity readouts for VoiceOver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Settings sign-in identity readouts (`CREDENTIAL` / `CLOUD`) now read as a single VoiceOver element each.** Same `accessibilityElement(children: .ignore)` pattern as #245 / #246 / #247.
 - **EpisodeDetail `FROM CHANNEL` chip now reads as one VoiceOver action** — `Open <podcast title> channel`. Was multi-stop (`From Channel`, podcast title, `chevron.right`). Hides the decorative chevron and combines the rest via `accessibilityElement(children: .ignore)`.
 - **Decorative chevrons on PodcastShelfRow and Settings rate-picker disclosure now hidden from VoiceOver.** The "ChevronRight" / "ChevronUp" SF symbol names were leaking into a11y readback as noise alongside the meaningful row labels.
 - **TunerReadout (Episode detail's `DUR / POS / STATE` hero readouts) now reads as one VoiceOver element per readout** — `Duration 38 minutes` instead of separate `Duration`, `38`, `minutes` stops. Combines tag + value + optional unit via `accessibilityElement(children: .ignore)`. Same pattern as the Library and Settings stats fixes from #245 and #246.

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -647,6 +647,12 @@ struct SettingsView: View {
                 .minimumScaleFactor(0.72)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        // Same single-element pattern as the Settings stats and
+        // Library header stats (#245 / #246) — VoiceOver reads
+        // "Credential authorized" instead of "CREDENTIAL", "AUTHORIZED"
+        // as separate stops.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(label.lowercased()) \(value.lowercased())")
     }
 
     private var identityStatusRows: some View {


### PR DESCRIPTION
## Summary
- CREDENTIAL / CLOUD readouts on the sign-in panel rendered as separate label/value stops.
- Combine via \`accessibilityElement(children: .ignore)\`. Same pattern as #245/#246/#247.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)