### PR TITLE
Fix normalized feed duplicates in Search subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ### Fixed
 - Lock screen / Control Center now receive generated Tuner fallback artwork immediately when an episode has no feed artwork or while remote artwork is loading, so Now Playing metadata no longer publishes without cover art.
+- Search and onboarding subscription staging now detect existing RSS feeds by normalized URL, so `http`/`https`, `feed://`, case, and trailing-slash variants do not create duplicate library rows.
 - Shared artwork fallback now renders consistently across app surfaces, keeping missing/loading cover art inside the Tuner visual language.
 - Shared empty-state treatment now keeps no-content Library, Queue, Search, and related surfaces aligned on sharp hairlines, mono status copy, and clear recovery actions.
 - App-wide Tuner buttons now provide consistent press feedback so action keys feel responsive without falling back to native Liquid Glass chrome.

--- a/OffScript/PodcastServices.swift
+++ b/OffScript/PodcastServices.swift
@@ -382,6 +382,7 @@ final class FeedSyncService {
         )
         podcastDescriptor.fetchLimit = 1
         let existing = try context.fetch(podcastDescriptor).first
+            ?? findExistingPodcast(matching: result.feedURL, in: context)
 
         let podcast: Podcast
         if let existing {
@@ -389,6 +390,7 @@ final class FeedSyncService {
             podcast.isSubscribed = true
             podcast.title = result.title
             podcast.author = result.author
+            podcast.feedURL = result.feedURL
             podcast.artworkURL = result.artworkURL
             podcast.websiteURL = result.websiteURL
             podcast.summary = result.summary
@@ -410,6 +412,51 @@ final class FeedSyncService {
         }
 
         return podcast
+    }
+
+    @MainActor
+    private func findExistingPodcast(matching feedURL: URL, in context: ModelContext) throws -> Podcast? {
+        let variants = Self.feedURLLookupVariants(for: feedURL)
+        var descriptor = FetchDescriptor<Podcast>(
+            predicate: #Predicate<Podcast> { variants.contains($0.feedURL) }
+        )
+        descriptor.fetchLimit = variants.count
+        let candidates = try context.fetch(descriptor)
+        let normalizedKey = feedURL.normalizedFeedKey
+        return candidates.first { $0.feedURL.normalizedFeedKey == normalizedKey }
+    }
+
+    private static func feedURLLookupVariants(for feedURL: URL) -> Set<URL> {
+        guard var components = URLComponents(url: feedURL, resolvingAgainstBaseURL: false) else {
+            return [feedURL]
+        }
+
+        let normalized = URL(string: feedURL.normalizedFeedKey) ?? feedURL
+        let normalizedPath = URLComponents(url: normalized, resolvingAgainstBaseURL: false)?.path ?? components.path
+        let trimmedPath = normalizedPath.hasSuffix("/") && normalizedPath != "/"
+            ? String(normalizedPath.dropLast())
+            : normalizedPath
+        let slashPath = trimmedPath.isEmpty || trimmedPath.hasSuffix("/")
+            ? trimmedPath
+            : "\(trimmedPath)/"
+        let schemes = Set([components.scheme, "https", "http", "feed"].compactMap(\.self))
+        let hosts = Set([components.host, components.host?.lowercased()].compactMap(\.self))
+        let paths = Set([components.path, normalizedPath, trimmedPath, slashPath])
+
+        var variants: Set<URL> = [feedURL, normalized]
+        for scheme in schemes {
+            for host in hosts {
+                for path in paths {
+                    components.scheme = scheme
+                    components.host = host
+                    components.path = path
+                    if let url = components.url {
+                        variants.insert(url)
+                    }
+                }
+            }
+        }
+        return variants
     }
 
     @MainActor
@@ -448,22 +495,23 @@ final class FeedSyncService {
     func stagePodcastSubscriptions(from results: [PodcastSearchResult], into context: ModelContext) throws -> [Podcast] {
         guard !results.isEmpty else { return [] }
 
-        let feedURLs = Set(results.map(\.feedURL))
+        let feedURLs = Set(results.flatMap { Self.feedURLLookupVariants(for: $0.feedURL) })
         let existingPodcasts = try context.fetch(FetchDescriptor<Podcast>(
             predicate: #Predicate<Podcast> {
                 feedURLs.contains($0.feedURL)
             }
         ))
         var podcastByFeedKey = Dictionary(
-            existingPodcasts.map { ($0.feedURL, $0) },
+            existingPodcasts.map { ($0.feedURL.normalizedFeedKey, $0) },
             uniquingKeysWith: { first, _ in first }
         )
         let now = Date()
         var stagedPodcasts: [Podcast] = []
 
         for result in results {
+            let feedKey = result.feedURL.normalizedFeedKey
             let podcast: Podcast
-            if let existing = podcastByFeedKey[result.feedURL] {
+            if let existing = podcastByFeedKey[feedKey] {
                 podcast = existing
                 podcast.isSubscribed = true
                 podcast.title = result.title
@@ -487,7 +535,7 @@ final class FeedSyncService {
                 )
                 podcast.subscribedAt = now
                 context.insert(podcast)
-                podcastByFeedKey[result.feedURL] = podcast
+                podcastByFeedKey[feedKey] = podcast
             }
 
             podcast.syncStatus = "idle"

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -40,7 +40,7 @@ struct SearchView: View {
     }
 
     private var subscribedFeedURLs: Set<String> {
-        Set(podcasts.filter(\.isSubscribed).map { $0.feedURL.absoluteString })
+        Set(podcasts.filter(\.isSubscribed).map { $0.feedURL.normalizedFeedKey })
     }
 
     var body: some View {
@@ -218,12 +218,13 @@ struct SearchView: View {
 
             LazyVStack(spacing: 0) {
                 ForEach(Array(results.enumerated()), id: \.element.id) { index, result in
+                    let resultKey = result.feedURL.normalizedFeedKey
                     SearchResultRow(
                         result: result,
                         rank: index + 1,
-                        isAdded: subscribedFeedURLs.contains(result.feedURL.absoluteString),
-                        isImporting: importingIDs.contains(result.id),
-                        importError: importErrors[result.id],
+                        isAdded: subscribedFeedURLs.contains(resultKey),
+                        isImporting: importingIDs.contains(resultKey),
+                        importError: importErrors[resultKey],
                         // Pull preview state at render-time so the
                         // `@Observable` loader can update individual rows
                         // as fetches complete without re-running the
@@ -286,12 +287,13 @@ struct SearchView: View {
 
     @MainActor
     private func add(_ result: PodcastSearchResult) async {
-        importingIDs.insert(result.id)
-        defer { importingIDs.remove(result.id) }
+        let resultKey = result.feedURL.normalizedFeedKey
+        importingIDs.insert(resultKey)
+        defer { importingIDs.remove(resultKey) }
         // Clear any prior failure for this row before a retry so the
         // button doesn't render the stale `✗ FAILED · RETRY` state
         // while the new attempt is in flight.
-        importErrors[result.id] = nil
+        importErrors[resultKey] = nil
 
         // Stage the subscription synchronously so the row flips to
         // `● IN LIBRARY` immediately, then await the hydration sync so
@@ -308,7 +310,7 @@ struct SearchView: View {
             storeRecentSearch(result.title)
         } catch {
             searchLogger.error("Stage failed for ‘\(result.title, privacy: .public)’: \(error.localizedDescription, privacy: .public)")
-            importErrors[result.id] = error.localizedDescription
+            importErrors[resultKey] = error.localizedDescription
             return
         }
 
@@ -323,7 +325,7 @@ struct SearchView: View {
             // Row-scoped error state — the row button now communicates the
             // failure and offers a retry without the user re-typing the
             // query or hunting for which row failed in a long results list.
-            importErrors[result.id] = error.localizedDescription
+            importErrors[resultKey] = error.localizedDescription
         }
     }
 

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -2973,6 +2973,45 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func feedSyncStagesSearchSubscriptionReusesNormalizedExistingFeed() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let existing = Podcast(
+            title: "Old Search Result",
+            author: "Old Author",
+            feedURL: URL(string: "http://example.com/search-feed/")!,
+            isSubscribed: false
+        )
+        context.insert(existing)
+        try context.save()
+
+        let result = PodcastSearchResult(
+            title: "Normalized Search Result",
+            author: "Fresh Author",
+            feedURL: URL(string: "https://EXAMPLE.com/search-feed")!,
+            artworkURL: URL(string: "https://example.com/search-feed.jpg")!,
+            websiteURL: URL(string: "https://example.com/search")!,
+            summary: "Same feed, different URL spelling."
+        )
+
+        let podcast = try FeedSyncService().stagePodcastSubscription(from: result, into: context)
+
+        let podcasts = try context.fetch(FetchDescriptor<Podcast>())
+        #expect(podcasts.count == 1)
+        #expect(podcast.id == existing.id)
+        #expect(podcast.isSubscribed)
+        #expect(podcast.title == "Normalized Search Result")
+        #expect(podcast.author == "Fresh Author")
+        #expect(podcast.feedURL == result.feedURL)
+        #expect(podcast.artworkURL == result.artworkURL)
+        #expect(podcast.websiteURL == result.websiteURL)
+        #expect(podcast.summary == result.summary)
+        #expect(podcast.syncStatus == "idle")
+        #expect(podcast.syncErrorMessage == nil)
+    }
+
+    @Test
+    @MainActor
     func feedSyncSubscribeThenHydrateCanReturnBeforeNetworkWork() throws {
         let container = try makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- normalize Search subscription/import state by feed URL so http/https/feed, casing, and trailing-slash variants resolve to one row state
- reuse existing podcasts during single and batch subscription staging when normalized feed keys match
- add a SwiftData regression proving Search subscription staging reuses an existing normalized feed row

Closes #123

## Verification
- `git diff --check`
- `xcodebuild -project OffScript.xcodeproj -scheme OffScript -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`\n- Xcode Issue Navigator: 0 warnings/errors via Xcode MCP\n- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:OffScriptTests` reached and passed `feedSyncStagesSearchSubscriptionReusesNormalizedExistingFeed()` and `feedSyncStagesMultipleOnboardingSubscriptionsInOneBatch()` before the known unrelated `PlaybackEventEmission` SwiftData reset crash (`This model instance was destroyed by calling ModelContext.reset and is no longer usable`).