### PR TITLE
Add × CLEAR SEARCH recovery key to Search empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 - **Home recommendations now have a dedicated “More From Shows You Chose” lane** so explicit like/more-like-this show intent is not mislabeled as passive completion affinity.
 
 ### Changed — Tuner UI conformance
+- **Search empty `NO MATCHES` state now exposes a `× CLEAR SEARCH` recovery key** — one-tap reset back to the starter-topics + recent-searches landing state. Mirrors the clear-filter affordances on PodcastDetail (#208) and Library directory (#220).
 - **Home discovery rail now owns per-pick import errors** — the same #214 fix applied to `HomeStarterRail` is now also on `TunerDiscoveryRail`. Failed `+ TUNE` flips to `✗ FAILED · RETRY` in `offscriptFnRecord` instead of overwriting a single global error strip. Per-pick in-flight tracking via `importingIDs: Set<String>` so concurrent taps both keep their `○ TUNING…` state.
 - **HeroTunerCard `…` more-actions key now reads as `More actions for <title>`** (was generic `More actions`) and meets 44pt tap target (was 32pt visible).
 - **EpisodeCompactCard's `+ QUEUE` and `✓ PLAYED` inline actions now expose title-aware VoiceOver labels** — `Add <title> to queue` / `Mark <title> as played`. Without this they read only the mono visible text without episode context.

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -167,7 +167,7 @@ struct SearchView: View {
     }
 
     private var emptyState: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             Rectangle().fill(Color.offscriptHairline).frame(height: 1)
             TunerLabel(text: "● NO MATCHES", color: .offscriptSoftPaper)
             Text("No matches")
@@ -177,6 +177,23 @@ struct SearchView: View {
                 .font(.system(size: 13.5))
                 .foregroundStyle(Color.offscriptPaperWhite)
                 .lineSpacing(2)
+
+            // One-tap reset to the starter-topics + recent-searches
+            // landing state. Mirrors the × CLEAR FILTER recovery key on
+            // PodcastDetail (#208) and Library directory (#220).
+            Button {
+                query = ""
+            } label: {
+                TunerLabel(text: "× CLEAR SEARCH", color: .offscriptSignalYellow, size: 10)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .frame(minHeight: 44)
+                    .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Clear search query")
+            .accessibilityIdentifier("SearchEmptyClearSearch")
         }
         .padding(.top, 8)
     }


### PR DESCRIPTION
## Summary
- Search "No matches" state had no one-tap reset to the landing view.
- Add \`× CLEAR SEARCH\` key inline. Mirrors #208 / #220.

## Test plan
- [x] \`xcodebuild build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)