### PR TITLE
Polish LibraryImportSheet BACK key — explicit a11y + 44pt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **LibraryImportSheet `BACK` button now reads as `Back to import menu`** instead of `ChevronLeft, BACK` two-stop readback. Also bumped to 44pt min height.
 - **Library OPML batch import strip's running header now reads as one VoiceOver stop** — `Importing 12 of 50 feeds in background` instead of two separate stops for the eyebrow and count. Cancel button stays its own a11y element.
 - **Settings sign-in identity readouts (`CREDENTIAL` / `CLOUD`) now read as a single VoiceOver element each.** Same `accessibilityElement(children: .ignore)` pattern as #245 / #246 / #247.
 - **EpisodeDetail `FROM CHANNEL` chip now reads as one VoiceOver action** — `Open <podcast title> channel`. Was multi-stop (`From Channel`, podcast title, `chevron.right`). Hides the decorative chevron and combines the rest via `accessibilityElement(children: .ignore)`.

--- a/OffScript/LibraryImportSheet.swift
+++ b/OffScript/LibraryImportSheet.swift
@@ -364,11 +364,16 @@ struct LibraryImportSheet: View {
             HStack(spacing: 6) {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 10, weight: .semibold))
+                    .accessibilityHidden(true)
                 TunerLabel(text: "BACK", color: .offscriptSoftPaper, size: 10)
             }
             .foregroundStyle(Color.offscriptSoftPaper)
+            .padding(.vertical, 6)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Back to import menu")
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- pasteURL / OPML mode → BACK button had no a11y label (chevron leaked) and no min-height (~16pt).
- Add \`accessibilityLabel("Back to import menu")\`, \`accessibilityHidden(true)\` on the chevron, and \`frame(minHeight: 44) + contentShape(Rectangle())\`.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)