### PR TITLE
Title-aware a11y on EpisodeCompactCard inline actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **EpisodeCompactCard's `+ QUEUE` and `✓ PLAYED` inline actions now expose title-aware VoiceOver labels** — `Add <title> to queue` / `Mark <title> as played`. Without this they read only the mono visible text without episode context.
 - **CardComponents queue button now uses title-aware VoiceOver label** — last surface still using generic `Already queued`. Now reads `<title> already queued` consistent with #224's pass.
 - **LibraryImportSheet `BACK` button now reads as `Back to import menu`** instead of `ChevronLeft, BACK` two-stop readback. Also bumped to 44pt min height.
 - **Library OPML batch import strip's running header now reads as one VoiceOver stop** — `Importing 12 of 50 feeds in background` instead of two separate stops for the eyebrow and count. Cancel button stays its own a11y element.

--- a/OffScript/CardComponents.swift
+++ b/OffScript/CardComponents.swift
@@ -309,6 +309,9 @@ struct EpisodeCompactCard: View {
                         catch { cardLogger.error("Queue add failed: \(error.localizedDescription, privacy: .public)") }
                         withAnimation(.easeInOut(duration: 0.16)) { showsActions = false }
                     }
+                    .accessibilityLabel(episode.isQueued
+                        ? "\(episode.title) already queued"
+                        : "Add \(episode.title) to queue")
 
                     tunerInlineAction(
                         title: episode.isPlayed ? "○ UNPLAYED" : "✓ PLAYED",
@@ -317,6 +320,9 @@ struct EpisodeCompactCard: View {
                         togglePlayedState()
                         withAnimation(.easeInOut(duration: 0.16)) { showsActions = false }
                     }
+                    .accessibilityLabel(episode.isPlayed
+                        ? "Mark \(episode.title) as unplayed"
+                        : "Mark \(episode.title) as played")
                     Spacer(minLength: 0)
                 }
                 .transition(.opacity.combined(with: .move(edge: .top)))


### PR DESCRIPTION
## Summary
- The \`+ QUEUE\` and \`✓ PLAYED\` inline actions inside \`EpisodeCompactCard\` had no explicit a11y label.
- Add title-aware labels matching the rest of the app.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)