### PR TITLE
Combine OPML batch import running-header for VoiceOver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Library OPML batch import strip's running header now reads as one VoiceOver stop** — `Importing 12 of 50 feeds in background` instead of two separate stops for the eyebrow and count. Cancel button stays its own a11y element.
 - **Settings sign-in identity readouts (`CREDENTIAL` / `CLOUD`) now read as a single VoiceOver element each.** Same `accessibilityElement(children: .ignore)` pattern as #245 / #246 / #247.
 - **EpisodeDetail `FROM CHANNEL` chip now reads as one VoiceOver action** — `Open <podcast title> channel`. Was multi-stop (`From Channel`, podcast title, `chevron.right`). Hides the decorative chevron and combines the rest via `accessibilityElement(children: .ignore)`.
 - **Decorative chevrons on PodcastShelfRow and Settings rate-picker disclosure now hidden from VoiceOver.** The "ChevronRight" / "ChevronUp" SF symbol names were leaking into a11y readback as noise alongside the meaningful row labels.

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -3021,7 +3021,7 @@ private struct LibraryBatchImportStrip: View {
                                        color: .offscriptFnInfo)
                         }
                         .accessibilityElement(children: .ignore)
-                        .accessibilityLabel("Importing \(importer.completedCount) of \(importer.totalCount) feeds in background")
+                        .accessibilityLabel("Importing \(importer.completedCount) of \(importer.totalCount) \(importer.totalCount == 1 ? "feed" : "feeds") in background")
 
                         // Cancel key — once a long OPML batch is running
                         // there was no way to abort it short of force-

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -3009,11 +3009,20 @@ private struct LibraryBatchImportStrip: View {
             case .running:
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 10) {
-                        TunerLabel(text: "● IMPORTING IN BACKGROUND",
-                                   color: .offscriptSignalYellow)
-                        Spacer()
-                        TunerLabel(text: "\(importer.completedCount)/\(importer.totalCount)",
-                                   color: .offscriptFnInfo)
+                        // Combined into a single VoiceOver element so
+                        // it reads "Importing 12 of 50 feeds in
+                        // background" instead of two separate stops.
+                        // Cancel button stays its own a11y element.
+                        HStack(spacing: 10) {
+                            TunerLabel(text: "● IMPORTING IN BACKGROUND",
+                                       color: .offscriptSignalYellow)
+                            Spacer()
+                            TunerLabel(text: "\(importer.completedCount)/\(importer.totalCount)",
+                                       color: .offscriptFnInfo)
+                        }
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Importing \(importer.completedCount) of \(importer.totalCount) feeds in background")
+
                         // Cancel key — once a long OPML batch is running
                         // there was no way to abort it short of force-
                         // quitting the app. Existing work is preserved


### PR DESCRIPTION
## Summary
- IMPORTING IN BACKGROUND eyebrow + 12/50 progress count read as two stops to VoiceOver.
- Wrap in inner HStack with \`accessibilityElement(children: .ignore)\` and explicit label \`Importing 12 of 50 feeds in background\`. Cancel button stays its own a11y element.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)