### PR TITLE
Harden Now Playing artwork and Tuner surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ## [Unreleased]
 
+### Fixed
+- Lock screen / Control Center now receive generated Tuner fallback artwork immediately when an episode has no feed artwork or while remote artwork is loading, so Now Playing metadata no longer publishes without cover art.
+- Shared artwork fallback now renders consistently across app surfaces, keeping missing/loading cover art inside the Tuner visual language.
+- Shared empty-state treatment now keeps no-content Library, Queue, Search, and related surfaces aligned on sharp hairlines, mono status copy, and clear recovery actions.
+- App-wide Tuner buttons now provide consistent press feedback so action keys feel responsive without falling back to native Liquid Glass chrome.
+
 ## [2.5.1] — 2026-05-20
 
 ### Fixed — schema migration ship bug (CRITICAL)
-- **Existing user libraries were being quarantined on first launch of 2.5.0** because Phase 38 (commit `b897e3d`) added two new fields to `EpisodeProfile` (`confidenceScore`, `freshnessBucket`) without bumping the SwiftData schema version or registering a migration stage. SwiftData detected the schema fingerprint mismatch against the V2-shaped on-disk store, the lightweight migration failed, and the three-tier recovery in `OffScriptApp.sharedModelContainer` fell through to the rename-and-fresh quarantine path. Users with the prior store still have it on disk as `OffScript-corrupted-<unix-timestamp>/` in Application Support; opening 2.5.1 will NOT auto-recover that store (the quarantine happened on 2.5.0 launch and the V2 store is no longer the live one), but the fresh V3 store built by 2.5.0 + the upgrade flow in 2.5.1 will continue forward cleanly.
-- **Adds `SchemaV3`** with the new `EpisodeProfile` shape and a lightweight `migrateV2toV3` stage (additive columns only; SwiftData fills defaults / nulls for existing rows automatically). Users who never installed 2.5.0 will skip directly through V1→V2→V3 on upgrade with no data loss.
+- **Existing user libraries were being quarantined on first launch of 2.5.0** because the published-transcript work expanded `EpisodeTranscriptCache` (`language` + timed-cue storage) without freezing the old V2 model shape and registering a V2→V3 migration stage. SwiftData detected the schema fingerprint mismatch against the V2-shaped on-disk store, the lightweight migration failed, and the three-tier recovery in `OffScriptApp.sharedModelContainer` fell through to the rename-and-fresh quarantine path. Users with the prior store still have it on disk as `OffScript-corrupted-<unix-timestamp>/` in Application Support; opening 2.5.1 will NOT auto-recover that store (the quarantine happened on 2.5.0 launch and the V2 store is no longer the live one), but the fresh V3 store built by 2.5.0 + the upgrade flow in 2.5.1 will continue forward cleanly.
+- **Adds `SchemaV3`** with the expanded `EpisodeTranscriptCache` shape, freezes the 2.4.x `SchemaV2.EpisodeTranscriptCache` model, and registers a lightweight `migrateV2toV3` stage (additive columns only; SwiftData fills defaults / nulls for existing rows automatically). Users who never installed 2.5.0 will skip directly through V1→V2→V3 on upgrade with no data loss.
+- **Fixes App Intents store access** so Siri/Shortcuts open the same V3 SwiftData store as the main app instead of trying to initialize a stale V2 container after the 2.5.1 migration.
 - **Lesson canonized:** every new `@Model` field — even nullable / defaulted — needs a new `SchemaVN` + migration stage. Documented in `SchemaMigration.swift`'s header comments and added to the audit-cycle ship-checklist in `docs/TESTFLIGHT.md` (separate commit).
 
 

--- a/OffScript/AppTheme.swift
+++ b/OffScript/AppTheme.swift
@@ -172,6 +172,14 @@ extension Color {
     static let offscriptSurfaceMedium = Color.white.opacity(0.12)
 }
 
+extension UIColor {
+    static let offscriptStudioBlack = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
+    static let offscriptPaperWhite = UIColor(red: 0.953, green: 0.945, blue: 0.918, alpha: 1)
+    static let offscriptSignalYellow = UIColor(red: 0.910, green: 0.824, blue: 0.290, alpha: 1)
+    static let offscriptFnInfo = UIColor(red: 0.365, green: 0.769, blue: 0.910, alpha: 1)
+    static let offscriptHairline = UIColor(white: 1, alpha: 0.08)
+}
+
 extension Font {
     // Tuner typography — instrument-cluster grotesque + monospaced metadata.
     // Headlines: SF Pro Display at light weights with tight tracking (Space Grotesk feel).
@@ -201,23 +209,157 @@ struct OffScriptBackgroundView: View {
 }
 
 struct OffScriptArtworkPlaceholder: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var cornerRadius: CGFloat = 3
+    @State private var pulse = false
 
     var body: some View {
-        // Tuner: cassette-cartridge placeholder — flat black, hairline border,
-        // with a clipped corner notch and a small mono "NO SIGNAL" tag.
-        ZStack {
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .fill(Color.offscriptStudioBlack)
-                .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .stroke(Color.offscriptHairline, lineWidth: 1)
-                )
+        GeometryReader { proxy in
+            let size = proxy.size
+            let minDimension = min(size.width, size.height)
+            let isCompact = minDimension < 72
+            let meterWidth = max(1, minDimension * (isCompact ? 0.018 : 0.012))
+            let meterHeights = isCompact
+                ? [0.16, 0.28, 0.40, 0.28, 0.16]
+                : [0.14, 0.26, 0.38, 0.52, 0.38, 0.26, 0.14]
+            let meterMaxHeight = minDimension * (isCompact ? 0.24 : 0.32)
 
-            Image(systemName: "waveform")
-                .font(.system(size: 18, weight: .light))
-                .foregroundStyle(Color.offscriptSoftPaper)
+            ZStack {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(Color.offscriptStudioBlack)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .stroke(Color.offscriptHairline, lineWidth: 1)
+                    )
+
+                if !isCompact {
+                    placeholderGrid
+                        .opacity(0.7)
+                }
+
+                VStack(spacing: isCompact ? 6 : 10) {
+                    if !isCompact {
+                        HStack(spacing: 8) {
+                            TunerLabel(text: "NO ART", color: .offscriptSoftPaper, size: 8)
+                            Spacer(minLength: 8)
+                            TunerLabel(text: "LOCAL SIGNAL", color: .offscriptFnInfo, size: 8)
+                        }
+                    }
+
+                    Spacer(minLength: 0)
+
+                    HStack(alignment: .center, spacing: max(2, minDimension * 0.018)) {
+                        ForEach(Array(meterHeights.enumerated()), id: \.offset) { index, ratio in
+                            Capsule(style: .continuous)
+                                .fill(index == meterHeights.count / 2 ? Color.offscriptSignalYellow : Color.offscriptSoftPaper)
+                                .frame(width: meterWidth, height: max(4, meterMaxHeight * ratio))
+                                .opacity(meterOpacity(for: index, count: meterHeights.count))
+                        }
+                    }
+                    .accessibilityHidden(true)
+
+                    Spacer(minLength: 0)
+
+                    if !isCompact {
+                        HStack(spacing: 8) {
+                            Rectangle()
+                                .fill(Color.offscriptSignalYellow)
+                                .frame(width: 28, height: 1)
+                            Rectangle()
+                                .fill(Color.offscriptHairline)
+                                .frame(height: 1)
+                            TunerLabel(text: "STANDBY", color: .offscriptSignalYellow, size: 8)
+                        }
+                    }
+                }
+                .padding(isCompact ? 0 : max(10, minDimension * 0.07))
+
+                if !isCompact {
+                    cornerTicks
+                }
+            }
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
+                    pulse = true
+                }
+            }
+            .onChange(of: reduceMotion) { _, newValue in
+                pulse = false
+                guard !newValue else { return }
+                withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
+                    pulse = true
+                }
+            }
         }
+    }
+
+    private var placeholderGrid: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                ForEach(0..<4, id: \.self) { _ in
+                    Rectangle()
+                        .fill(Color.offscriptHairline)
+                        .frame(height: 1)
+                    Spacer(minLength: 0)
+                }
+                Rectangle()
+                    .fill(Color.offscriptHairline)
+                    .frame(height: 1)
+            }
+
+            HStack(spacing: 0) {
+                ForEach(0..<4, id: \.self) { _ in
+                    Rectangle()
+                        .fill(Color.offscriptHairline)
+                        .frame(width: 1)
+                    Spacer(minLength: 0)
+                }
+                Rectangle()
+                    .fill(Color.offscriptHairline)
+                    .frame(width: 1)
+            }
+        }
+    }
+
+    private var cornerTicks: some View {
+        VStack {
+            HStack {
+                cornerTick
+                Spacer()
+                cornerTick
+                    .rotationEffect(.degrees(90))
+            }
+            Spacer()
+            HStack {
+                cornerTick
+                    .rotationEffect(.degrees(270))
+                Spacer()
+                cornerTick
+                    .rotationEffect(.degrees(180))
+            }
+        }
+        .padding(10)
+    }
+
+    private var cornerTick: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Rectangle()
+                .fill(Color.offscriptSignalYellow)
+                .frame(width: 14, height: 1)
+            Rectangle()
+                .fill(Color.offscriptSignalYellow)
+                .frame(width: 1, height: 14)
+        }
+        .opacity(0.75)
+    }
+
+    private func meterOpacity(for index: Int, count: Int) -> Double {
+        guard !reduceMotion else { return 0.7 }
+        let center = count / 2
+        if index == center { return pulse ? 1.0 : 0.62 }
+        return pulse ? 0.56 : 0.34
     }
 }
 
@@ -546,6 +688,85 @@ struct RecommendationSignalTraceView: View {
     }
 }
 
+struct TunerPressButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(isEnabled && configuration.isPressed && !reduceMotion ? 0.985 : 1)
+            .opacity(isEnabled ? (configuration.isPressed ? 0.72 : 1) : 0.45)
+            .animation(
+                reduceMotion ? nil : .easeOut(duration: 0.12),
+                value: configuration.isPressed
+            )
+            .animation(
+                reduceMotion ? nil : .easeOut(duration: 0.16),
+                value: isEnabled
+            )
+    }
+}
+
+extension ButtonStyle where Self == TunerPressButtonStyle {
+    static var tunerPress: TunerPressButtonStyle { TunerPressButtonStyle() }
+}
+
+struct TunerEmptyState<Action: View>: View {
+    let status: String
+    let title: String
+    let message: String
+    var statusColor: Color = .offscriptSoftPaper
+    @ViewBuilder var action: () -> Action
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Rectangle()
+                .fill(Color.offscriptHairline)
+                .frame(height: 1)
+
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                TunerLabel(text: status, color: statusColor)
+                Spacer(minLength: 10)
+                TunerLabel(text: "STANDBY", color: .offscriptFnInfo, size: 8)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.system(size: 22, weight: .semibold))
+                    .tracking(0)
+                    .foregroundStyle(Color.offscriptPaperWhite)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(message)
+                    .font(.system(size: 13.5))
+                    .foregroundStyle(Color.offscriptPaperWhite)
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            action()
+                .padding(.top, 2)
+        }
+        .padding(.vertical, 14)
+    }
+}
+
+extension TunerEmptyState where Action == EmptyView {
+    init(
+        status: String,
+        title: String,
+        message: String,
+        statusColor: Color = .offscriptSoftPaper
+    ) {
+        self.status = status
+        self.title = title
+        self.message = message
+        self.statusColor = statusColor
+        self.action = { EmptyView() }
+    }
+}
+
 /// Inline navigation key for pushed Tuner detail screens. The visible control
 /// stays compact, but the outer frame preserves a 44pt hit target.
 struct TunerInlineBackButton: View {
@@ -568,7 +789,7 @@ struct TunerInlineBackButton: View {
             .frame(minWidth: 44, minHeight: 44, alignment: .center)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityIdentifier(accessibilityIdentifier)
     }
@@ -688,7 +909,7 @@ struct TunerRatePicker: View {
                     .overlay(Rectangle().stroke(isSelected ? Color.offscriptSignalYellow : Color.offscriptHairline, lineWidth: 1))
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel("\(accessibilityActionPrefix) \(String(format: "%.2g×", rate))")
                 .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)

--- a/OffScript/CardComponents.swift
+++ b/OffScript/CardComponents.swift
@@ -41,7 +41,7 @@ struct EpisodeVerticalCard: View {
                 )
                 .frame(width: 200, height: 150)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
 
             // Tuner text + transport zone
             VStack(alignment: .leading, spacing: 8) {
@@ -71,7 +71,7 @@ struct EpisodeVerticalCard: View {
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
 
                 Text(metadata.uppercased())
                     .tunerFont(size: 8, tracking: 1.4)
@@ -106,7 +106,7 @@ struct EpisodeVerticalCard: View {
                             .frame(width: 44, height: 44)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel(isCurrentlyPlaying ? "Pause" : "Play \(episode.title)")
 
                     // Tuner queue key — hairline square
@@ -124,7 +124,7 @@ struct EpisodeVerticalCard: View {
                             .frame(width: 44, height: 44)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .disabled(episode.isQueued)
                     .accessibilityLabel(episode.isQueued ? "\(episode.title) already queued" : "Add \(episode.title) to queue")
 
@@ -204,7 +204,7 @@ struct EpisodeCompactCard: View {
                 .frame(width: 52, height: 52)
                 .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
 
             Button {
                 if let onTap {
@@ -236,7 +236,7 @@ struct EpisodeCompactCard: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
 
             // Tuner play key — sharp hairline rectangle, signal-yellow ring.
             // Was Circle (Tuner-vocab violation). 32pt visible / 44pt hit.
@@ -251,7 +251,7 @@ struct EpisodeCompactCard: View {
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel(isCurrentlyPlaying ? "Pause" : "Play \(episode.title)")
 
             Button {
@@ -267,7 +267,7 @@ struct EpisodeCompactCard: View {
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("More actions for \(episode.title)")
             .accessibilityHint(showsActions ? "Double-tap to hide actions." : "Double-tap to show queue and played actions.")
 
@@ -283,7 +283,7 @@ struct EpisodeCompactCard: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Remove \(episode.title)")
             }
             }
@@ -368,7 +368,7 @@ struct EpisodeCompactCard: View {
                 .contentShape(Rectangle())
         }
         .disabled(disabled)
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
     }
 
     private func togglePlayedState() {

--- a/OffScript/ContentView.swift
+++ b/OffScript/ContentView.swift
@@ -314,7 +314,7 @@ private struct TunerTabBar: View {
                             } label: {
                                 tabContent(for: tab)
                             }
-                            .buttonStyle(.plain)
+                            .buttonStyle(.tunerPress)
                             .frame(width: segmentWidth)
                             .accessibilityLabel(tab.label.capitalized)
                             .accessibilityAddTraits(selection == tab ? .isSelected : [])

--- a/OffScript/DebugInspectorView.swift
+++ b/OffScript/DebugInspectorView.swift
@@ -92,7 +92,7 @@ struct DebugInspectorView: View {
                         .frame(minHeight: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Close debug inspector")
             }
             Text("Debug-only diagnostics. Surfaces dormant telemetry, per-podcast sync state, download queues, and runtime metadata.")
@@ -133,7 +133,7 @@ struct DebugInspectorView: View {
                             .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Clear all telemetry events")
                     .accessibilityHint("Asks for confirmation before deleting every recorded event.")
                 }
@@ -182,7 +182,7 @@ struct DebugInspectorView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Telemetry event \(event.name), \(timestampLabel(event.createdAt))")
         .accessibilityHint("Double-tap to inspect full payload.")
@@ -206,7 +206,7 @@ struct DebugInspectorView: View {
                         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Cancel clear telemetry")
 
                 Button {
@@ -220,7 +220,7 @@ struct DebugInspectorView: View {
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Confirm clear telemetry")
             }
         }
@@ -411,7 +411,7 @@ struct DebugInspectorView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(episode.title), download failed: \(message). Double-tap to retry.")
     }
@@ -660,7 +660,7 @@ private struct TelemetryDetailSheet: View {
                             .frame(minHeight: 44)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Close telemetry event detail")
                 }
 

--- a/OffScript/DownloadButton.swift
+++ b/OffScript/DownloadButton.swift
@@ -24,7 +24,7 @@ struct DownloadButton: View {
             .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityLabel(downloadAccessibilityLabel)
         .accessibilityHint(downloadAccessibilityHint)
     }

--- a/OffScript/EpisodeDetailView.swift
+++ b/OffScript/EpisodeDetailView.swift
@@ -235,7 +235,7 @@ struct EpisodeDetailView: View {
                 .frame(minHeight: 44)
                 .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .disabled(isCurrentlyPlaying)
             .accessibilityLabel(
                 isCurrentlyPlaying
@@ -263,7 +263,7 @@ struct EpisodeDetailView: View {
                 .frame(minHeight: 44)
                 .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .disabled(episode.isQueued)
             .accessibilityLabel(episode.isQueued ? "\(episode.title) already queued" : "Add \(episode.title) to queue")
 
@@ -293,7 +293,7 @@ struct EpisodeDetailView: View {
                     .frame(minHeight: 44)
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Queue \(episode.title) to play next")
                 .accessibilityIdentifier("EpisodeDetailQueueNext")
             }
@@ -349,7 +349,7 @@ struct EpisodeDetailView: View {
                             .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Retry download for \(episode.title)")
                 }
             }
@@ -457,7 +457,7 @@ struct EpisodeDetailView: View {
                     .frame(minHeight: 44)
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(feedbackGiven != nil)
                 .accessibilityLabel(
                     feedbackGiven == .like
@@ -488,7 +488,7 @@ struct EpisodeDetailView: View {
                     .frame(minHeight: 44)
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(feedbackGiven != nil)
                 .accessibilityLabel(
                     feedbackGiven == .lessLikeThis
@@ -536,7 +536,7 @@ struct EpisodeDetailView: View {
             .padding(10)
             .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Open \(episode.podcast.title) channel")
     }

--- a/OffScript/EpisodeTranslationView.swift
+++ b/OffScript/EpisodeTranslationView.swift
@@ -85,7 +85,7 @@ struct EpisodeTranslationView: View {
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .padding(.top, 4)
             }
         }

--- a/OffScript/GenrePickerView.swift
+++ b/OffScript/GenrePickerView.swift
@@ -83,13 +83,13 @@ struct GenrePickerView: View {
                         )
                     )
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(selectedGenres.isEmpty)
 
                 Button(action: onBack) {
                     TunerLabel(text: "← BACK")
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 14)
@@ -161,7 +161,7 @@ private struct GenreCard: View {
                 )
             )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .sensoryFeedback(.impact(flexibility: .soft), trigger: isSelected)
         .accessibilityLabel("\(genre.title)\(isSelected ? ", selected" : "")")
         .accessibilityAddTraits(isSelected ? .isSelected : [])

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -130,7 +130,8 @@ struct HomeView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         // No `.toolbar` ToolbarItem here. iOS 26's NavigationStack wraps any
-        // toolbar Button in a Liquid Glass capsule that ignores `.plain`
+        // toolbar Button in a Liquid Glass capsule that ignores custom
+        // Tuner button styling
         // styling and our color tokens — that's the gray-circle chrome we
         // saw in the screenshot. The settings affordance is rendered inline
         // in HomeTunerHeader instead, where we have full control.
@@ -338,7 +339,7 @@ private struct HomeTunerHeader: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(isRetuning)
                 .accessibilityLabel(isRetuning ? "Retuning recommendations" : "Retune recommendations")
 
@@ -354,7 +355,7 @@ private struct HomeTunerHeader: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Open settings")
             }
 
@@ -373,13 +374,12 @@ private struct HomeErrorRow: View {
     var onRetry: (() -> Void)? = nil
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            TunerLabel(text: "● FEED UNAVAILABLE", color: .offscriptFnRecord)
-            Text(message)
-                .font(.system(size: 12.5))
-                .foregroundStyle(Color.offscriptPaperWhite)
-                .fixedSize(horizontal: false, vertical: true)
-
+        TunerEmptyState(
+            status: "● FEED UNAVAILABLE",
+            title: "Home feed paused",
+            message: message,
+            statusColor: .offscriptFnRecord
+        ) {
             // Retry key — recommendation pipeline is cheap to re-run and
             // the most common cause of `errorMessage` is a transient
             // SwiftData fetch hiccup or a momentary CDN glitch on the
@@ -394,18 +394,13 @@ private struct HomeErrorRow: View {
                         .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Retry loading recommendations")
                 .accessibilityIdentifier("HomeErrorRetry")
             }
         }
         .padding(.horizontal, OffScriptTheme.pagePadding)
-        .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .overlay(
-            Rectangle().fill(Color.offscriptHairline).frame(height: 1),
-            alignment: .top
-        )
     }
 }
 
@@ -550,7 +545,7 @@ private struct HomeStarterRail: View {
                     ))
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(isAdded || isImporting)
                 .accessibilityLabel(
                     isAdded
@@ -647,7 +642,7 @@ private struct HomeEmptyState: View {
                 .padding(.vertical, 12)
                 .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .padding(.top, 4)
         }
         .padding(.horizontal, OffScriptTheme.pagePadding)
@@ -860,7 +855,7 @@ private struct TunerDiscoveryRail: View {
                     .overlay(Rectangle().stroke(actionColor, lineWidth: 1))
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .disabled(isAdded || isImporting)
             .accessibilityLabel(
                 isAdded
@@ -959,7 +954,7 @@ private struct HeroTunerCard: View {
                         .lineLimit(3)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
 
                 // Reason as a TunerTag with signal yellow accent
                 TunerTag(text: displayReason, color: .offscriptSignalYellow, dim: true, wraps: true)
@@ -1037,7 +1032,7 @@ private struct HeroTunerCard: View {
                             .frame(minWidth: 44, minHeight: 44)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("More actions for \(episode.title)")
                     .accessibilityHint(showsFeedbackActions ? "Double-tap to hide feedback actions." : "Double-tap to show feedback actions.")
                 }
@@ -1078,7 +1073,7 @@ private struct HeroTunerCard: View {
                 .padding(.vertical, 10)
                 .overlay(Rectangle().stroke(color.opacity(disabled ? 0.3 : 1.0), lineWidth: 1))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .disabled(disabled)
         .accessibilityLabel(accessibilityLabel)
     }
@@ -1156,7 +1151,7 @@ private struct HeroTunerCard: View {
                 .overlay(Rectangle().stroke(color.opacity(0.65), lineWidth: 1))
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityLabel(accessibilityLabel)
     }
 
@@ -1271,7 +1266,7 @@ private struct TunerRailCard: View {
                     TunerLabel(text: metadata, color: .offscriptSoftPaper, size: 8)
                 }
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             // Combine artwork + podcast eyebrow + title + reason +
             // metadata into one VoiceOver stop. Use the VO-friendly
             // metadata variant — the visible `metadata` is uppercased,
@@ -1297,7 +1292,7 @@ private struct TunerRailCard: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Play \(episode.title)")
 
                 Button {
@@ -1312,7 +1307,7 @@ private struct TunerRailCard: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(episode.isQueued)
                 .accessibilityLabel(episode.isQueued ? "\(episode.title) already queued" : "Add \(episode.title) to queue")
 

--- a/OffScript/ImportProgressView.swift
+++ b/OffScript/ImportProgressView.swift
@@ -82,7 +82,7 @@ struct ImportProgressView: View {
                             .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                             .frame(minHeight: 44)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .disabled(isImporting)
 
                     if doneCount > 0 {
@@ -96,7 +96,7 @@ struct ImportProgressView: View {
                                 .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                                 .frame(minHeight: 44)
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.tunerPress)
                     }
                 }
             }

--- a/OffScript/LibraryImportSheet.swift
+++ b/OffScript/LibraryImportSheet.swift
@@ -114,7 +114,7 @@ struct LibraryImportSheet: View {
                         .frame(minHeight: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Close import")
             }
             Rectangle().fill(Color.offscriptHairline).frame(height: 1)
@@ -172,7 +172,7 @@ struct LibraryImportSheet: View {
                         .padding(.vertical, 14)
                         .overlay(Rectangle().stroke(Color.offscriptFnInfo, lineWidth: 1))
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                 }
             }
             .padding(.top, 8)
@@ -232,7 +232,7 @@ struct LibraryImportSheet: View {
                             .frame(width: 44, height: 44)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Clear URL")
                 }
             }
@@ -371,7 +371,7 @@ struct LibraryImportSheet: View {
             .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityLabel("Back to import menu")
     }
 
@@ -389,7 +389,7 @@ struct LibraryImportSheet: View {
             .padding(.vertical, 14)
             .overlay(Rectangle().stroke(disabled ? Color.offscriptHairline : color, lineWidth: 1))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .disabled(disabled)
     }
 

--- a/OffScript/LibraryView.swift
+++ b/OffScript/LibraryView.swift
@@ -801,6 +801,7 @@ struct LibraryView: View {
     @State private var selectedPodcastID: UUID?
     @State private var directoryPodcasts: [LibraryDirectoryPodcast] = []
     @State private var didLoadDirectoryPodcasts = false
+    @State private var directoryLoadError: String?
     @State private var cachedDirectorySnapshot = LibraryDirectorySnapshot.empty
     @State private var didBuildDirectorySnapshot = false
     @State private var isSyncingLibrary = false
@@ -1007,7 +1008,28 @@ struct LibraryView: View {
                         }
                     }
 
-                    if didLoadDirectoryPodcasts && directoryPodcasts.isEmpty {
+                    if let directoryLoadError {
+                        TunerEmptyState(
+                            status: "● DIRECTORY UNAVAILABLE",
+                            title: "Channel directory failed",
+                            message: directoryLoadError,
+                            statusColor: .offscriptFnRecord
+                        ) {
+                            Button {
+                                loadDirectoryPodcasts(force: true)
+                            } label: {
+                                TunerLabel(text: "↻ RETRY DIRECTORY", color: .offscriptSignalYellow, size: 10)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 8)
+                                    .frame(minHeight: 44)
+                                    .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.tunerPress)
+                            .accessibilityLabel("Retry loading channel directory")
+                            .accessibilityIdentifier("LibraryDirectoryRetry")
+                        }
+                    } else if didLoadDirectoryPodcasts && directoryPodcasts.isEmpty {
                         emptyState
                     } else {
                         if !inProgressEpisodes.isEmpty {
@@ -1118,17 +1140,12 @@ struct LibraryView: View {
     }
 
     private var emptyState: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            TunerLabel(text: "● NO CHANNELS TUNED", color: .offscriptFnInfo)
-            Text("Your library is empty")
-                .font(.system(size: 22, weight: .semibold))
-                .tracking(0)
-                .foregroundStyle(Color.offscriptPaperWhite)
-            Text("Use Search to bring in shows. OffScript keeps them fresh here once you subscribe.")
-                .font(.system(size: 13.5))
-                .foregroundStyle(Color.offscriptPaperWhite)
-                .lineSpacing(2)
-
+        TunerEmptyState(
+            status: "● NO CHANNELS TUNED",
+            title: "Your library is empty",
+            message: "Use Search to bring in shows. OffScript keeps them fresh here once you subscribe.",
+            statusColor: .offscriptFnInfo
+        ) {
             NavigationLink {
                 SearchView(hidesRootNavigationBar: false)
             } label: {
@@ -1140,7 +1157,7 @@ struct LibraryView: View {
                 .padding(.vertical, 12)
                 .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .padding(.top, 4)
         }
         .padding(.top, 16)
@@ -1218,7 +1235,7 @@ struct LibraryView: View {
                                 )
                                 .equatable()
                             }
-                            .buttonStyle(.plain)
+                            .buttonStyle(.tunerPress)
                             // Rich VoiceOver label folds the channel
                             // number, author, in-progress count,
                             // unplayed count, and sync-failure chip
@@ -1249,6 +1266,7 @@ struct LibraryView: View {
     private func loadDirectoryPodcasts(force: Bool = false) {
         guard force || !didLoadDirectoryPodcasts else { return }
         directoryPodcastLoadTask?.cancel()
+        directoryLoadError = nil
         let modelContainer = modelContext.container
         let interval = OffScriptPerformanceLog.begin(
             "library.directory.fetch",
@@ -1267,6 +1285,7 @@ struct LibraryView: View {
                 }
                 directoryPodcasts = podcasts
                 didLoadDirectoryPodcasts = true
+                directoryLoadError = nil
                 rebuildDirectorySnapshot()
                 OffScriptPerformanceLog.end(
                     interval,
@@ -1275,6 +1294,7 @@ struct LibraryView: View {
             } catch {
                 directoryPodcasts = []
                 didLoadDirectoryPodcasts = true
+                directoryLoadError = error.localizedDescription
                 cachedDirectorySnapshot = .empty
                 didBuildDirectorySnapshot = true
                 OffScriptPerformanceLog.end(
@@ -1745,7 +1765,7 @@ private struct LibraryTunerHeader: View {
                     .frame(minWidth: 44, minHeight: 44)
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Import podcasts")
 
                 // Sync + Tune match the IMPORT key's icon+label hairline-
@@ -1779,7 +1799,7 @@ private struct LibraryTunerHeader: View {
                     .frame(minWidth: 44, minHeight: 44)
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(isSyncing)
                 .accessibilityLabel(isSyncing ? "Syncing library" : "Sync library")
 
@@ -1804,7 +1824,7 @@ private struct LibraryTunerHeader: View {
                     .frame(minWidth: 44, minHeight: 44)
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Open settings")
             }
 
@@ -1939,7 +1959,7 @@ private struct LibraryDirectoryControls: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Clear library filter")
             }
         }
@@ -1997,7 +2017,7 @@ private struct LibraryDirectoryControls: View {
             .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .disabled(isDisabled)
         // Dimension-prefixed spoken label disambiguates chips that share
         // a value across rows (e.g. "ALL" could mean Scope or any future
@@ -2033,7 +2053,7 @@ private struct LibraryAlphabetRail: View {
                                 )
                             }
                             .id(target.key)
-                            .buttonStyle(.plain)
+                            .buttonStyle(.tunerPress)
                             .accessibilityElement(children: .ignore)
                             .accessibilityLabel(target.isNearestJump ? "Jump near \(target.key)" : "Jump to \(target.key)")
                             .accessibilityIdentifier("LibraryJumpLetter\(target.key)")
@@ -2105,13 +2125,11 @@ private struct LibraryDirectoryEmptyState: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            TunerLabel(text: "○ NO DIRECTORY MATCH", color: .offscriptSoftPaper)
-            Text(message)
-                .font(.system(size: 13))
-                .foregroundStyle(Color.offscriptPaperWhite.opacity(0.72))
-                .fixedSize(horizontal: false, vertical: true)
-
+        TunerEmptyState(
+            status: "○ NO DIRECTORY MATCH",
+            title: "No directory match",
+            message: message
+        ) {
             // Recovery key — without this, a user who narrowed scope
             // to NEEDS SYNC and got 0 results had to scroll up and
             // manually flip back to ALL. One-tap reset matches the
@@ -2125,12 +2143,11 @@ private struct LibraryDirectoryEmptyState: View {
                         .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Clear directory filter and search")
                 .accessibilityIdentifier("LibraryDirectoryClearFilter")
             }
         }
-        .padding(.vertical, 14)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -2200,7 +2217,7 @@ private struct TunerLibraryCard: View {
                     Spacer()
                 }
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             // Combine artwork + podcast eyebrow + title + reason into
             // one VoiceOver stop. Sibling Play / Queue keys keep their
             // own a11y elements. Mirrors PodcastEpisodeTunerRow (#265)
@@ -2220,7 +2237,7 @@ private struct TunerLibraryCard: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Play \(episode.title)")
 
                 Button {
@@ -2235,7 +2252,7 @@ private struct TunerLibraryCard: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(episode.isQueued)
                 .accessibilityLabel(episode.isQueued ? "\(episode.title) already queued" : "Add \(episode.title) to queue")
 
@@ -2426,9 +2443,12 @@ struct PodcastDetailView: View {
                 FilterRow(selection: $filter)
 
                 if let loadError {
-                    VStack(alignment: .leading, spacing: 8) {
-                        TunerLabel(text: "LOAD ERROR · \(loadError.uppercased())", color: .offscriptFnRecord)
-                            .fixedSize(horizontal: false, vertical: true)
+                    TunerEmptyState(
+                        status: "● LOAD ERROR",
+                        title: "Episodes unavailable",
+                        message: loadError,
+                        statusColor: .offscriptFnRecord
+                    ) {
                         Button {
                             loadEpisodes(resetLimit: true)
                         } label: {
@@ -2439,20 +2459,19 @@ struct PodcastDetailView: View {
                                 .frame(minHeight: 44)
                                 .contentShape(Rectangle())
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.tunerPress)
                         .accessibilityLabel("Retry loading episodes")
                     }
                 }
 
                 if episodes.isEmpty {
-                    VStack(alignment: .leading, spacing: 10) {
-                        TunerLabel(text: "● NO EPISODES MATCH FILTER", color: .offscriptSoftPaper)
-                        Text(episodeSearchQuery.isEmpty
-                             ? "Change the filter or sync this feed again later."
-                             : "No episodes match \"\(episodeSearchQuery)\".")
-                            .font(.system(size: 13.5))
-                            .foregroundStyle(Color.offscriptPaperWhite)
-
+                    TunerEmptyState(
+                        status: "● NO EPISODES MATCH FILTER",
+                        title: "No episodes in range",
+                        message: episodeSearchQuery.isEmpty
+                            ? "Change the filter or sync this feed again later."
+                            : "No episodes match \"\(episodeSearchQuery)\"."
+                    ) {
                         // Inline recovery key — tapping the filter back to
                         // ALL or clearing the search query is otherwise a
                         // two-step manual undo (find the filter row, find
@@ -2470,12 +2489,11 @@ struct PodcastDetailView: View {
                                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                                     .contentShape(Rectangle())
                             }
-                            .buttonStyle(.plain)
+                            .buttonStyle(.tunerPress)
                             .accessibilityLabel("Clear episode filter and search")
                             .accessibilityIdentifier("PodcastDetailClearFilter")
                         }
                     }
-                    .padding(.vertical, 12)
                     .overlay(
                         Rectangle().fill(Color.offscriptHairline).frame(height: 1),
                         alignment: .top
@@ -2511,7 +2529,7 @@ struct PodcastDetailView: View {
                                 .frame(minHeight: 44)
                                 .contentShape(Rectangle())
                             }
-                            .buttonStyle(.plain)
+                            .buttonStyle(.tunerPress)
                             .accessibilityLabel("Load 100 more episodes")
                             .overlay(
                                 Rectangle().fill(Color.offscriptHairline).frame(height: 1),
@@ -2682,7 +2700,7 @@ struct PodcastDetailView: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Clear episode search")
             }
         }
@@ -2768,7 +2786,7 @@ private struct PodcastDetailTunerHeader: View {
                             .padding(.vertical, 9)
                             .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Unsubscribe from \(podcast.title)")
                     .accessibilityIdentifier("PodcastDetailUnsubscribeButton")
                 }
@@ -2787,7 +2805,7 @@ private struct PodcastDetailTunerHeader: View {
                             .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Open \(podcast.title) website")
                 }
 
@@ -2810,7 +2828,7 @@ private struct PodcastDetailTunerHeader: View {
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(isRefreshing)
                 .accessibilityLabel("Refresh \(podcast.title) feed")
                 .accessibilityIdentifier("PodcastDetailRefreshFeed")
@@ -2872,7 +2890,7 @@ private struct PodcastDetailTunerHeader: View {
                         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Cancel unsubscribe from \(podcast.title)")
 
                 Button {
@@ -2886,7 +2904,7 @@ private struct PodcastDetailTunerHeader: View {
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Confirm unsubscribe from \(podcast.title)")
                 .accessibilityIdentifier("PodcastDetailConfirmUnsubscribeButton")
             }
@@ -2977,7 +2995,7 @@ private struct EpisodeDownloadStateChip: View {
                         .frame(minHeight: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Retry download for \(episode.title)")
                 .accessibilityHint("Double-tap to retry the download.")
             } else {
@@ -3090,7 +3108,7 @@ private struct PodcastEpisodeTunerRow: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             // Combine the NavigationLink into a single VoiceOver stop
             // so each row reads as one navigation, not three. Sibling
             // Play / Queue / More keys stay their own a11y elements.
@@ -3129,7 +3147,7 @@ private struct PodcastEpisodeTunerRow: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Play \(episode.title)")
 
                 Button {
@@ -3144,7 +3162,7 @@ private struct PodcastEpisodeTunerRow: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(episode.isQueued)
                 .accessibilityLabel(episode.isQueued ? "\(episode.title) already queued" : "Add \(episode.title) to queue")
 
@@ -3223,7 +3241,7 @@ private struct FilterRow: View {
                         .frame(minHeight: 44)
                         .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Filter episodes by \(filter.title)")
                     .accessibilityAddTraits(selection == filter ? .isSelected : [])
                 }
@@ -3270,7 +3288,7 @@ private struct LibrarySyncResultStrip: View {
                     .frame(minHeight: 44)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Dismiss sync result")
         }
         .padding(.vertical, 10)
@@ -3328,7 +3346,7 @@ private struct LibraryBatchImportStrip: View {
                                 .frame(minHeight: 44)
                                 .contentShape(Rectangle())
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.tunerPress)
                         .accessibilityLabel("Cancel import")
                         .accessibilityIdentifier("LibraryBatchImportCancel")
                     }
@@ -3378,7 +3396,7 @@ private struct LibraryBatchImportStrip: View {
                                 .frame(minHeight: 44)
                                 .contentShape(Rectangle())
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.tunerPress)
                         .accessibilityLabel("Retry \(failed) failed feed imports")
                         .accessibilityIdentifier("LibraryBatchImportRetryFailed")
                     }
@@ -3393,7 +3411,7 @@ private struct LibraryBatchImportStrip: View {
                             .frame(minHeight: 44)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Dismiss import status")
                 }
                 .padding(.vertical, 10)

--- a/OffScript/MiniPlayer.swift
+++ b/OffScript/MiniPlayer.swift
@@ -72,7 +72,7 @@ struct MiniPlayer: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Open player")
                     .accessibilityHint("Expand the now-playing screen for \(episode.title)")
 
@@ -93,7 +93,7 @@ struct MiniPlayer: View {
                                 .frame(width: 44, height: 44)
                                 .contentShape(Rectangle())
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.tunerPress)
                         .accessibilityLabel("Skip back 15 seconds")
                     }
 
@@ -110,7 +110,7 @@ struct MiniPlayer: View {
                             .frame(width: 44, height: 44)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel(player.isPlaying ? "Pause" : "Play")
 
                     // Skip-forward-30 — same vocabulary as skip-back. Used for
@@ -129,7 +129,7 @@ struct MiniPlayer: View {
                                 .frame(width: 44, height: 44)
                                 .contentShape(Rectangle())
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.tunerPress)
                         .accessibilityLabel("Skip ahead 30 seconds")
                     }
                 }

--- a/OffScript/Models.swift
+++ b/OffScript/Models.swift
@@ -351,9 +351,10 @@ final class EpisodeProfile {
     //     fingerprinting across episodes of the same show — substantial
     //     implementation cost, no current consumer.
     //
-    // Dormant fields are retained (rather than deleted) to avoid a SwiftData
-    // V2 -> V3 schema migration. When a producer lands, flip the comment and
-    // wire it in the existing enrich() pipeline.
+    // Dormant fields are retained (rather than deleted) because dropping
+    // persisted columns should be a deliberate SchemaVN migration. When a
+    // producer lands, flip the comment and wire it in the existing enrich()
+    // pipeline.
     var qualityScore: Double = 0.0
     var confidenceScore: Double = 0.0
     var estimatedListeningContext: String?

--- a/OffScript/OffScriptAppIntents.swift
+++ b/OffScript/OffScriptAppIntents.swift
@@ -18,7 +18,7 @@ enum OffScriptAppIntents {
     /// same on-disk store the main app uses so reads/writes are coherent.
     @MainActor
     static func makeContext() throws -> ModelContext {
-        let schema = Schema(versionedSchema: SchemaV2.self)
+        let schema = Schema(versionedSchema: SchemaV3.self)
         let directory = FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)
             .first!

--- a/OffScript/OnboardingFlowView.swift
+++ b/OffScript/OnboardingFlowView.swift
@@ -188,7 +188,7 @@ struct OnboardingFlowView: View {
                         .padding(.vertical, 16)
                         .background(Color.offscriptSignalYellow)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .staggeredEntrance(index: 9, delay: 0.10)
                 }
 

--- a/OffScript/PlaybackController.swift
+++ b/OffScript/PlaybackController.swift
@@ -65,7 +65,8 @@ final class PlaybackController: ObservableObject {
     private var modelContext: ModelContext?
     private var lastProgressSaveTime: TimeInterval = 0
     private var lastProgressSaveDate: Date = .distantPast
-    private var nowPlayingArtworkURL: URL?
+    private var nowPlayingArtworkKey: String?
+    private var nowPlayingArtwork: MPMediaItemArtwork?
     private var nowPlayingArtworkTask: Task<Void, Never>?
 
     private var interruptionObserver: NSObjectProtocol?
@@ -396,7 +397,8 @@ final class PlaybackController: ObservableObject {
         currentEpisode = episode
         lastProgressSaveTime = episode.playedPosition
         lastProgressSaveDate = .distantPast
-        nowPlayingArtworkURL = nil
+        nowPlayingArtworkKey = nil
+        nowPlayingArtwork = nil
         nowPlayingArtworkTask?.cancel()
         duration = episode.duration ?? 0
         // Resolve the rate this podcast should play at — per-podcast
@@ -560,6 +562,10 @@ final class PlaybackController: ObservableObject {
         isPlayerPresented = false
         playbackError = nil
         modelContext = nil
+        nowPlayingArtworkKey = nil
+        nowPlayingArtwork = nil
+        nowPlayingArtworkTask?.cancel()
+        nowPlayingArtworkTask = nil
         sleepTimerTask?.cancel()
         sleepTimerTask = nil
         sleepTimerEndDate = nil
@@ -836,6 +842,9 @@ final class PlaybackController: ObservableObject {
     }
 
     private func updateNowPlaying(episode: Episode) {
+        let artworkURL = episode.artworkURL ?? episode.podcast.artworkURL
+        let fallbackKey = Self.fallbackArtworkKey(for: episode)
+        let remoteKey = artworkURL.map { Self.artworkKey(for: $0) }
         var info: [String: Any] = [
             MPMediaItemPropertyTitle: episode.title,
             MPNowPlayingInfoPropertyElapsedPlaybackTime: currentTime,
@@ -845,26 +854,47 @@ final class PlaybackController: ObservableObject {
         ]
         info[MPMediaItemPropertyPodcastTitle] = episode.podcast.title
         info[MPMediaItemPropertyArtist] = episode.podcast.author ?? episode.podcast.title
+        if let artwork = nowPlayingArtwork(for: episode, remoteKey: remoteKey, fallbackKey: fallbackKey) {
+            info[MPMediaItemPropertyArtwork] = artwork
+        }
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
-        updateNowPlayingArtwork(for: episode)
+        updateNowPlayingArtwork(for: episode, artworkURL: artworkURL)
     }
 
-    /// Fetch the episode artwork off-main and hand it to the Now Playing
-    /// info center. Without this the lock screen and Control Center show
-    /// title + podcast but no image — looked broken next to Apple Podcasts.
-    /// Local file URLs read synchronously off the file system; remote URLs
-    /// hit the network on a utility-priority detached task.
-    private func updateNowPlayingArtwork(for episode: Episode) {
-        guard let url = episode.artworkURL ?? episode.podcast.artworkURL else { return }
-        guard nowPlayingArtworkURL != url else { return }
-        nowPlayingArtworkURL = url
+    private func nowPlayingArtwork(for episode: Episode, remoteKey: String?, fallbackKey: String) -> MPMediaItemArtwork? {
+        if let remoteKey, nowPlayingArtworkKey == remoteKey, let nowPlayingArtwork {
+            return nowPlayingArtwork
+        }
+        if nowPlayingArtworkKey == fallbackKey, let nowPlayingArtwork {
+            return nowPlayingArtwork
+        }
+        let artwork = Self.makeNowPlayingFallbackArtwork(
+            episodeTitle: episode.title,
+            podcastTitle: episode.podcast.title
+        )
+        nowPlayingArtworkKey = fallbackKey
+        nowPlayingArtwork = artwork
+        return artwork
+    }
+
+    /// Fetch the episode artwork off-main and hand it to the Now Playing info
+    /// center. The lock screen gets a Tuner-native fallback immediately, then
+    /// real feed artwork replaces it when the URL succeeds.
+    private func updateNowPlayingArtwork(for episode: Episode, artworkURL url: URL?) {
+        guard let url else {
+            nowPlayingArtworkTask?.cancel()
+            return
+        }
+        let key = Self.artworkKey(for: url)
+        guard nowPlayingArtworkKey != key else { return }
         nowPlayingArtworkTask?.cancel()
         let logger = self.logger
-        nowPlayingArtworkTask = Task.detached(priority: .utility) { [url] in
+        let episodeID = episode.id
+        nowPlayingArtworkTask = Task.detached(priority: .utility) { [url, key, episodeID] in
             // Failure here is non-fatal (the lock screen falls back to the
-            // app icon) but CLAUDE.md bans bare `try?` and we want a log
-            // line on persistent failures so an offline-only user with a
-            // missing artwork URL can be diagnosed from sysdiagnose.
+            // generated Tuner artwork) but CLAUDE.md bans bare `try?` and
+            // we want a log line on persistent failures so an offline-only
+            // user with a missing artwork URL can be diagnosed from sysdiagnose.
             // URLSession.shared.data(from:) doesn't treat HTTP 4xx/5xx as
             // a thrown error — explicitly check the status so a 404
             // artwork URL gets logged with its status code instead of
@@ -892,9 +922,104 @@ final class PlaybackController: ObservableObject {
             }
             let artwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
             await MainActor.run {
-                guard PlaybackController.shared.nowPlayingArtworkURL == url else { return }
+                let controller = PlaybackController.shared
+                guard controller.currentEpisode?.id == episodeID else { return }
+                controller.nowPlayingArtworkKey = key
+                controller.nowPlayingArtwork = artwork
                 MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPMediaItemPropertyArtwork] = artwork
             }
+        }
+    }
+
+    private static func artworkKey(for url: URL) -> String {
+        "url:\(url.absoluteString)"
+    }
+
+    private static func fallbackArtworkKey(for episode: Episode) -> String {
+        "fallback:\(episode.id.uuidString)"
+    }
+
+    static func makeNowPlayingFallbackArtwork(
+        episodeTitle: String,
+        podcastTitle: String,
+        size: CGSize = CGSize(width: 1024, height: 1024)
+    ) -> MPMediaItemArtwork {
+        let image = makeNowPlayingFallbackImage(
+            episodeTitle: episodeTitle,
+            podcastTitle: podcastTitle,
+            size: size
+        )
+        return MPMediaItemArtwork(boundsSize: image.size) { requestedSize in
+            guard requestedSize.width > 0, requestedSize.height > 0, requestedSize != image.size else {
+                return image
+            }
+            return makeNowPlayingFallbackImage(
+                episodeTitle: episodeTitle,
+                podcastTitle: podcastTitle,
+                size: requestedSize
+            )
+        }
+    }
+
+    private static func makeNowPlayingFallbackImage(
+        episodeTitle: String,
+        podcastTitle: String,
+        size: CGSize
+    ) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        return renderer.image { context in
+            let rect = CGRect(origin: .zero, size: size)
+            let cg = context.cgContext
+
+            UIColor.offscriptStudioBlack.setFill()
+            cg.fill(rect)
+
+            UIColor.offscriptHairline.setStroke()
+            cg.setLineWidth(max(2, size.width * 0.006))
+            cg.stroke(rect.insetBy(dx: size.width * 0.055, dy: size.height * 0.055))
+
+            let center = CGPoint(x: size.width / 2, y: size.height * 0.44)
+            let barWidth = max(8, size.width * 0.018)
+            let gap = max(10, size.width * 0.026)
+            let heights = [0.12, 0.22, 0.34, 0.48, 0.34, 0.22, 0.12].map { size.height * $0 }
+            UIColor.offscriptSignalYellow.setFill()
+            for (index, height) in heights.enumerated() {
+                let x = center.x + CGFloat(index - 3) * (barWidth + gap)
+                let barRect = CGRect(
+                    x: x - barWidth / 2,
+                    y: center.y - height / 2,
+                    width: barWidth,
+                    height: height
+                )
+                cg.fill(barRect)
+            }
+
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.alignment = .center
+            paragraph.lineBreakMode = .byTruncatingTail
+
+            let podcastAttributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.monospacedSystemFont(ofSize: max(22, size.width * 0.043), weight: .semibold),
+                .foregroundColor: UIColor.offscriptFnInfo,
+                .kern: 4,
+                .paragraphStyle: paragraph
+            ]
+            (podcastTitle.uppercased() as NSString).draw(
+                in: CGRect(x: size.width * 0.09, y: size.height * 0.73, width: size.width * 0.82, height: size.height * 0.06),
+                withAttributes: podcastAttributes
+            )
+
+            let titleAttributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: max(30, size.width * 0.058), weight: .bold),
+                .foregroundColor: UIColor.offscriptPaperWhite,
+                .paragraphStyle: paragraph
+            ]
+            (episodeTitle as NSString).draw(
+                in: CGRect(x: size.width * 0.09, y: size.height * 0.81, width: size.width * 0.82, height: size.height * 0.09),
+                withAttributes: titleAttributes
+            )
         }
     }
 

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -43,7 +43,7 @@ struct PlayerView: View {
 
     var body: some View {
         // No NavigationStack here — iOS 26 wraps any toolbar item in a glass
-        // capsule chrome that ignores .buttonStyle(.plain) and our color
+        // capsule chrome that ignores custom button styling and our color
         // tokens. Same problem the tab bar + settings cog had. PlayerView is
         // a full-screen modal cover; we render our own dismiss key inline at
         // the top so we keep full control over its rendering.
@@ -95,7 +95,7 @@ struct PlayerView: View {
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Close player")
             Spacer()
         }
@@ -235,7 +235,7 @@ struct PlayerView: View {
                 .frame(width: 56, height: 56)
                 .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityLabel(label)
     }
 
@@ -248,7 +248,7 @@ struct PlayerView: View {
                 .frame(width: 80, height: 56)
                 .background(Color.offscriptSignalYellow)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityLabel(label)
     }
 
@@ -275,7 +275,7 @@ struct PlayerView: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Dismiss playback error")
                 .accessibilityIdentifier("PlayerErrorDismiss")
             }
@@ -294,7 +294,7 @@ struct PlayerView: View {
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Retry playback of \(episode.title)")
             .accessibilityIdentifier("PlayerErrorRetry")
         }
@@ -394,7 +394,7 @@ struct PlayerView: View {
                 .frame(minHeight: 44)
                 .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Chapter \(idx + 1), \(chapter.title), at \(EpisodeDurationFormatter.spoken(chapter.startTime))")
             .accessibilityHint("Seeks to this chapter")
 
@@ -409,7 +409,7 @@ struct PlayerView: View {
                         .overlay(Rectangle().stroke(Color.offscriptFnInfo.opacity(0.7), lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Open chapter notes for \(chapter.title)")
                 .accessibilityHint("Opens the chapter's linked page in an in-app browser")
             }
@@ -520,7 +520,7 @@ struct PlayerView: View {
                             .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Play \(nextItem.episode.title) now")
                     .accessibilityIdentifier("PlayerUpNextPlay")
 
@@ -534,7 +534,7 @@ struct PlayerView: View {
                             .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Remove \(nextItem.episode.title) from up next")
                     .accessibilityIdentifier("PlayerUpNextDrop")
 
@@ -599,7 +599,7 @@ struct PlayerView: View {
                         tunerControlLabel(text: "SPEED  \(String(format: "%.2g", player.playbackRate))×",
                                           color: hasCustomRate(for: episode) ? .offscriptSignalYellow : .offscriptPaperWhite)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Playback speed")
                     .accessibilityHint("Pick a speed for this podcast")
 
@@ -616,7 +616,7 @@ struct PlayerView: View {
                             // label for opposite semantics was a real bug.
                             tunerControlLabel(text: "+ QUEUE", color: .offscriptPaperWhite)
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.tunerPress)
                         .accessibilityLabel("Add \(episode.title) to end of queue")
                     }
 
@@ -642,7 +642,7 @@ struct PlayerView: View {
                             color: .offscriptSignalYellow
                         )
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel(episode.isPlayed
                         ? "Mark \(episode.title) as unplayed"
                         : "Mark \(episode.title) as played")
@@ -658,7 +658,7 @@ struct PlayerView: View {
                                             ? .offscriptSignalYellow
                                             : .offscriptPaperWhite)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Sleep timer")
                     .accessibilityHint((player.sleepTimerEndDate != nil || player.isEndOfEpisodeSleepArmed)
                         ? "Active. Pick a new duration or cancel."
@@ -716,7 +716,7 @@ struct PlayerView: View {
                         .frame(maxWidth: .infinity, minHeight: 44)
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord.opacity(0.7), lineWidth: 1))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
             }
 
             ForEach([5, 15, 30, 45, 60], id: \.self) { minutes in
@@ -730,7 +730,7 @@ struct PlayerView: View {
                         .frame(maxWidth: .infinity, minHeight: 44)
                         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
             }
 
             // End-of-episode option — pauses when the current episode
@@ -747,7 +747,7 @@ struct PlayerView: View {
                     .frame(maxWidth: .infinity, minHeight: 44)
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow.opacity(0.7), lineWidth: 1))
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Sleep at end of current episode")
             .accessibilityIdentifier("PlayerSleepEndOfEpisode")
         }
@@ -756,15 +756,11 @@ struct PlayerView: View {
     // MARK: empty
 
     private var emptyState: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            TunerLabel(text: "● NO SIGNAL", color: .offscriptSoftPaper)
-            Text("Nothing playing")
-                .font(.system(size: 22, weight: .semibold))
-                .foregroundStyle(Color.offscriptPaperWhite)
-            Text("Start an episode from Home, Library, or Queue to fill this panel.")
-                .font(.system(size: 13.5))
-                .foregroundStyle(Color.offscriptPaperWhite)
-        }
+        TunerEmptyState(
+            status: "● NO SIGNAL",
+            title: "Nothing playing",
+            message: "Start an episode from Home, Library, or Queue to fill this panel."
+        )
         .padding(OffScriptTheme.pagePadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color.offscriptStudioBlack.ignoresSafeArea())
@@ -1070,7 +1066,7 @@ private struct PlayerSuggestionRow: View {
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Play \(scored.episode.title)")
 
             // Queue key — lets the user stack a What's Next suggestion
@@ -1091,7 +1087,7 @@ private struct PlayerSuggestionRow: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Add \(scored.episode.title) to queue")
                 .accessibilityIdentifier("PlayerWhatsNextQueue")
             }

--- a/OffScript/PodcastPickerView.swift
+++ b/OffScript/PodcastPickerView.swift
@@ -14,6 +14,7 @@ struct PodcastPickerView: View {
     @State private var selectedFeeds: Set<URL> = []
     @State private var livePodcasts: [Genre: [PodcastSearchResult]] = [:]
     @State private var allPodcasts: [PodcastSearchResult] = []
+    @State private var didLoadCatalog = false
     @State private var openedCollection: EditorialCollection?
 
     private var prioritizedGenres: [Genre] {
@@ -64,21 +65,31 @@ struct PodcastPickerView: View {
                     }
                     .padding(.horizontal, 20)
 
-                    EditorialCollectionsStrip(
-                        collections: nonEmptyCollections,
-                        onOpen: { openedCollection = $0 }
-                    )
+                    if didLoadCatalog && allPodcasts.isEmpty && nonEmptyCollections.isEmpty {
+                        TunerEmptyState(
+                            status: "● CHANNEL BANK EMPTY",
+                            title: "Starter channels unavailable",
+                            message: "The local starter catalog did not load. Go back, change taste bands, or continue setup later.",
+                            statusColor: .offscriptFnRecord
+                        )
+                        .padding(.horizontal, 20)
+                    } else {
+                        EditorialCollectionsStrip(
+                            collections: nonEmptyCollections,
+                            onOpen: { openedCollection = $0 }
+                        )
 
-                    VStack(alignment: .leading, spacing: 22) {
-                        ForEach(prioritizedGenres) { genre in
-                            let podcasts = mergedPodcasts(for: genre)
-                            if !podcasts.isEmpty {
-                                PodcastGenreRail(
-                                    genre: genre,
-                                    podcasts: podcasts,
-                                    selectedFeeds: $selectedFeeds,
-                                    isExplore: !selectedGenres.isEmpty && !selectedGenres.contains(genre)
-                                )
+                        VStack(alignment: .leading, spacing: 22) {
+                            ForEach(prioritizedGenres) { genre in
+                                let podcasts = mergedPodcasts(for: genre)
+                                if !podcasts.isEmpty {
+                                    PodcastGenreRail(
+                                        genre: genre,
+                                        podcasts: podcasts,
+                                        selectedFeeds: $selectedFeeds,
+                                        isExplore: !selectedGenres.isEmpty && !selectedGenres.contains(genre)
+                                    )
+                                }
                             }
                         }
                     }
@@ -115,13 +126,13 @@ struct PodcastPickerView: View {
                         )
                     )
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(!canContinue)
 
                 Button(action: onBack) {
                     TunerLabel(text: "← BACK")
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 14)
@@ -164,6 +175,7 @@ struct PodcastPickerView: View {
         // origin/main removed TopPodcastsService — fall back to the curated
         // catalog only. Reintroducing live top-by-genre is a follow-up.
         allPodcasts = CuratedPodcastCatalog.all
+        didLoadCatalog = true
     }
 }
 
@@ -258,7 +270,7 @@ private struct OnboardingPodcastCard: View {
             }
             .frame(width: 120, alignment: .leading)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .sensoryFeedback(.impact(flexibility: .soft), trigger: isSelected)
         .accessibilityLabel("\(podcast.title) by \(podcast.author)\(isSelected ? ", selected" : "")")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -367,7 +379,7 @@ private struct EditorialCollectionCard: View {
                 Rectangle().stroke(Color.offscriptHairline, lineWidth: 1)
             )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityAddTraits(.isButton)
@@ -461,7 +473,7 @@ private struct EditorialCollectionDetailView: View {
                 .padding(.vertical, 16)
                 .background(Color.offscriptSignalYellow)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .padding(.horizontal, 20)
             .padding(.bottom, 16)
         }
@@ -537,7 +549,7 @@ private struct EditorialDetailRow: View {
             }
             .padding(.vertical, 12)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .sensoryFeedback(.impact(flexibility: .soft), trigger: isSelected)
         .accessibilityLabel("\(entry.result.title) by \(entry.result.author)\(isSelected ? ", selected" : "")")
         .accessibilityAddTraits(isSelected ? .isSelected : [])

--- a/OffScript/QueueView.swift
+++ b/OffScript/QueueView.swift
@@ -81,19 +81,13 @@ struct QueueView: View {
 
     private var emptyState: some View {
         let hasSubscriptions = !subscribedPodcasts.isEmpty
-        return VStack(alignment: .leading, spacing: 12) {
-            TunerLabel(text: "● QUEUE EMPTY", color: .offscriptSoftPaper)
-            Text("Nothing queued yet")
-                .font(.system(size: 22, weight: .semibold))
-                .tracking(0)
-                .foregroundStyle(Color.offscriptPaperWhite)
-            Text(hasSubscriptions
-                 ? "This is your working set, not a backlog. Queue a few episodes from Library or Home that you actually plan to hear next."
-                 : "This is your working set, not a backlog. Find shows you trust first, then queue episodes you actually plan to hear next.")
-                .font(.system(size: 13.5))
-                .foregroundStyle(Color.offscriptPaperWhite)
-                .lineSpacing(2)
-
+        return TunerEmptyState(
+            status: "● QUEUE EMPTY",
+            title: "Nothing queued yet",
+            message: hasSubscriptions
+                ? "This is your working set, not a backlog. Queue a few episodes from Library or Home that you actually plan to hear next."
+                : "This is your working set, not a backlog. Find shows you trust first, then queue episodes you actually plan to hear next."
+        ) {
             // Context-aware escape hatch — a user with subscriptions
             // wants Library (find an episode to queue), not Search
             // (which they'd already used to get those subscriptions).
@@ -115,7 +109,7 @@ struct QueueView: View {
                     .padding(.vertical, 12)
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Browse library to find episodes to queue")
                 .accessibilityIdentifier("QueueEmptyBrowseLibrary")
                 .padding(.top, 4)
@@ -131,7 +125,7 @@ struct QueueView: View {
                     .padding(.vertical, 12)
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .padding(.top, 4)
             }
         }
@@ -154,7 +148,7 @@ struct QueueView: View {
                             .frame(minHeight: 44)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .disabled(isConfirmingClearAll)
                     .accessibilityLabel("Clear all \(orderedItems.count) queued episodes")
                     .accessibilityHint("Asks for confirmation before clearing the queue")
@@ -227,7 +221,7 @@ struct QueueView: View {
                         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Cancel clear all queued episodes")
                 .accessibilityIdentifier("QueueClearAllCancel")
 
@@ -246,7 +240,7 @@ struct QueueView: View {
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Confirm clear all \(orderedItems.count) queued episodes")
                 .accessibilityIdentifier("QueueClearAllConfirm")
             }
@@ -384,7 +378,7 @@ private struct QueueLeadStrip: View {
                     .overlay(Rectangle().stroke(isCurrentlyPlaying ? Color.offscriptFnMode : Color.offscriptSignalYellow, lineWidth: 1))
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(isCurrentlyPlaying)
                 .accessibilityLabel(
                     isCurrentlyPlaying
@@ -412,7 +406,7 @@ private struct QueueLeadStrip: View {
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Remove \(item.episode.title) from queue")
 
                 Spacer()
@@ -494,7 +488,7 @@ private struct QueueItemRow: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel({
                 var parts: [String] = [
                     "Open \(item.episode.title) from \(item.episode.podcast.title)"
@@ -517,7 +511,7 @@ private struct QueueItemRow: View {
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Play \(item.episode.title)")
 
             // Enabled reorder chevrons render in signal-yellow so they
@@ -541,7 +535,7 @@ private struct QueueItemRow: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Remove \(item.episode.title) from queue")
             }
         }
@@ -566,6 +560,6 @@ private struct QueueItemRow: View {
                 .contentShape(Rectangle())
         }
         .disabled(disabled)
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
     }
 }

--- a/OffScript/SchemaMigration.swift
+++ b/OffScript/SchemaMigration.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftData
 
 // MARK: - Schema V1 (baseline)
@@ -25,7 +26,9 @@ enum SchemaV1: VersionedSchema {
 // MARK: - Schema V2
 // Adds EpisodeTranscriptCache (new table — additive, lightweight migration).
 // Existing V1 stores gain the new table automatically; no data transformation
-// is needed, so a .lightweight stage is sufficient.
+// is needed, so a .lightweight stage is sufficient. Keep the nested
+// EpisodeTranscriptCache model frozen to the 2.4.x store shape; later releases
+// add fields in SchemaV3.
 
 enum SchemaV2: VersionedSchema {
     static var versionIdentifier: Schema.Version = Schema.Version(2, 0, 0)
@@ -40,21 +43,42 @@ enum SchemaV2: VersionedSchema {
             EpisodeProfile.self,
             UserTasteProfile.self,
             TelemetryEvent.self,
-            EpisodeTranscriptCache.self,
+            SchemaV2.EpisodeTranscriptCache.self,
         ]
     }
 }
 
+extension SchemaV2 {
+    @Model
+    final class EpisodeTranscriptCache {
+        @Attribute(.unique) var episodeID: UUID = UUID()
+        var text: String = ""
+        var generatedAt: Date = Date()
+        var source: String = "speech"
+        var coverageSeconds: TimeInterval?
+
+        init(
+            episodeID: UUID,
+            text: String,
+            generatedAt: Date = .now,
+            source: String = "speech",
+            coverageSeconds: TimeInterval? = nil
+        ) {
+            self.episodeID = episodeID
+            self.text = text
+            self.generatedAt = generatedAt
+            self.source = source
+            self.coverageSeconds = coverageSeconds
+        }
+    }
+}
+
 // MARK: - Schema V3
-// 2.5.0 added two scoring fields to EpisodeProfile (`confidenceScore`,
-// `freshnessBucket`) — see Models.swift around line 358. Both have default
-// or nullable types so the migration is additive + lightweight. The
-// missing-V3 was the cause of the 2.5.0 ship bug where existing-user
-// libraries quarantined: SwiftData saw a fingerprint mismatch against
-// the V2-shaped on-disk store, failed migration, and the three-tier
-// recovery in OffScriptApp.swift fell through to the rename-and-fresh
-// quarantine path. 2.5.1 ships V3 + the migration stage so existing
-// libraries upgrade in place.
+// 2.5.0 expanded EpisodeTranscriptCache for published/timed transcripts
+// (`language`, JSON cue storage) and EpisodeChapter's Codable payload shape.
+// EpisodeChapter is persisted inside Episode.chaptersStorage as JSON, so the
+// store-level schema change here is the transcript-cache table. V3 freezes that
+// new shape and lets 2.4.x stores migrate in place instead of being quarantined.
 
 enum SchemaV3: VersionedSchema {
     static var versionIdentifier: Schema.Version = Schema.Version(3, 0, 0)
@@ -93,10 +117,9 @@ enum OffScriptMigrationPlan: SchemaMigrationPlan {
         toVersion: SchemaV2.self
     )
 
-    /// Lightweight migration: adds EpisodeProfile.confidenceScore (Double
-    /// with default 0.0) + EpisodeProfile.freshnessBucket (optional String).
-    /// Pure additive columns; SwiftData fills defaults / nulls for
-    /// existing rows automatically.
+    /// Lightweight migration: adds EpisodeTranscriptCache.language (optional)
+    /// + cue storage (String with empty default). Pure additive columns;
+    /// SwiftData fills defaults / nulls for existing rows automatically.
     static let migrateV2toV3 = MigrationStage.lightweight(
         fromVersion: SchemaV2.self,
         toVersion: SchemaV3.self

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -147,7 +147,7 @@ struct SearchView: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Clear search")
             }
         }
@@ -182,17 +182,11 @@ struct SearchView: View {
     }
 
     private var emptyState: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Rectangle().fill(Color.offscriptHairline).frame(height: 1)
-            TunerLabel(text: "● NO MATCHES", color: .offscriptSoftPaper)
-            Text("No matches")
-                .font(.system(size: 22, weight: .semibold))
-                .foregroundStyle(Color.offscriptPaperWhite)
-            Text("Try a different show name, host, or topic. Exact titles work best.")
-                .font(.system(size: 13.5))
-                .foregroundStyle(Color.offscriptPaperWhite)
-                .lineSpacing(2)
-
+        TunerEmptyState(
+            status: "● NO MATCHES",
+            title: "No shows found",
+            message: "Try a different show name, host, or topic. Exact titles work best."
+        ) {
             // One-tap reset to the starter-topics + recent-searches
             // landing state. Mirrors the × CLEAR FILTER recovery key on
             // PodcastDetail (#208) and Library directory (#220).
@@ -206,7 +200,7 @@ struct SearchView: View {
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Clear search query")
             .accessibilityIdentifier("SearchEmptyClearSearch")
         }
@@ -416,7 +410,7 @@ private struct StarterTopicsSection: View {
                             .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Search for \(topic)")
                 }
             }
@@ -445,7 +439,7 @@ private struct RecentSearchesSection: View {
                         .frame(minHeight: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityIdentifier("RecentSearchesClear")
                 .accessibilityLabel("Clear recent searches")
                 .disabled(showClearConfirm)
@@ -472,7 +466,7 @@ private struct RecentSearchesSection: View {
                                 .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                                 .contentShape(Rectangle())
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.tunerPress)
                         .accessibilityIdentifier("RecentSearchesClearCancel")
                         .accessibilityLabel("Cancel clear recent searches")
 
@@ -487,7 +481,7 @@ private struct RecentSearchesSection: View {
                                 .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                                 .contentShape(Rectangle())
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.tunerPress)
                         .accessibilityIdentifier("RecentSearchesClearConfirm")
                         .accessibilityLabel("Confirm clear recent searches")
                     }
@@ -518,7 +512,7 @@ private struct RecentSearchesSection: View {
                         }
                         .padding(.vertical, 10)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Search again for \(item)")
                     if idx < items.count - 1 {
                         Rectangle().fill(Color.offscriptHairline).frame(height: 1)
@@ -534,12 +528,12 @@ private struct SearchErrorStrip: View {
     var onRetry: (() -> Void)? = nil
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            TunerLabel(text: "● SEARCH ERROR", color: .offscriptFnRecord)
-            Text(message)
-                .font(.system(size: 12.5))
-                .foregroundStyle(Color.offscriptPaperWhite)
-
+        TunerEmptyState(
+            status: "● SEARCH ERROR",
+            title: "Search unavailable",
+            message: message,
+            statusColor: .offscriptFnRecord
+        ) {
             // Retry key — surfaces a way out for transient network errors
             // without requiring the user to mutate the query.
             if let onRetry {
@@ -552,16 +546,11 @@ private struct SearchErrorStrip: View {
                         .frame(minHeight: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Retry search")
             }
         }
-        .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .overlay(
-            Rectangle().fill(Color.offscriptFnRecord).frame(height: 1),
-            alignment: .top
-        )
     }
 }
 
@@ -753,7 +742,7 @@ private struct SearchResultRow: View {
                     .frame(minHeight: 44)
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(isImporting || isAdded)
                 .accessibilityLabel(
                     isAdded
@@ -780,7 +769,7 @@ private struct SearchResultRow: View {
                             .frame(minHeight: 44)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("Open \(result.title) website")
                 }
                 Spacer()

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -139,7 +139,7 @@ struct SettingsView: View {
                         .frame(minHeight: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Close settings")
             }
             Rectangle().fill(Color.offscriptHairline).frame(height: 1)
@@ -265,7 +265,7 @@ struct SettingsView: View {
                     .padding(.vertical, 8)
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel("Default playback rate")
                 .accessibilityValue(String(format: "%.2g×", currentDefaultRate))
@@ -324,7 +324,7 @@ struct SettingsView: View {
                     .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .disabled(isConfirmingResetRates)
                 .accessibilityLabel("Reset per-podcast playback rates")
                 .accessibilityHint("Asks for confirmation before clearing every show's custom rate")
@@ -361,7 +361,7 @@ struct SettingsView: View {
                         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Cancel reset per-podcast playback rates")
                 .accessibilityIdentifier("SettingsResetRatesCancel")
 
@@ -376,7 +376,7 @@ struct SettingsView: View {
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Confirm reset per-podcast playback rates")
                 .accessibilityIdentifier("SettingsResetRatesConfirm")
             }
@@ -429,7 +429,7 @@ struct SettingsView: View {
             .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityLabel(title)
         .accessibilityValue(isOn.wrappedValue ? "On" : "Off")
         .accessibilityAddTraits(isOn.wrappedValue ? [.isButton, .isSelected] : .isButton)
@@ -478,7 +478,7 @@ struct SettingsView: View {
             .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityLabel("Download only on Wi-Fi. Currently \(downloadsWiFiOnly ? "on" : "off").")
         .accessibilityValue(downloadsWiFiOnly ? "On" : "Off")
         .accessibilityHint("Double-tap to toggle. When on, downloads pause on cellular.")
@@ -510,7 +510,7 @@ struct SettingsView: View {
                 .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                 .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Open debug inspector")
             .accessibilityHint("Shows telemetry, sync history, download state, and runtime metadata.")
             .accessibilityIdentifier("SettingsOpenDebugInspector")
@@ -559,7 +559,7 @@ struct SettingsView: View {
                         .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Rebuild signal profile from current listening history")
 
                 if let signalUpdatedAt {
@@ -637,7 +637,7 @@ struct SettingsView: View {
                         .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
                         .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .accessibilityLabel("\(mode.label) recommendation mode")
                     .accessibilityAddTraits(isSelected ? .isSelected : [])
                 }
@@ -689,7 +689,7 @@ struct SettingsView: View {
                             .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.tunerPress)
                     .padding(.top, 4)
                     .accessibilityLabel(showSignOutConfirmation ? "Hide sign out confirmation" : "Sign out of OffScript")
                     .accessibilityHint(showSignOutConfirmation ? "" : "Stops iCloud sync on next launch. Local data remains on this device.")
@@ -881,7 +881,7 @@ struct SettingsView: View {
                         .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Cancel sign out")
 
                 Button {
@@ -895,7 +895,7 @@ struct SettingsView: View {
                         .overlay(Rectangle().stroke(Color.offscriptFnRecord, lineWidth: 1))
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Confirm sign out")
             }
         }

--- a/OffScript/SpeechTranscriptionPanel.swift
+++ b/OffScript/SpeechTranscriptionPanel.swift
@@ -230,7 +230,7 @@ struct SpeechTranscriptionPanel: View {
             .overlay(Rectangle().stroke(color.opacity(disabled ? 0.4 : 1.0), lineWidth: 1))
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .disabled(disabled)
         .padding(.top, 4)
     }
@@ -335,7 +335,7 @@ struct SpeechTranscriptionPanel: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.tunerPress)
                 .accessibilityLabel("Clear search")
             }
 
@@ -362,7 +362,7 @@ struct SpeechTranscriptionPanel: View {
                     .padding(.vertical, 4)
                     .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.tunerPress)
             .accessibilityLabel("Follow playhead. Currently off")
             .accessibilityHint("Re-engages auto-scroll to the current cue.")
         }
@@ -479,7 +479,7 @@ struct SpeechTranscriptionPanel: View {
             }
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.tunerPress)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel(idx: idx, cue: cue, isCurrent: isCurrent))
         .accessibilityHint("Double-tap to seek to this line.")

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -1,9 +1,60 @@
 import AppIntents
 import AVFoundation
 import Foundation
+import MediaPlayer
 import SwiftData
 import Testing
 @testable import OffScript
+
+struct SchemaMigrationTests {
+    @Test
+    @MainActor
+    func v2TranscriptCacheStoreMigratesToV3() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OffScriptMigrationTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let storeURL = directory.appendingPathComponent("OffScript.store")
+        let episodeID = UUID()
+        let generatedAt = Date(timeIntervalSince1970: 1_779_305_200)
+
+        do {
+            let schema = Schema(versionedSchema: SchemaV2.self)
+            let config = ModelConfiguration(schema: schema, url: storeURL, cloudKitDatabase: .none)
+            let container = try ModelContainer(for: schema, configurations: [config])
+            let context = ModelContext(container)
+            context.insert(SchemaV2.EpisodeTranscriptCache(
+                episodeID: episodeID,
+                text: "legacy speech transcript",
+                generatedAt: generatedAt,
+                source: "speech",
+                coverageSeconds: 42
+            ))
+            try context.save()
+        }
+
+        let schema = Schema(versionedSchema: SchemaV3.self)
+        let config = ModelConfiguration(schema: schema, url: storeURL, cloudKitDatabase: .none)
+        let container = try ModelContainer(
+            for: schema,
+            migrationPlan: OffScriptMigrationPlan.self,
+            configurations: [config]
+        )
+        let context = ModelContext(container)
+        let caches = try context.fetch(FetchDescriptor<EpisodeTranscriptCache>())
+
+        #expect(caches.count == 1)
+        let cache = try #require(caches.first)
+        #expect(cache.episodeID == episodeID)
+        #expect(cache.text == "legacy speech transcript")
+        #expect(cache.generatedAt == generatedAt)
+        #expect(cache.source == "speech")
+        #expect(cache.coverageSeconds == 42)
+        #expect(cache.language == nil)
+        #expect(cache.cues.isEmpty)
+    }
+}
 
 struct OffScriptTests {
     @Test
@@ -4985,6 +5036,88 @@ struct CuratedDiscoveryTests {
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
         #expect(loader.state(for: Self.sampleResult, rank: 1) == .failed)
+    }
+}
+
+// MARK: - Now Playing artwork
+
+@Suite("NowPlayingArtwork")
+struct NowPlayingArtworkTests {
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            Podcast.self,
+            Episode.self,
+            EpisodeProfile.self,
+            PlaybackEvent.self,
+            PreferenceSignal.self,
+            QueueItem.self,
+            UserTasteProfile.self,
+            TelemetryEvent.self
+        ])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    @MainActor
+    private func makeEpisode(title: String, in context: ModelContext) -> Episode {
+        let podcast = Podcast(title: "No Artwork Show", feedURL: URL(string: "https://example.com/no-art.xml")!)
+        let episode = Episode(
+            title: title,
+            pubDate: .now,
+            audioURL: URL(string: "https://example.com/no-art.mp3")!,
+            podcast: podcast
+        )
+        context.insert(podcast)
+        context.insert(episode)
+        return episode
+    }
+
+    @Test
+    @MainActor
+    func fallbackNowPlayingArtworkRendersRequestedSizes() throws {
+        let artwork = PlaybackController.makeNowPlayingFallbackArtwork(
+            episodeTitle: "Signal Overload in the Studio",
+            podcastTitle: "OffScript Lab",
+            size: CGSize(width: 512, height: 512)
+        )
+
+        let full = try #require(artwork.image(at: CGSize(width: 512, height: 512)))
+        let small = try #require(artwork.image(at: CGSize(width: 128, height: 128)))
+
+        #expect(full.size == CGSize(width: 512, height: 512))
+        #expect(small.size == CGSize(width: 128, height: 128))
+    }
+
+    @Test
+    @MainActor
+    func debugPrimePlaybackPublishesFallbackArtworkWhenFeedArtworkIsMissing() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let episode = makeEpisode(title: "No Artwork Episode", in: context)
+        episode.artworkURL = nil
+        episode.podcast.artworkURL = nil
+
+        DebugTeardown.resetAllSingletons()
+        defer {
+            DebugTeardown.resetAllSingletons()
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        }
+
+        let controller = PlaybackController.shared
+        controller.configure(context: context)
+        controller.debugPrimePlayback(
+            episode: episode,
+            duration: 1800,
+            currentTime: 120,
+            isPlaying: false,
+            presentPlayer: true
+        )
+
+        let info = try #require(MPNowPlayingInfoCenter.default().nowPlayingInfo)
+        let artwork = try #require(info[MPMediaItemPropertyArtwork] as? MPMediaItemArtwork)
+        let rendered = try #require(artwork.image(at: CGSize(width: 256, height: 256)))
+
+        #expect(rendered.size == CGSize(width: 256, height: 256))
     }
 }
 

--- a/build/TestFlight/notes/testflight-notes.txt
+++ b/build/TestFlight/notes/testflight-notes.txt
@@ -1,8 +1,14 @@
 2.5.1 — CRITICAL FIX: SwiftData schema migration
 
-If you installed 2.5.0 (build 2026052003) and your library appeared empty after upgrade, this fixes it going forward. Apologies for the data-loss scare — root-cause was a missed schema-version bump for the new EpisodeProfile fields shipped in 2.5.0. SwiftData saw the schema fingerprint mismatch, failed the lightweight migration, and the app's three-tier recovery quarantined the old store rather than crash. Your data is NOT deleted — it's renamed to `OffScript-corrupted-<timestamp>/` inside the app's Application Support container. Restoring from a device backup will bring it back; opening the app on 2.5.1 will continue forward cleanly from whatever state you're at now.
+If you installed 2.5.0 (build 2026052003) and your library appeared empty after upgrade, this fixes it going forward. Apologies for the data-loss scare — root-cause was a missed schema-version bump for the expanded published-transcript cache shipped in 2.5.0. SwiftData saw the schema fingerprint mismatch, failed the lightweight migration, and the app's three-tier recovery quarantined the old store rather than crash. Your data is NOT deleted — it's renamed to `OffScript-corrupted-<timestamp>/` inside the app's Application Support container. Restoring from a device backup will bring it back; opening the app on 2.5.1 will continue forward cleanly from whatever state you're at now.
 
-— Fix: SchemaV3 + migrateV2toV3 lightweight migration stage.
+— Fix: frozen 2.4.x SchemaV2 transcript-cache shape + SchemaV3 + migrateV2toV3 lightweight migration stage.
+— Fix: Siri/Shortcuts App Intents now open the same V3 SwiftData store as the main app.
 — Users who skipped 2.5.0 and go straight from 2.4.x to 2.5.1 get the full V1→V2→V3 migration path with no data loss.
+
+Tuner UI polish in this build:
+— Shared artwork fallback now appears consistently across app surfaces when feed art is missing or still loading.
+— Shared empty states keep Library, Queue, Search, and related no-content screens aligned with the Tuner spec-sheet treatment.
+— App-wide Tuner buttons now have consistent press feedback while staying in the flat OLED / hairline control language.
 
 All other 2.5.0 features are unchanged — see the 2.5.0 release notes for the podcast-namespace chapters / published transcripts / CarPlay scaffolding / recommendation-credibility wiring.


### PR DESCRIPTION
## Summary
- Fixes lock-screen / Control Center cover art by publishing generated Tuner fallback artwork when feed art is missing or still loading.
- Adds regression coverage for fallback Now Playing artwork and the V2 to V3 SwiftData migration path.
- Completes the broad Tuner surface pass with shared artwork fallback, shared empty states, and app-wide flat Tuner press feedback.
- Updates changelog and TestFlight notes for the migration/artwork/UI behavior.

Closes #272.
Supersedes draft PR #273, which only carried the older three-line partial lock-screen fix.

## Verification
- `git diff --check`
- `xcodebuild -project OffScript.xcodeproj -scheme OffScript -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:OffScriptTests/SchemaMigrationTests`
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:OffScriptTests/NowPlayingArtworkTests`
- Xcode Issue Navigator: warning-or-higher clean
- Simulator live inspection with debug sample data: Home, Library, Queue, Search

## Visual Proof
- `/tmp/offscript-library-live-20260520.png`
- `/tmp/offscript-queue-live-20260520.png`
- `/tmp/offscript-search-live-20260520.png`

## Known Follow-ups
- Player What's Next should get explicit empty/error recommendation states under #108.
- Episode briefing loading/failure can be standardized in a smaller UX pass.
- Broad test suite still has the pre-existing SwiftData singleton teardown risk in PlaybackEventEmissionTests; focused tests above are green.
