### PR TITLE
Make Settings ABOUT · BUILD VERSION tap-to-copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ## [Unreleased]
 
+### Added — power-user QoL
+- **Settings ABOUT · BUILD `VERSION` row is now tap-to-copy** — tapping the build readout writes `<version> (<build>)` to the clipboard so a tester filing TestFlight feedback or a bug report doesn't have to retype it. The strip flips to `✓ COPIED · <version>` in `offscriptFnMode` for ~1.5s before resetting. Includes a `TAP TO COPY` hint chip in `offscriptSignalYellow` so the affordance is discoverable without VoiceOver. Tap target is 44pt min-height with explicit a11y identifier and label.
+
 ### Added — UI QA swarm coverage
 - **New `-offscript.debugWipeLibrary YES` launch arg wipes the SwiftData store before seeding** so UI tests that need a guaranteed-empty Library or Queue can launch deterministically regardless of prior simulator state. Documented in `docs/TEST_MATRIX.md`. Closes #177.
 - **Library empty state now has UI smoke coverage** that asserts `● NO CHANNELS TUNED` and "Your library is empty" render on a freshly-wiped store, pinning the day-one Library experience against future header refactors (#115).

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -2,6 +2,7 @@ import AuthenticationServices
 import OSLog
 import SwiftData
 import SwiftUI
+import UIKit
 
 private let settingsLogger = Logger(subsystem: "com.offscript", category: "Settings")
 
@@ -30,6 +31,12 @@ struct SettingsView: View {
     /// custom speed) and otherwise irreversible — drop into a confirm
     /// strip first, mirroring the Queue × CLEAR ALL pattern from #200.
     @State private var isConfirmingResetRates = false
+    /// Tracks whether the ABOUT · BUILD `VERSION` row has just copied
+    /// itself to the clipboard, so a tester sending a bug report
+    /// doesn't have to remember the build number — one tap copies,
+    /// strip flips to ✓ COPIED for ~1.5s, then resets.
+    @State private var didCopyBuildVersion = false
+    @State private var copyVersionResetTask: Task<Void, Never>?
 
     @State private var subscribedPodcastCount: Int = 0
     @State private var episodeCount: Int = 0
@@ -681,10 +688,42 @@ struct SettingsView: View {
                 .foregroundStyle(Color.offscriptPaperWhite)
                 .lineSpacing(2)
 
-            HStack {
-                TunerLabel(text: "VERSION  \(buildVersionString.uppercased())", color: .offscriptSoftPaper)
-                Spacer()
+            // VERSION readout doubles as a copy-to-clipboard key —
+            // testers filing TestFlight feedback or bug reports can
+            // grab the exact build string without leaving the app.
+            // Strip flips to ✓ COPIED for ~1.5s after the tap.
+            Button {
+                copyVersionResetTask?.cancel()
+                UIPasteboard.general.string = buildVersionString
+                withAnimation(.easeInOut(duration: 0.18)) { didCopyBuildVersion = true }
+                copyVersionResetTask = Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(1500))
+                    guard !Task.isCancelled else { return }
+                    withAnimation(.easeInOut(duration: 0.18)) { didCopyBuildVersion = false }
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    TunerLabel(
+                        text: didCopyBuildVersion
+                            ? "✓ COPIED · \(buildVersionString.uppercased())"
+                            : "VERSION  \(buildVersionString.uppercased())",
+                        color: didCopyBuildVersion ? .offscriptFnMode : .offscriptSoftPaper
+                    )
+                    Spacer()
+                    if !didCopyBuildVersion {
+                        TunerLabel(text: "TAP TO COPY", color: .offscriptSignalYellow, size: 8)
+                    }
+                }
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("SettingsCopyBuildVersion")
+            .accessibilityLabel(
+                didCopyBuildVersion
+                    ? "Copied build version \(buildVersionString) to clipboard"
+                    : "Copy build version \(buildVersionString) to clipboard"
+            )
             .padding(.top, 4)
         }
         .padding(.vertical, 12)


### PR DESCRIPTION
## Summary
- Settings ABOUT · BUILD `VERSION` row is now a Button — tapping it writes `<version> (<build>)` to the clipboard so testers filing TestFlight feedback don't have to retype the build string.
- Strip flips to `✓ COPIED · <version>` in `offscriptFnMode` for ~1.5s, then resets. Reset Task is cancellable so rapid retaps don't fight a stale timer.
- `TAP TO COPY` hint chip in `offscriptSignalYellow` makes the affordance discoverable for sighted users.
- 44pt min-height tap target with explicit a11y identifier (`SettingsCopyBuildVersion`) and a state-aware label.

## Test plan
- [x] xcodebuild build (Debug, iPhone 17 Pro)
- [ ] Manual: open Settings → tap VERSION row → paste elsewhere to verify clipboard contents → confirm strip flips to ✓ COPIED then resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)