### PR TITLE
HeroTunerCard … more-actions: title-aware + 44pt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **HeroTunerCard `…` more-actions key now reads as `More actions for <title>`** (was generic `More actions`) and meets 44pt tap target (was 32pt visible).
 - **EpisodeCompactCard's `+ QUEUE` and `✓ PLAYED` inline actions now expose title-aware VoiceOver labels** — `Add <title> to queue` / `Mark <title> as played`. Without this they read only the mono visible text without episode context.
 - **CardComponents queue button now uses title-aware VoiceOver label** — last surface still using generic `Already queued`. Now reads `<title> already queued` consistent with #224's pass.
 - **LibraryImportSheet `BACK` button now reads as `Back to import menu`** instead of `ChevronLeft, BACK` two-stop readback. Also bumped to 44pt min height.

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -973,6 +973,7 @@ private struct HeroTunerCard: View {
                             .frame(minWidth: 44, minHeight: 44)
                             .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                     .accessibilityLabel("More actions for \(episode.title)")
                     .accessibilityHint(showsFeedbackActions ? "Double-tap to hide feedback actions." : "Double-tap to show feedback actions.")
                 }

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -970,8 +970,10 @@ private struct HeroTunerCard: View {
                             .foregroundStyle(Color.offscriptSignalYellow)
                             .frame(width: 38, height: 32)
                             .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+                            .frame(minWidth: 44, minHeight: 44)
+                            .contentShape(Rectangle())
                     }
-                    .accessibilityLabel("More actions")
+                    .accessibilityLabel("More actions for \(episode.title)")
                     .accessibilityHint(showsFeedbackActions ? "Double-tap to hide feedback actions." : "Double-tap to show feedback actions.")
                 }
                 .padding(.top, 4)


### PR DESCRIPTION
## Summary
- Hero card ellipsis button read as generic \`More actions\` and was 32pt visible.
- Add title-aware label and 44pt tap target.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)