### PR TITLE
Harden discovery privacy and tuner UX

### DIFF
--- a/OffScript/AppSettings.swift
+++ b/OffScript/AppSettings.swift
@@ -30,6 +30,7 @@ enum AppSettings {
         static let preferShortEpisodes = "offscript.preferShortEpisodes"
         static let preferredGenres = "offscript.preferredGenres"
         static let recommendationMode = "offscript.recommendationMode"
+        static let remoteDiscoveryUsesTasteSignals = "offscript.remoteDiscoveryUsesTasteSignals"
         static let recentSearches = "offscript.recentSearches"
         static let cloudSyncEnabled = "offscript.cloudSyncEnabled"
         static let cloudSyncRuntimeState = "offscript.cloudSyncRuntimeState"
@@ -60,9 +61,9 @@ enum AppSettings {
             case .signalLocked:
                 "Only episodes with explicit local evidence. No new-show discovery."
             case .balanced:
-                "Prioritize queue, resume, completion, and topic signal with a small discovery lane."
+                "Prioritize local signal with a small coarse-catalog discovery lane."
             case .discovery:
-                "Keep local signal first, then surface more new-show candidates from your taste profile."
+                "Keep local signal first, then surface more new-show candidates from genre catalog search."
             }
         }
 
@@ -118,6 +119,15 @@ enum AppSettings {
             return mode
         }
         set { defaults.set(newValue.rawValue, forKey: Key.recommendationMode) }
+    }
+
+    /// Default false: silent Apple Podcasts discovery uses coarse catalog
+    /// inputs, then ranks locally with the user's private taste profile.
+    /// Explicit user search remains unrestricted; this flag is only for
+    /// automatic discovery queries derived from listening history.
+    static var remoteDiscoveryUsesTasteSignals: Bool {
+        get { defaults.bool(forKey: Key.remoteDiscoveryUsesTasteSignals) }
+        set { defaults.set(newValue, forKey: Key.remoteDiscoveryUsesTasteSignals) }
     }
 
     static var recentSearchesStorage: String {

--- a/OffScript/BackgroundTranscriptionService.swift
+++ b/OffScript/BackgroundTranscriptionService.swift
@@ -147,7 +147,8 @@ enum BackgroundTranscriptionService {
 
             for episode in candidates {
                 let elapsed = Date().timeIntervalSince(start)
-                if elapsed > maxRunDurationSeconds {
+                let remainingBudget = maxRunDurationSeconds - elapsed
+                if remainingBudget <= 1 {
                     bgTranscribeLogger.info(
                         "Hit time budget (\(elapsed, privacy: .public)s) after \(attempted, privacy: .public) episode(s) — exiting"
                     )
@@ -167,11 +168,19 @@ enum BackgroundTranscriptionService {
                     "Transcribing in background: \(episode.title, privacy: .public)"
                 )
                 do {
-                    _ = try await SpeechTranscriptionService.shared.transcribe(
-                        episode: episode,
-                        localAudioURL: localURL,
-                        persistTo: context
-                    )
+                    let transcriptionTask = Task { @MainActor in
+                        try await SpeechTranscriptionService.shared.transcribe(
+                            episode: episode,
+                            localAudioURL: localURL,
+                            persistTo: context
+                        )
+                    }
+                    let timeoutTask = Task {
+                        try await Task.sleep(for: .seconds(remainingBudget))
+                        transcriptionTask.cancel()
+                    }
+                    defer { timeoutTask.cancel() }
+                    _ = try await transcriptionTask.value
                 } catch is CancellationError {
                     // Re-throw so the outer catch handles cancellation
                     // uniformly (don't classify as a per-episode failure).

--- a/OffScript/CrashReporter.swift
+++ b/OffScript/CrashReporter.swift
@@ -77,12 +77,10 @@ enum CrashReporter {
 
             // Drop anything below .error so handled / info noise never bills.
             options.beforeSend = { event in
-                switch event.level {
-                case .fatal, .error:
-                    return event
-                default:
-                    return nil
-                }
+                Self.filterAndScrub(event: event)
+            }
+            options.beforeBreadcrumb = { breadcrumb in
+                Self.scrub(breadcrumb: breadcrumb)
             }
 
             // Privacy: never auto-capture screen content. Episode titles
@@ -149,5 +147,231 @@ enum CrashReporter {
             }
         }
         #endif
+    }
+
+    nonisolated static func filterAndScrub(event: Event) -> Event? {
+        switch event.level {
+        case .fatal, .error:
+            return scrub(event: event)
+        default:
+            return nil
+        }
+    }
+
+    nonisolated static func scrub(event: Event) -> Event {
+        event.transaction = event.transaction.map { SentryPrivacyScrubber.scrubRoute($0) }
+        event.tags = event.tags.map { SentryPrivacyScrubber.scrubStringDictionary($0) }
+        event.extra = event.extra.map { SentryPrivacyScrubber.scrubDictionary($0) }
+        event.context = event.context.map { context in
+            context.mapValues { SentryPrivacyScrubber.scrubDictionary($0) }
+        }
+        event.breadcrumbs = event.breadcrumbs?.compactMap { scrub(breadcrumb: $0) }
+
+        if let request = event.request {
+            request.url = request.url.map { SentryPrivacyScrubber.scrubURLOrString($0, key: "url") }
+            request.queryString = nil
+            request.fragment = nil
+            request.cookies = nil
+            request.headers = nil
+        }
+
+        if let message = event.message {
+            let scrubbedFormatted = SentryPrivacyScrubber.scrubURLOrString(message.formatted, key: "message")
+            let scrubbedMessage = SentryMessage(formatted: scrubbedFormatted)
+            scrubbedMessage.message = message.message.map { SentryPrivacyScrubber.scrubURLOrString($0, key: "message") }
+            scrubbedMessage.params = message.params?.map { SentryPrivacyScrubber.scrubURLOrString($0, key: "message") }
+            event.message = scrubbedMessage
+        }
+
+        event.exceptions = event.exceptions?.map { exception in
+            exception.value = SentryPrivacyScrubber.scrubURLOrString(exception.value, key: "exception")
+            return exception
+        }
+
+        return event
+    }
+
+    nonisolated static func scrub(breadcrumb: Breadcrumb) -> Breadcrumb? {
+        breadcrumb.message = breadcrumb.message.map { SentryPrivacyScrubber.scrubURLOrString($0, key: "message") }
+        breadcrumb.data = breadcrumb.data.map { SentryPrivacyScrubber.scrubDictionary($0) }
+        return breadcrumb
+    }
+}
+
+private enum SentryPrivacyScrubber {
+    private static let redacted = "[redacted]"
+
+    private static let urlRegex: NSRegularExpression = {
+        do {
+            return try NSRegularExpression(pattern: #"(?:https?|feed|offscript)://[^\s<>"'`]+(?<![.,;:!?)\]\}])"#)
+        } catch {
+            fatalError("Invalid Sentry URL scrub regex: \(error)")
+        }
+    }()
+
+    private static let uuidRegex: NSRegularExpression = {
+        do {
+            return try NSRegularExpression(
+                pattern: #"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"#
+            )
+        } catch {
+            fatalError("Invalid Sentry UUID scrub regex: \(error)")
+        }
+    }()
+
+    static func scrubStringDictionary(_ dictionary: [String: String]) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: dictionary.map { key, value in
+            (key, scrubURLOrString(value, key: key))
+        })
+    }
+
+    static func scrubDictionary(_ dictionary: [String: Any]) -> [String: Any] {
+        Dictionary(uniqueKeysWithValues: dictionary.map { key, value in
+            (key, scrubValue(value, key: key))
+        })
+    }
+
+    static func scrubRoute(_ value: String) -> String {
+        scrubURLOrString(value, key: "route")
+    }
+
+    static func scrubURLOrString(_ value: String, key: String) -> String {
+        var scrubbed = replaceURLs(in: value)
+        scrubbed = replaceMatches(in: scrubbed, regex: uuidRegex, with: redacted)
+
+        if isSensitiveKey(key), scrubbed == value {
+            if isRouteKey(key) {
+                return redactRouteSegments(scrubbed)
+            }
+            return value.isEmpty ? value : redacted
+        }
+
+        if isRouteKey(key) {
+            return redactRouteSegments(scrubbed)
+        }
+
+        return scrubbed
+    }
+
+    private static func scrubValue(_ value: Any, key: String) -> Any {
+        switch value {
+        case let string as String:
+            return scrubURLOrString(string, key: key)
+        case let url as URL:
+            return scrubURL(url.absoluteString)
+        case let dictionary as [String: Any]:
+            return scrubDictionary(dictionary)
+        case let dictionary as NSDictionary:
+            var scrubbed: [String: Any] = [:]
+            for (nestedKey, nestedValue) in dictionary {
+                guard let nestedKey = nestedKey as? String else { continue }
+                scrubbed[nestedKey] = scrubValue(nestedValue, key: nestedKey)
+            }
+            return scrubbed
+        case let array as [Any]:
+            return array.map { scrubValue($0, key: key) }
+        default:
+            if isSensitiveKey(key) {
+                return redacted
+            }
+            return value
+        }
+    }
+
+    private static func replaceURLs(in value: String) -> String {
+        replaceMatches(in: value, regex: urlRegex) { match in
+            scrubURL(match)
+        }
+    }
+
+    private static func scrubURL(_ value: String) -> String {
+        guard var components = URLComponents(string: value), let scheme = components.scheme else {
+            return redacted
+        }
+
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+
+        let hasSensitivePath = !components.path.isEmpty && components.path != "/"
+        if hasSensitivePath {
+            components.path = "/\(redacted)"
+        }
+
+        if components.host == nil {
+            return "\(scheme):\(redacted)"
+        }
+
+        return (components.string ?? redacted)
+            .replacingOccurrences(of: "%5Bredacted%5D", with: redacted)
+    }
+
+    private static func redactRouteSegments(_ value: String) -> String {
+        let separators = CharacterSet(charactersIn: "/?#&")
+        return value
+            .components(separatedBy: separators)
+            .map { segment in
+                shouldRedactRouteSegment(segment) ? redacted : segment
+            }
+            .joined(separator: "/")
+    }
+
+    private static func shouldRedactRouteSegment(_ segment: String) -> Bool {
+        guard !segment.isEmpty else { return false }
+        if segment == redacted { return false }
+        if segment.range(of: uuidRegex.pattern, options: .regularExpression) != nil { return true }
+        return segment.count >= 16 && segment.rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) == nil
+    }
+
+    private static func isSensitiveKey(_ key: String) -> Bool {
+        let lowercased = key.lowercased()
+        return [
+            "url",
+            "uri",
+            "query",
+            "search",
+            "transcript",
+            "feed",
+            "podcast",
+            "episode",
+            "audio",
+            "artwork",
+            "route",
+            "context",
+            "identifier",
+            "title"
+        ].contains { lowercased.contains($0) }
+    }
+
+    private static func isRouteKey(_ key: String) -> Bool {
+        let lowercased = key.lowercased()
+        return lowercased.contains("route") || lowercased.contains("context") || lowercased.contains("transaction")
+    }
+
+    private static func replaceMatches(
+        in value: String,
+        regex: NSRegularExpression,
+        with replacement: String
+    ) -> String {
+        replaceMatches(in: value, regex: regex) { _ in replacement }
+    }
+
+    private static func replaceMatches(
+        in value: String,
+        regex: NSRegularExpression,
+        transform: (String) -> String
+    ) -> String {
+        let nsValue = value as NSString
+        let matches = regex.matches(in: value, range: NSRange(location: 0, length: nsValue.length))
+        guard !matches.isEmpty else { return value }
+
+        var scrubbed = value
+        for match in matches.reversed() {
+            let original = nsValue.substring(with: match.range)
+            guard let range = Range(match.range, in: scrubbed) else { continue }
+            scrubbed.replaceSubrange(range, with: transform(original))
+        }
+        return scrubbed
     }
 }

--- a/OffScript/DiscoveryService.swift
+++ b/OffScript/DiscoveryService.swift
@@ -29,6 +29,7 @@ actor DiscoveryService {
     func discoverPodcasts(
         tasteProfile: UserTasteProfile,
         subscribedFeedURLs: Set<String>,
+        includePrivateTasteSignals: Bool,
         limit: Int = 10
     ) async -> [ScoredDiscoveryResult] {
         let normalizedSubscribedFeedURLs = Set(subscribedFeedURLs.map(Self.normalizedFeedKey))
@@ -45,7 +46,10 @@ actor DiscoveryService {
             }
         }
 
-        let queries = buildQueries(from: tasteProfile)
+        let queries = Self.catalogQueries(
+            for: tasteProfile,
+            includePrivateTasteSignals: includePrivateTasteSignals
+        )
         guard !queries.isEmpty else { return [] }
 
         let searchService = PodcastSearchService()
@@ -98,34 +102,34 @@ actor DiscoveryService {
 
     // MARK: - Query Generation
 
-    private func buildQueries(from profile: UserTasteProfile) -> [String] {
+    nonisolated static func catalogQueries(
+        for profile: UserTasteProfile,
+        includePrivateTasteSignals: Bool
+    ) -> [String] {
         var queries: [String] = []
 
-        // Query from top tags (most specific signal)
-        let topTags = profile.topTags
-        if topTags.count >= 2 {
-            queries.append(topTags.prefix(2).joined(separator: " "))
-        } else if let first = topTags.first {
-            queries.append(first)
-        }
-
-        // Query from preferred genres
         let genres = profile.preferredGenres
         if let genre = genres.first {
             queries.append("\(genre) podcast")
         }
 
-        // Cross-signal: combine a tag with a genre for more targeted results
-        if let tag = topTags.first, let genre = genres.first {
-            queries.append("\(tag) \(genre)")
+        if includePrivateTasteSignals {
+            let topTags = profile.topTags
+            if topTags.count >= 2 {
+                queries.insert(topTags.prefix(2).joined(separator: " "), at: 0)
+            } else if let first = topTags.first {
+                queries.insert(first, at: 0)
+            }
+
+            if let tag = topTags.first, let genre = genres.first {
+                queries.append("\(tag) \(genre)")
+            }
+
+            if let favoriteShow = profile.showAffinity.first {
+                queries.append("podcasts like \(favoriteShow)")
+            }
         }
 
-        // Show affinity: find shows similar to favorites
-        if let favoriteShow = profile.showAffinity.first {
-            queries.append("podcasts like \(favoriteShow)")
-        }
-
-        // Cap at 4 queries
         return Array(queries.prefix(4))
     }
 

--- a/OffScript/GenrePickerView.swift
+++ b/OffScript/GenrePickerView.swift
@@ -6,6 +6,8 @@ import SwiftUI
 // Each genre is a hairline rectangle with a mono channel index, the genre
 // glyph in signal yellow when active, and a tracked-out caption.
 struct GenrePickerView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @Binding var selectedGenres: Set<Genre>
     let onContinue: () -> Void
     let onBack: () -> Void
@@ -82,12 +84,16 @@ struct GenrePickerView: View {
                             lineWidth: 1
                         )
                     )
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.tunerPress)
                 .disabled(selectedGenres.isEmpty)
 
                 Button(action: onBack) {
                     TunerLabel(text: "← BACK")
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.tunerPress)
             }
@@ -105,11 +111,19 @@ struct GenrePickerView: View {
     }
 
     private func toggleGenre(_ genre: Genre) {
-        withAnimation(.spring(response: 0.25, dampingFraction: 0.7)) {
+        let updates = {
             if selectedGenres.contains(genre) {
                 selectedGenres.remove(genre)
             } else {
                 selectedGenres.insert(genre)
+            }
+        }
+
+        if reduceMotion {
+            updates()
+        } else {
+            withAnimation(.spring(response: 0.25, dampingFraction: 0.7)) {
+                updates()
             }
         }
     }

--- a/OffScript/HomeView.swift
+++ b/OffScript/HomeView.swift
@@ -1071,7 +1071,9 @@ private struct HeroTunerCard: View {
             TunerLabel(text: title, color: color.opacity(disabled ? 0.5 : 1.0), size: 10)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 10)
+                .frame(minHeight: 44)
                 .overlay(Rectangle().stroke(color.opacity(disabled ? 0.3 : 1.0), lineWidth: 1))
+                .contentShape(Rectangle())
         }
         .buttonStyle(.tunerPress)
         .disabled(disabled)

--- a/OffScript/ImportProgressView.swift
+++ b/OffScript/ImportProgressView.swift
@@ -34,7 +34,7 @@ struct ImportProgressView: View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 6) {
                 HStack {
-                    TunerLabel(text: "03 · TUNING", color: .offscriptSignalYellow)
+                    TunerLabel(text: "03 · STAGING", color: .offscriptSignalYellow)
                     Spacer()
                     TunerLabel(
                         text: statusReadout,
@@ -71,34 +71,8 @@ struct ImportProgressView: View {
                 }
             }
 
-            if hasFailures {
-                HStack(spacing: 10) {
-                    Button {
-                        Task { await runImports(onlyFailed: true) }
-                    } label: {
-                        TunerLabel(text: "↻ RETRY FAILED", color: .offscriptSignalYellow, size: 10)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 10)
-                            .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
-                            .frame(minHeight: 44)
-                    }
-                    .buttonStyle(.tunerPress)
-                    .disabled(isImporting)
-
-                    if doneCount > 0 {
-                        Button {
-                            isComplete = true
-                            onComplete()
-                        } label: {
-                            TunerLabel(text: "→ CONTINUE", color: .offscriptFnInfo, size: 10)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 10)
-                                .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
-                                .frame(minHeight: 44)
-                        }
-                        .buttonStyle(.tunerPress)
-                    }
-                }
+            if shouldShowCompletionActions {
+                completionActions
             }
 
             Spacer()
@@ -125,10 +99,14 @@ struct ImportProgressView: View {
         hasFinishedAttempt && failedCount > 0 && !isComplete
     }
 
+    private var shouldShowCompletionActions: Bool {
+        hasFinishedAttempt && !isImporting
+    }
+
     private var statusReadout: String {
-        if isComplete { return "● COMPLETE" }
+        if isComplete { return "● READY" }
         if hasFailures { return "● \(failedCount) FAILED" }
-        return "● TUNING \(doneCount)/\(podcasts.count)"
+        return "● STAGING \(doneCount)/\(podcasts.count)"
     }
 
     private var statusReadoutColor: Color {
@@ -138,24 +116,58 @@ struct ImportProgressView: View {
     }
 
     private var headerTitle: String {
-        if isComplete { return "Channels tuned." }
+        if isComplete { return "Channels staged." }
         if hasFailures { return "Some channels missed." }
-        return "Tuning channels..."
+        return "Staging channels..."
     }
 
     private var headerCopy: String {
         if isComplete {
-            return "Your feed is ready. Recommendations build as you listen."
+            return "Subscriptions are saved. Episode hydration continues in the background after you enter the app."
         }
         if hasFailures {
-            return "Retry failed channels or continue with the feeds that tuned successfully."
+            return "Retry failed channels or enter the app now. Any staged feeds will hydrate in the background."
         }
-        return "Subscribing now. Starter episodes tune in behind the scenes so you can get into the app without waiting on feed hydration."
+        return "Saving subscriptions now. Starter episodes hydrate behind the scenes so setup is not gated by feed parsing."
+    }
+
+    private var completionActions: some View {
+        HStack(spacing: 10) {
+            if hasFailures {
+                Button {
+                    Task { await runImports(onlyFailed: true) }
+                } label: {
+                    TunerLabel(text: "↻ RETRY FAILED", color: .offscriptSignalYellow, size: 10)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .overlay(Rectangle().stroke(Color.offscriptSignalYellow, lineWidth: 1))
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.tunerPress)
+                .disabled(isImporting)
+            }
+
+            Button {
+                isComplete = true
+                onComplete()
+            } label: {
+                TunerLabel(text: "→ ENTER APP", color: .offscriptFnInfo, size: 10)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .overlay(Rectangle().stroke(Color.offscriptHairline, lineWidth: 1))
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.tunerPress)
+            .accessibilityLabel("Enter OffScript")
+        }
     }
 
     // Onboarding should commit selected subscriptions immediately. Starter
-    // feed hydration runs after the app opens so first launch is not gated by
-    // XML parsing, enrichment, external chapter fetches, or slow feed hosts.
+    // feed hydration stays decoupled from the explicit "enter app" route so
+    // setup is not gated by XML parsing, enrichment, chapter fetches, or slow
+    // feed hosts.
     @MainActor
     private func runImports(onlyFailed: Bool = false) async {
         guard !isImporting else { return }
@@ -192,7 +204,6 @@ struct ImportProgressView: View {
         if failedCount == 0 {
             isComplete = true
             isImporting = false
-            onComplete()
         } else {
             isImporting = false
         }
@@ -245,7 +256,11 @@ enum OnboardingHydrationScheduler {
     static func waitForPostOnboardingPaintGap(delayNanoseconds: UInt64 = defaultDelayNanoseconds) async {
         await Task.yield()
         guard delayNanoseconds > 0 else { return }
-        try? await Task.sleep(nanoseconds: delayNanoseconds)
+        do {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+        } catch {
+            return
+        }
     }
 }
 
@@ -258,7 +273,12 @@ enum OnboardingPreferenceSignalService {
             sortBy: [SortDescriptor(\Episode.pubDate, order: .reverse)]
         )
         descriptor.fetchLimit = 1
-        return try? context.fetch(descriptor).first
+        do {
+            return try context.fetch(descriptor).first
+        } catch {
+            importLogger.error("Newest onboarding episode fetch failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
     }
 }
 
@@ -300,9 +320,9 @@ private struct ImportRow: View {
         case .pending:
             TunerLabel(text: "○ STANDBY", color: .offscriptSoftPaper, size: 9)
         case .importing:
-            TunerLabel(text: "● TUNING", color: .offscriptSignalYellow, size: 9)
+            TunerLabel(text: "● STAGING", color: .offscriptSignalYellow, size: 9)
         case .done:
-            TunerLabel(text: "✓ TUNED", color: .offscriptFnMode, size: 9)
+            TunerLabel(text: "✓ STAGED", color: .offscriptFnMode, size: 9)
         case .failed:
             TunerLabel(text: "✕ FAILED", color: .offscriptFnRecord, size: 9)
         }

--- a/OffScript/MetricKitReporter.swift
+++ b/OffScript/MetricKitReporter.swift
@@ -9,10 +9,10 @@ import Sentry
 /// 1. **OSLog**: human-readable summaries land in Console.app and Xcode's
 ///    debug console. Free, no quota, useful during development.
 /// 2. **Sentry forwarding (errors only)**: crash diagnostics get promoted
-///    to a Sentry event with `level: .fatal` and the MetricKit payload
-///    attached as context — so the same crash is visible in App Store
-///    Connect (Apple's pipeline), Sentry (our pipeline), AND grouped by
-///    Sentry's stack-signature dedupe.
+///    to a Sentry event with `level: .fatal` and a trimmed MetricKit
+///    summary — so the same crash is visible in App Store Connect
+///    (Apple's pipeline), Sentry (our pipeline), AND grouped by
+///    Sentry's stack-signature dedupe without shipping opaque diagnostics.
 ///
 /// MetricKit only delivers payloads to App Store / TestFlight builds where
 /// the user has opted in to "Share with App Developers." Coverage is
@@ -94,14 +94,37 @@ final class MetricKitReporter: NSObject, MXMetricManagerSubscriber {
         // dedupes on stack signature, so already-reported crashes coalesce.
         let event = Event(level: .fatal)
         event.message = SentryMessage(formatted: "MetricKit crash diagnostic")
-        event.extra = [
-            "metrickit_payload": crash.dictionaryRepresentation(),
-            "termination_reason": crash.terminationReason ?? "unknown",
-            "exception_type": crash.exceptionType?.stringValue ?? "unknown",
-            "exception_code": crash.exceptionCode?.stringValue ?? "unknown",
-            "signal": crash.signal?.stringValue ?? "unknown"
-        ]
+        event.extra = Self.trimmedCrashExtras(
+            terminationReason: crash.terminationReason,
+            exceptionType: crash.exceptionType?.stringValue,
+            exceptionCode: crash.exceptionCode?.stringValue,
+            signal: crash.signal?.stringValue
+        )
         SentrySDK.capture(event: event)
         logger.error("Forwarded MetricKit crash diagnostic to Sentry")
+    }
+
+    nonisolated static func trimmedCrashExtras(
+        terminationReason: String?,
+        exceptionType: String?,
+        exceptionCode: String?,
+        signal: String?
+    ) -> [String: Any] {
+        [
+            "metrickit_source": "MXCrashDiagnostic",
+            "termination_reason": sanitizedDiagnosticValue(terminationReason),
+            "exception_type": sanitizedDiagnosticValue(exceptionType),
+            "exception_code": sanitizedDiagnosticValue(exceptionCode),
+            "signal": sanitizedDiagnosticValue(signal)
+        ]
+    }
+
+    private nonisolated static func sanitizedDiagnosticValue(_ value: String?) -> String {
+        guard let value, !value.isEmpty else { return "unknown" }
+        let firstLine = value.components(separatedBy: .newlines).first ?? value
+        if firstLine.contains("://") || firstLine.contains("/") {
+            return "[redacted]"
+        }
+        return String(firstLine.prefix(160))
     }
 }

--- a/OffScript/Models.swift
+++ b/OffScript/Models.swift
@@ -105,7 +105,7 @@ final class Episode {
     @Relationship(deleteRule: .nullify, inverse: \PlaybackEvent.episode)
     var playbackEvents: [PlaybackEvent] = []
 
-    @Relationship(deleteRule: .nullify, inverse: \PreferenceSignal.episode)
+    @Relationship(deleteRule: .cascade, inverse: \PreferenceSignal.episode)
     var preferenceSignals: [PreferenceSignal] = []
 
     @Relationship(deleteRule: .cascade, inverse: \EpisodeProfile.episode)
@@ -246,8 +246,9 @@ final class PreferenceSignal {
     var date: Date = Date()
     private var actionRawValue: String = Action.like.rawValue
     // Non-optional Episode so RecommendationService keypaths (\.episode.id)
-    // resolve cleanly. SwiftData cascades the relationship — deleting an
-    // Episode also clears its preferences.
+    // resolve cleanly. Episode.preferenceSignals owns the cascade delete;
+    // this side is explicit so SwiftData never tries to null a required row.
+    @Relationship(deleteRule: .noAction)
     var episode: Episode
 
     init(action: Action, episode: Episode) {

--- a/OffScript/PlaybackController.swift
+++ b/OffScript/PlaybackController.swift
@@ -26,6 +26,14 @@ enum OffScriptAudioSessionConfiguration {
 }
 #endif
 
+private final class PlaybackCompletionNotificationItem: @unchecked Sendable {
+    let item: AVPlayerItem?
+
+    init(_ item: AVPlayerItem?) {
+        self.item = item
+    }
+}
+
 @MainActor
 final class PlaybackController: ObservableObject {
     static let shared = PlaybackController()
@@ -85,6 +93,18 @@ final class PlaybackController: ObservableObject {
     /// "End of Episode" doesn't see a stale wall-clock countdown when
     /// the episode is 38 minutes long.
     @Published private(set) var isEndOfEpisodeSleepArmed: Bool = false
+
+    #if DEBUG
+    private var suppressExternalSideEffectsForTesting = false
+    #endif
+
+    private var externalSideEffectsEnabled: Bool {
+        #if DEBUG
+        return !suppressExternalSideEffectsForTesting
+        #else
+        return true
+        #endif
+    }
 
     private init() {
         configureAudioSession()
@@ -285,7 +305,14 @@ final class PlaybackController: ObservableObject {
                     self.updateNowPlayingPlaybackRate()
                     return
                 }
-                try? await Task.sleep(for: .seconds(1))
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch is CancellationError {
+                    return
+                } catch {
+                    self.logger.error("Sleep timer tick failed: \(error.localizedDescription, privacy: .public)")
+                    return
+                }
             }
         }
     }
@@ -333,17 +360,21 @@ final class PlaybackController: ObservableObject {
     func play(_ episode: Episode, in context: ModelContext? = nil) {
         prepareItem(for: episode, in: context)
 
-        // Re-activate the audio session immediately before starting playback.
-        // The init-time activation can fail silently (no audio queued yet, or
-        // another app holds focus); without re-activating here, the session
-        // never enters .playback, and iOS silences us on background. Calling
-        // setActive(true) right before player.play() is the supported pattern
-        // for AVPlayer-backed apps.
-        activateAudioSession()
-        player.play()
-        player.rate = playbackRate
+        if externalSideEffectsEnabled {
+            // Re-activate the audio session immediately before starting playback.
+            // The init-time activation can fail silently (no audio queued yet, or
+            // another app holds focus); without re-activating here, the session
+            // never enters .playback, and iOS silences us on background. Calling
+            // setActive(true) right before player.play() is the supported pattern
+            // for AVPlayer-backed apps.
+            activateAudioSession()
+            player.play()
+            player.rate = playbackRate
+        }
         isPlaying = true
-        donatePlayEpisodeIntent(for: episode)
+        if externalSideEffectsEnabled {
+            donatePlayEpisodeIntent(for: episode)
+        }
         // Emit .started so TasteProfileService.unfinishedEpisodeAffinity has
         // a meaningful denominator. The reader at TasteProfileService.swift:152
         // counts `.started || .resumed` as the "began listening" denominator;
@@ -356,7 +387,9 @@ final class PlaybackController: ObservableObject {
         // after the app is force-quit. Persist only on actual play (not the
         // load() path) so a Spotlight-tap-without-play doesn't pollute Siri's
         // "resume" target. Flagged dead-code by the 2026-05-19 intents audit.
-        UserDefaults.standard.set(episode.audioURL.absoluteString, forKey: "offscript.lastEpisodeAudioURL")
+        if externalSideEffectsEnabled {
+            UserDefaults.standard.set(episode.audioURL.absoluteString, forKey: "offscript.lastEpisodeAudioURL")
+        }
     }
 
     /// Load an episode into the player WITHOUT starting playback. Used by
@@ -406,22 +439,28 @@ final class PlaybackController: ObservableObject {
         // remembers its own pace.
         playbackRate = PodcastPlaybackPreferences.preferredRate(for: episode.podcast)
             ?? PodcastPlaybackPreferences.globalDefault
-        let url = episode.localFileURL ?? episode.audioURL
-        let item = AVPlayerItem(url: url)
-        observeItem(item)
         playbackError = nil
-        player.replaceCurrentItem(with: item)
 
         let savedPosition = episode.playedPosition
         if savedPosition > 0 {
-            player.seek(to: CMTime(seconds: savedPosition, preferredTimescale: 600))
             currentTime = savedPosition
         } else {
             currentTime = 0
         }
+        if externalSideEffectsEnabled {
+            let url = episode.localFileURL ?? episode.audioURL
+            let item = AVPlayerItem(url: url)
+            observeItem(item)
+            player.replaceCurrentItem(with: item)
+            if savedPosition > 0 {
+                player.seek(to: CMTime(seconds: savedPosition, preferredTimescale: 600))
+            }
+        }
 
         isPlayerPresented = true
-        updateNowPlaying(episode: episode)
+        if externalSideEffectsEnabled {
+            updateNowPlaying(episode: episode)
+        }
     }
 
     /// Hard pause — stops playback regardless of current state. Used by
@@ -440,26 +479,34 @@ final class PlaybackController: ObservableObject {
         // Capture the pre-toggle state so we know which donation maps to the
         // user's actual action — `isPlaying.toggle()` below flips it.
         let wasPlaying = isPlaying
-        if isPlaying {
-            player.pause()
-        } else {
-            // Same reason as play() — the session can be inactive when we
-            // resume from pause (especially after a long background pause
-            // or after another app interrupted us).
-            activateAudioSession()
-            player.play()
-            player.rate = playbackRate
+        if externalSideEffectsEnabled {
+            if isPlaying {
+                player.pause()
+            } else {
+                // Same reason as play() — the session can be inactive when we
+                // resume from pause (especially after a long background pause
+                // or after another app interrupted us).
+                activateAudioSession()
+                player.play()
+                player.rate = playbackRate
+            }
         }
         isPlaying.toggle()
-        updateNowPlayingPlaybackRate()
+        if externalSideEffectsEnabled {
+            updateNowPlayingPlaybackRate()
+        }
         // Donate after the state change so we only signal user intent that
         // actually took effect. Interruption / route-change handlers go
         // through `player.pause()` directly, not this entry point, so they
         // correctly bypass donation.
         if wasPlaying {
-            donatePauseListeningIntent()
+            if externalSideEffectsEnabled {
+                donatePauseListeningIntent()
+            }
         } else {
-            donateResumeListeningIntent()
+            if externalSideEffectsEnabled {
+                donateResumeListeningIntent()
+            }
             // Emit `.resumed` only when un-pausing meaningful progress.
             // Below `resumedMinimumProgressSeconds` the user is still in
             // the initial-play phase (loaded, tapped pause, tapped play
@@ -531,14 +578,18 @@ final class PlaybackController: ObservableObject {
         duration: TimeInterval,
         currentTime: TimeInterval,
         isPlaying: Bool,
-        presentPlayer: Bool
+        presentPlayer: Bool,
+        suppressExternalSideEffects: Bool = false
     ) {
+        suppressExternalSideEffectsForTesting = suppressExternalSideEffects
         currentEpisode = episode
         self.duration = max(duration, 1)
         self.currentTime = min(max(currentTime, 0), self.duration)
         self.isPlaying = isPlaying
         isPlayerPresented = presentPlayer
-        updateNowPlaying(episode: episode)
+        if !suppressExternalSideEffectsForTesting {
+            updateNowPlaying(episode: episode)
+        }
     }
 
     /// Reset the singleton's per-episode state for test isolation. The
@@ -570,6 +621,11 @@ final class PlaybackController: ObservableObject {
         sleepTimerTask = nil
         sleepTimerEndDate = nil
         isEndOfEpisodeSleepArmed = false
+        suppressExternalSideEffectsForTesting = false
+    }
+
+    func debugCompleteCurrentEpisodeForTesting() {
+        completeCurrentEpisode()
     }
     #endif
 
@@ -622,42 +678,55 @@ final class PlaybackController: ObservableObject {
             forName: .AVPlayerItemDidPlayToEndTime,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                guard let self, let episode = self.currentEpisode else { return }
-                episode.isPlayed = true
-                episode.playedPosition = self.duration
-                if let context = self.modelContext {
-                    let event = PlaybackEvent(kind: .completed, position: self.duration, episode: episode)
-                    context.insert(event)
-                    do { try context.save() } catch { self.logger.error("Failed to save playback completion event: \(error.localizedDescription, privacy: .public)") }
+        ) { [weak self] notification in
+            let completedItem = PlaybackCompletionNotificationItem(notification.object as? AVPlayerItem)
+            Task { @MainActor [weak self, completedItem] in
+                guard let self,
+                      let item = completedItem.item,
+                      item === self.player.currentItem else { return }
+                self.completeCurrentEpisode()
+            }
+        }
+    }
+
+    private func completeCurrentEpisode() {
+        guard let episode = currentEpisode else { return }
+        episode.isPlayed = true
+        episode.playedPosition = duration
+        if let context = modelContext {
+            let event = PlaybackEvent(kind: .completed, position: duration, episode: episode)
+            context.insert(event)
+            do {
+                try context.save()
+            } catch {
+                logger.error("Failed to save playback completion event: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        // End-of-episode sleep wins over auto-advance — clear the flag and
+        // stop. Without this guard, an armed end-of-episode sleep would still
+        // auto-jump into the next queued episode and defeat the purpose.
+        if isEndOfEpisodeSleepArmed {
+            isEndOfEpisodeSleepArmed = false
+            if externalSideEffectsEnabled {
+                player.pause()
+                updateNowPlayingPlaybackRate()
+            }
+            isPlaying = false
+        } else if UserDefaults.standard.object(forKey: "offscript.autoPlayNext") as? Bool ?? true {
+            skipToNextInQueue()
+            // Auto-advance matches the `PlayNextInQueueIntent` semantic
+            // ("play the next thing in the queue"), so donate it here — but
+            // only when an episode actually queued up (skipToNextInQueue is a
+            // no-op on an empty queue).
+            if let newEpisode = currentEpisode, newEpisode.id != episode.id {
+                if externalSideEffectsEnabled {
+                    donatePlayNextInQueueIntent()
                 }
-                // End-of-episode sleep wins over auto-advance — clear
-                // the flag and stop. Without this guard, an armed
-                // end-of-episode sleep would still auto-jump into the
-                // next queued episode and defeat the purpose.
-                if self.isEndOfEpisodeSleepArmed {
-                    self.isEndOfEpisodeSleepArmed = false
-                    self.player.pause()
-                    self.isPlaying = false
-                    self.updateNowPlayingPlaybackRate()
-                } else if UserDefaults.standard.object(forKey: "offscript.autoPlayNext") as? Bool ?? true {
-                    self.skipToNextInQueue()
-                    // Auto-advance matches the `PlayNextInQueueIntent`
-                    // semantic ("play the next thing in the queue"), so
-                    // donate it here — but only when an episode actually
-                    // queued up (skipToNextInQueue is a no-op on an
-                    // empty queue).
-                    if let newEpisode = self.currentEpisode, newEpisode.id != episode.id {
-                        self.donatePlayNextInQueueIntent()
-                        // `.advancedFromQueue` is a positive signal about
-                        // the NEW episode — the user trusted the queue's
-                        // pick, so credit that pick. We deliberately don't
-                        // fire it on the finished one (which already got
-                        // `.completed`).
-                        self.recordPlaybackEvent(.advancedFromQueue, position: 0, for: newEpisode)
-                    }
-                }
+                // `.advancedFromQueue` is a positive signal about the NEW
+                // episode — the user trusted the queue's pick, so credit that
+                // pick. We deliberately don't fire it on the finished one
+                // (which already got `.completed`).
+                recordPlaybackEvent(.advancedFromQueue, position: 0, for: newEpisode)
             }
         }
     }

--- a/OffScript/PlayerView.swift
+++ b/OffScript/PlayerView.swift
@@ -21,7 +21,9 @@ private let playerLogger = Logger(subsystem: "com.offscript", category: "Player"
 struct PlayerView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject private var player = PlaybackController.shared
+    @ObservedObject private var downloadService = DownloadService.shared
     @Query private var queueItems: [QueueItem]
     @State private var isSpeedPickerExpanded = false
     @State private var isSleepPickerExpanded = false
@@ -64,6 +66,7 @@ struct PlayerView: View {
                         chaptersSection(episode: episode)
                         upNext
                         whatsNextSection(episode: episode)
+                        localEpisodeToolsSection(episode: episode)
                         controlsSection(episode: episode)
                     }
                     .padding(.horizontal, OffScriptTheme.pagePadding)
@@ -591,7 +594,7 @@ struct PlayerView: View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
                     Button {
-                        withAnimation(.easeInOut(duration: 0.16)) {
+                        animateControlState {
                             isSpeedPickerExpanded.toggle()
                             if isSpeedPickerExpanded { isSleepPickerExpanded = false }
                         }
@@ -648,7 +651,7 @@ struct PlayerView: View {
                         : "Mark \(episode.title) as played")
 
                     Button {
-                        withAnimation(.easeInOut(duration: 0.16)) {
+                        animateControlState {
                             isSleepPickerExpanded.toggle()
                             if isSleepPickerExpanded { isSpeedPickerExpanded = false }
                         }
@@ -674,7 +677,7 @@ struct PlayerView: View {
                         accessibilityActionPrefix: "Set playback speed to"
                     ) { rate in
                         player.setPlaybackRate(rate)
-                        withAnimation(.easeInOut(duration: 0.16)) {
+                        animateControlState {
                             isSpeedPickerExpanded = false
                         }
                     }
@@ -693,6 +696,75 @@ struct PlayerView: View {
         )
     }
 
+    private func localEpisodeToolsSection(episode: Episode) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                TunerLabel(text: "LOCAL · DEVICE", color: .offscriptSignalYellow)
+                Spacer()
+                TunerLabel(text: offlineReadout(for: episode), color: offlineReadoutColor(for: episode))
+            }
+
+            HStack(alignment: .center, spacing: 10) {
+                DownloadButton(episode: episode)
+                if let status = downloadService.statusText(for: episode) {
+                    TunerLabel(text: status.uppercased(), color: offlineReadoutColor(for: episode), size: 9)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    TunerLabel(text: "AVAILABLE FOR OFFLINE", color: .offscriptSoftPaper, size: 9)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 0)
+            }
+
+            SpeechTranscriptionPanel(episode: episode)
+        }
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .overlay(
+            Rectangle().fill(Color.offscriptHairline).frame(height: 1),
+            alignment: .top
+        )
+    }
+
+    private func offlineReadout(for episode: Episode) -> String {
+        switch episode.downloadState {
+        case .notDownloaded:
+            return "○ ONLINE"
+        case .queued:
+            return "● QUEUED"
+        case .downloading:
+            return "● \(Int((episode.downloadProgress * 100).rounded()))%"
+        case .downloaded:
+            return "● OFFLINE"
+        case .failed:
+            return "● ERROR"
+        }
+    }
+
+    private func offlineReadoutColor(for episode: Episode) -> Color {
+        switch episode.downloadState {
+        case .notDownloaded:
+            return .offscriptSoftPaper
+        case .queued, .downloading:
+            return .offscriptSignalYellow
+        case .downloaded:
+            return .offscriptFnMode
+        case .failed:
+            return .offscriptFnRecord
+        }
+    }
+
+    private func animateControlState(_ updates: () -> Void) {
+        if reduceMotion {
+            updates()
+        } else {
+            withAnimation(.easeInOut(duration: 0.16)) {
+                updates()
+            }
+        }
+    }
+
     @ViewBuilder
     private func tunerControlLabel(text: String, color: Color) -> some View {
         TunerLabel(text: text, color: color, size: 10)
@@ -708,7 +780,7 @@ struct PlayerView: View {
             if player.sleepTimerEndDate != nil || player.isEndOfEpisodeSleepArmed {
                 Button {
                     player.cancelSleepTimer()
-                    withAnimation(.easeInOut(duration: 0.16)) {
+                    animateControlState {
                         isSleepPickerExpanded = false
                     }
                 } label: {
@@ -722,7 +794,7 @@ struct PlayerView: View {
             ForEach([5, 15, 30, 45, 60], id: \.self) { minutes in
                 Button {
                     player.setSleepTimer(minutes: minutes)
-                    withAnimation(.easeInOut(duration: 0.16)) {
+                    animateControlState {
                         isSleepPickerExpanded = false
                     }
                 } label: {
@@ -739,7 +811,7 @@ struct PlayerView: View {
             // episode without committing to a guess at remaining time.
             Button {
                 player.armEndOfEpisodeSleep()
-                withAnimation(.easeInOut(duration: 0.16)) {
+                animateControlState {
                     isSleepPickerExpanded = false
                 }
             } label: {
@@ -807,6 +879,8 @@ struct PlayerView: View {
 }
 
 private struct TunerScrubber: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     let value: Double
     let duration: Double
     let onSeek: (Double) -> Void
@@ -882,13 +956,17 @@ private struct TunerScrubber: View {
                     }
                     .onEnded { gesture in
                         let newValue = seekValue(for: gesture.location.x, width: width)
-                        withAnimation(.easeOut(duration: 0.18)) {
+                        if reduceMotion {
                             dragValue = nil
+                        } else {
+                            withAnimation(.easeOut(duration: 0.18)) {
+                                dragValue = nil
+                            }
                         }
                         onSeek(newValue)
                     }
             )
-            .animation(.easeOut(duration: 0.12), value: isDragging)
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: isDragging)
         }
         .frame(height: 44)
         .accessibilityElement(children: .ignore)
@@ -967,6 +1045,7 @@ private struct ScrubberBubbleWidthPreferenceKey: PreferenceKey {
 
 private struct PlayerWhatsNextSection: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let currentEpisode: Episode
     @State private var suggestions: [ScoredEpisode] = []
 
@@ -1007,8 +1086,12 @@ private struct PlayerWhatsNextSection: View {
                 context: modelContext,
                 limit: 3
             )
-            withAnimation(.easeInOut(duration: 0.2)) {
+            if reduceMotion {
                 suggestions = results
+            } else {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    suggestions = results
+                }
             }
         } catch {
             playerLogger.error("Failed to load player suggestions: \(error.localizedDescription, privacy: .public)")

--- a/OffScript/PodcastPickerView.swift
+++ b/OffScript/PodcastPickerView.swift
@@ -125,12 +125,16 @@ struct PodcastPickerView: View {
                             lineWidth: 1
                         )
                     )
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.tunerPress)
                 .disabled(!canContinue)
 
                 Button(action: onBack) {
                     TunerLabel(text: "← BACK")
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.tunerPress)
             }
@@ -180,6 +184,8 @@ struct PodcastPickerView: View {
 }
 
 private struct PodcastGenreRail: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     let genre: Genre
     let podcasts: [PodcastSearchResult]
     @Binding var selectedFeeds: Set<URL>
@@ -208,18 +214,30 @@ private struct PodcastGenreRail: View {
                             podcast: podcast,
                             isSelected: selectedFeeds.contains(podcast.feedURL),
                             onTap: {
-                                withAnimation(.spring(response: 0.25, dampingFraction: 0.7)) {
-                                    if selectedFeeds.contains(podcast.feedURL) {
-                                        selectedFeeds.remove(podcast.feedURL)
-                                    } else {
-                                        selectedFeeds.insert(podcast.feedURL)
-                                    }
-                                }
+                                toggleSelection(podcast.feedURL)
                             }
                         )
                     }
                 }
                 .padding(.horizontal, 20)
+            }
+        }
+    }
+
+    private func toggleSelection(_ feedURL: URL) {
+        let updates = {
+            if selectedFeeds.contains(feedURL) {
+                selectedFeeds.remove(feedURL)
+            } else {
+                selectedFeeds.insert(feedURL)
+            }
+        }
+
+        if reduceMotion {
+            updates()
+        } else {
+            withAnimation(.spring(response: 0.25, dampingFraction: 0.7)) {
+                updates()
             }
         }
     }
@@ -407,6 +425,7 @@ private struct EditorialCollectionDetailView: View {
     let entries: [CuratedEntry]
     @Binding var selectedFeeds: Set<URL>
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         ScrollView {
@@ -472,6 +491,8 @@ private struct EditorialCollectionDetailView: View {
                 }
                 .padding(.vertical, 16)
                 .background(Color.offscriptSignalYellow)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.tunerPress)
             .padding(.horizontal, 20)
@@ -484,11 +505,19 @@ private struct EditorialCollectionDetailView: View {
     }
 
     private func toggleSelection(_ feedURL: URL) {
-        withAnimation(.spring(response: 0.25, dampingFraction: 0.7)) {
+        let updates = {
             if selectedFeeds.contains(feedURL) {
                 selectedFeeds.remove(feedURL)
             } else {
                 selectedFeeds.insert(feedURL)
+            }
+        }
+
+        if reduceMotion {
+            updates()
+        } else {
+            withAnimation(.spring(response: 0.25, dampingFraction: 0.7)) {
+                updates()
             }
         }
     }

--- a/OffScript/RecommendationService.swift
+++ b/OffScript/RecommendationService.swift
@@ -239,6 +239,7 @@ final class RecommendationService {
         let results = await discoveryService.discoverPodcasts(
             tasteProfile: tasteProfile,
             subscribedFeedURLs: subscribedFeedURLs,
+            includePrivateTasteSignals: AppSettings.remoteDiscoveryUsesTasteSignals,
             limit: limit
         )
 

--- a/OffScript/SearchView.swift
+++ b/OffScript/SearchView.swift
@@ -29,6 +29,7 @@ struct SearchView: View {
     /// fold ask for a preview when they appear; everything below the cap
     /// renders the no-preview shape so layout doesn't shift on scroll.
     @State private var previewLoader = SearchPreviewLoader()
+    @State private var searchGeneration = 0
     @FocusState private var searchFieldFocused: Bool
 
     private let searchService = PodcastSearchService()
@@ -255,6 +256,8 @@ struct SearchView: View {
     @MainActor
     private func search() async {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        searchGeneration += 1
+        let generation = searchGeneration
         // Any query change should cancel in-flight preview fetches that
         // were scheduled for the previous result set. The loader's cache
         // is preserved, so flipping back to a previous query stays
@@ -271,15 +274,29 @@ struct SearchView: View {
         } catch {
             return
         }
+        guard generation == searchGeneration,
+              trimmed == query.trimmingCharacters(in: .whitespacesAndNewlines),
+              !Task.isCancelled else { return }
 
         isSearching = true
-        defer { isSearching = false }
+        defer {
+            if generation == searchGeneration {
+                isSearching = false
+            }
+        }
 
         do {
-            results = try await searchService.search(query: trimmed)
+            let searchResults = try await searchService.search(query: trimmed)
+            guard generation == searchGeneration,
+                  trimmed == query.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !Task.isCancelled else { return }
+            results = searchResults
             errorMessage = nil
             storeRecentSearch(trimmed)
         } catch {
+            guard generation == searchGeneration,
+                  trimmed == query.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !Task.isCancelled else { return }
             searchLogger.error("Search failed for query '\(trimmed, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             errorMessage = "Apple Podcasts Search failed: \(error.localizedDescription)"
         }

--- a/OffScript/SettingsView.swift
+++ b/OffScript/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     // pattern as `autoPlayNext` above. Once the user touches the toggle,
     // the explicit value wins.
     @AppStorage("offscript.downloadsWiFiOnly") private var downloadsWiFiOnly = true
+    @AppStorage("offscript.remoteDiscoveryUsesTasteSignals") private var remoteDiscoveryUsesTasteSignals = false
     @AppStorage("offscript.cloudSyncEnabled") private var cloudSyncEnabled = false
     @State private var recommendationMode = AppSettings.recommendationMode
     @State private var signedInUserID: String?
@@ -648,6 +649,15 @@ struct SettingsView: View {
                 .foregroundStyle(Color.offscriptPaperWhite.opacity(0.75))
                 .lineSpacing(2)
                 .fixedSize(horizontal: false, vertical: true)
+
+            Rectangle().fill(Color.offscriptHairline).frame(height: 1)
+                .padding(.top, 2)
+
+            tunerToggle(
+                title: "Use taste profile for catalog search",
+                detail: "When off, Apple Podcasts Search receives only coarse genre queries; your tags and show affinity still rank results on-device.",
+                isOn: $remoteDiscoveryUsesTasteSignals
+            )
         }
         .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/OffScript/SpeechTranscriptionService.swift
+++ b/OffScript/SpeechTranscriptionService.swift
@@ -6,6 +6,25 @@ import SwiftData
 
 private let speechLogger = Logger(subsystem: "com.offscript", category: "SpeechTranscription")
 
+private final class SpeechRecognitionCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    nonisolated(unsafe) private var task: SFSpeechRecognitionTask?
+
+    nonisolated func set(_ task: SFSpeechRecognitionTask) {
+        lock.lock()
+        self.task = task
+        lock.unlock()
+    }
+
+    nonisolated func cancel() {
+        lock.lock()
+        let task = task
+        self.task = nil
+        lock.unlock()
+        task?.cancel()
+    }
+}
+
 /// On-device transcription via Apple's Speech framework. We use this as a
 /// fallback when an episode has no published transcript URL — common for
 /// indie shows and most legacy back-catalogs.
@@ -29,7 +48,6 @@ final class SpeechTranscriptionService {
     /// process-lifetime cache is a real memory-pressure risk.
     private var cacheOrder: [UUID] = []
     private let maxCachedTranscripts = 5
-    private var inFlightTask: Task<String?, Error>?
 
     private init() {}
 
@@ -72,7 +90,14 @@ final class SpeechTranscriptionService {
         )
         descriptor.fetchLimit = 1
 
-        guard let entry = try? context.fetch(descriptor).first else { return nil }
+        let entry: EpisodeTranscriptCache?
+        do {
+            entry = try context.fetch(descriptor).first
+        } catch {
+            speechLogger.error("Failed to fetch cached transcript for episode \(episodeID.uuidString, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        guard let entry else { return nil }
         // Hydrate via LRU-aware path so the cap stays honoured.
         storeTranscript(entry.text, for: episodeID)
         return entry.text
@@ -104,6 +129,7 @@ final class SpeechTranscriptionService {
         if let context, let stored = persistedTranscript(for: episode.id, in: context) {
             return stored
         }
+        try Task.checkCancellation()
 
         // If the feed publishes an authoritative transcript, prefer that
         // over running Speech recognition. Publisher transcripts are faster
@@ -147,7 +173,9 @@ final class SpeechTranscriptionService {
         request.shouldReportPartialResults = false
         request.taskHint = .dictation
 
-        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+        let cancellation = SpeechRecognitionCancellation()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
             var didResume = false
             let resume: (Result<String, Error>) -> Void = { result in
                 guard !didResume else { return }
@@ -155,7 +183,7 @@ final class SpeechTranscriptionService {
                 continuation.resume(with: result)
             }
 
-            recognizer.recognitionTask(with: request) { [weak self] result, error in
+            let task = recognizer.recognitionTask(with: request) { [weak self] result, error in
                 if let error {
                     speechLogger.error("Recognition failed: \(error.localizedDescription, privacy: .public)")
                     resume(.failure(TranscriptionError.recognitionFailed(error.localizedDescription)))
@@ -187,6 +215,10 @@ final class SpeechTranscriptionService {
                 }
                 resume(.success(text))
             }
+            cancellation.set(task)
+        }
+        } onCancel: {
+            cancellation.cancel()
         }
     }
 }

--- a/OffScriptTests/OffScriptTests.swift
+++ b/OffScriptTests/OffScriptTests.swift
@@ -2,6 +2,7 @@ import AppIntents
 import AVFoundation
 import Foundation
 import MediaPlayer
+import Sentry
 import SwiftData
 import Testing
 @testable import OffScript
@@ -1498,6 +1499,45 @@ struct OffScriptTests {
 
     @Test
     @MainActor
+    func discoveryCatalogQueriesDefaultToCoarseGenresOnly() throws {
+        let tasteProfile = UserTasteProfile()
+        tasteProfile.topTags = ["audio craft", "field interviews"]
+        tasteProfile.preferredGenres = ["Technology"]
+        tasteProfile.showAffinity = ["Private Favorite Show"]
+
+        let queries = DiscoveryService.catalogQueries(
+            for: tasteProfile,
+            includePrivateTasteSignals: false
+        )
+
+        #expect(queries == ["Technology podcast"])
+        #expect(!queries.contains { $0.localizedCaseInsensitiveContains("audio craft") })
+        #expect(!queries.contains { $0.localizedCaseInsensitiveContains("field interviews") })
+        #expect(!queries.contains { $0.localizedCaseInsensitiveContains("Private Favorite Show") })
+        #expect(!queries.contains { $0.localizedCaseInsensitiveContains("podcasts like") })
+    }
+
+    @Test
+    @MainActor
+    func discoveryCatalogQueriesCanUseTasteSignalsAfterExplicitOptIn() throws {
+        let tasteProfile = UserTasteProfile()
+        tasteProfile.topTags = ["audio craft", "field interviews"]
+        tasteProfile.preferredGenres = ["Technology"]
+        tasteProfile.showAffinity = ["Private Favorite Show"]
+
+        let queries = DiscoveryService.catalogQueries(
+            for: tasteProfile,
+            includePrivateTasteSignals: true
+        )
+
+        #expect(queries.contains("audio craft field interviews"))
+        #expect(queries.contains("Technology podcast"))
+        #expect(queries.contains("audio craft Technology"))
+        #expect(queries.contains("podcasts like Private Favorite Show"))
+    }
+
+    @Test
+    @MainActor
     func playerSuggestionsExposeNowPlayingSignalTrace() throws {
         let container = try makeContainer()
         let context = container.mainContext
@@ -1870,6 +1910,84 @@ struct OffScriptTests {
         #expect(SentryEnvironmentResolver.sentryEnvironment(storeKitEnvironmentRawValue: "Sandbox") == "testflight")
         #expect(SentryEnvironmentResolver.sentryEnvironment(storeKitEnvironmentRawValue: "Xcode") == "debug")
         #expect(SentryEnvironmentResolver.sentryEnvironment(storeKitEnvironmentRawValue: "Unexpected") == "production")
+    }
+
+    @Test
+    @MainActor
+    func sentryBeforeSendScrubsURLsQueriesAndListeningIdentifiers() throws {
+        let event = Event(level: .error)
+        event.transaction = "offscript://episode/123e4567-e89b-12d3-a456-426614174000/play?query=decoder"
+        let request = SentryRequest()
+        request.url = "https://feeds.example.com/private/show.xml?token=secret#episode"
+        request.queryString = "token=secret"
+        request.fragment = "episode"
+        request.headers = ["Authorization": "Bearer secret"]
+        event.request = request
+        event.tags = [
+            "feedURL": "https://feeds.example.com/private/show.xml?token=secret",
+            "route": "episode/123e4567-e89b-12d3-a456-426614174000/play",
+            "environment": "production"
+        ]
+        event.extra = [
+            "search_query": "private podcast",
+            "nested": [
+                "transcriptID": "123e4567-e89b-12d3-a456-426614174000",
+                "audio_url": "https://cdn.example.com/member/episode.mp3?sig=secret",
+                "count": 4
+            ]
+        ]
+
+        let scrubbed = try #require(CrashReporter.filterAndScrub(event: event))
+
+        #expect(scrubbed.transaction == "offscript://episode/[redacted]")
+        #expect(scrubbed.request?.url == "https://feeds.example.com/[redacted]")
+        #expect(scrubbed.request?.queryString == nil)
+        #expect(scrubbed.request?.fragment == nil)
+        #expect(scrubbed.request?.headers == nil)
+        #expect(scrubbed.tags?["feedURL"] == "https://feeds.example.com/[redacted]")
+        #expect(scrubbed.tags?["route"] == "episode/[redacted]/play")
+        #expect(scrubbed.tags?["environment"] == "production")
+
+        let nested = try #require(scrubbed.extra?["nested"] as? [String: Any])
+        #expect(scrubbed.extra?["search_query"] as? String == "[redacted]")
+        #expect(nested["transcriptID"] as? String == "[redacted]")
+        #expect(nested["audio_url"] as? String == "https://cdn.example.com/[redacted]")
+        #expect(nested["count"] as? Int == 4)
+    }
+
+    @Test
+    @MainActor
+    func sentryBeforeBreadcrumbScrubsURLDataAndSearchContext() throws {
+        let breadcrumb = Breadcrumb(level: .info, category: "http")
+        breadcrumb.message = "GET https://feeds.example.com/private/show.xml?token=secret"
+        breadcrumb.data = [
+            "url": "https://feeds.example.com/private/show.xml?token=secret",
+            "search": "private show",
+            "status_code": 200
+        ]
+
+        let scrubbed = try #require(CrashReporter.scrub(breadcrumb: breadcrumb))
+
+        #expect(scrubbed.message == "GET https://feeds.example.com/[redacted]")
+        #expect(scrubbed.data?["url"] as? String == "https://feeds.example.com/[redacted]")
+        #expect(scrubbed.data?["search"] as? String == "[redacted]")
+        #expect(scrubbed.data?["status_code"] as? Int == 200)
+    }
+
+    @Test
+    func metricKitCrashExtrasDoNotIncludeFullDiagnosticPayloadsOrPaths() {
+        let extras = MetricKitReporter.trimmedCrashExtras(
+            terminationReason: "Namespace SPRINGBOARD, Code 0x8badf00d\n/private/var/mobile/Containers/Data/Application/app.db",
+            exceptionType: "1",
+            exceptionCode: "https://example.com/private?token=secret",
+            signal: "9"
+        )
+
+        #expect(extras["metrickit_payload"] == nil)
+        #expect(extras["metrickit_source"] as? String == "MXCrashDiagnostic")
+        #expect(extras["termination_reason"] as? String == "Namespace SPRINGBOARD, Code 0x8badf00d")
+        #expect(extras["exception_code"] as? String == "[redacted]")
+        #expect(extras["signal"] as? String == "9")
     }
 
     @Test
@@ -5310,6 +5428,7 @@ struct PlaybackEventEmissionTests {
         let incoming = makeEpisode(title: "Incoming", in: context)
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
         controller.debugPrimePlayback(
@@ -5317,7 +5436,8 @@ struct PlaybackEventEmissionTests {
             duration: 1800,
             currentTime: 900, // 50% through — abandonment territory
             isPlaying: true,
-            presentPlayer: true
+            presentPlayer: true,
+            suppressExternalSideEffects: true
         )
 
         controller.play(incoming, in: context)
@@ -5338,6 +5458,7 @@ struct PlaybackEventEmissionTests {
         let incoming = makeEpisode(title: "Incoming", in: context)
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
         controller.debugPrimePlayback(
@@ -5345,7 +5466,8 @@ struct PlaybackEventEmissionTests {
             duration: 1800,
             currentTime: 5, // 5 seconds — quick skip
             isPlaying: true,
-            presentPlayer: true
+            presentPlayer: true,
+            suppressExternalSideEffects: true
         )
 
         controller.play(incoming, in: context)
@@ -5368,6 +5490,7 @@ struct PlaybackEventEmissionTests {
         let incoming = makeEpisode(title: "Incoming", in: context)
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
         controller.debugPrimePlayback(
@@ -5375,7 +5498,8 @@ struct PlaybackEventEmissionTests {
             duration: 1800,
             currentTime: 1620, // 90%
             isPlaying: true,
-            presentPlayer: true
+            presentPlayer: true,
+            suppressExternalSideEffects: true
         )
 
         controller.play(incoming, in: context)
@@ -5396,6 +5520,7 @@ struct PlaybackEventEmissionTests {
         let ep = makeEpisode(in: context)
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
         controller.debugPrimePlayback(
@@ -5403,7 +5528,8 @@ struct PlaybackEventEmissionTests {
             duration: 1800,
             currentTime: 600,
             isPlaying: true,
-            presentPlayer: true
+            presentPlayer: true,
+            suppressExternalSideEffects: true
         )
 
         controller.play(ep, in: context)
@@ -5424,6 +5550,7 @@ struct PlaybackEventEmissionTests {
         let ep = makeEpisode(in: context)
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
         controller.debugPrimePlayback(
@@ -5431,7 +5558,8 @@ struct PlaybackEventEmissionTests {
             duration: 1800,
             currentTime: 600, // 10 minutes in — well past 60s gate
             isPlaying: false, // paused — togglePlayPause will resume
-            presentPlayer: true
+            presentPlayer: true,
+            suppressExternalSideEffects: true
         )
 
         controller.togglePlayPause()
@@ -5457,6 +5585,7 @@ struct PlaybackEventEmissionTests {
         let ep = makeEpisode(in: context)
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
         controller.debugPrimePlayback(
@@ -5464,7 +5593,8 @@ struct PlaybackEventEmissionTests {
             duration: 1800,
             currentTime: 10, // below 60s gate
             isPlaying: false,
-            presentPlayer: true
+            presentPlayer: true,
+            suppressExternalSideEffects: true
         )
 
         controller.togglePlayPause()
@@ -5476,9 +5606,9 @@ struct PlaybackEventEmissionTests {
 
     @Test
     @MainActor
-    func playbackCompletionWithAutoplayEmitsAdvancedFromQueue() async throws {
-        // Drive the real completion observer by posting
-        // `.AVPlayerItemDidPlayToEndTime`. The observer should:
+    func playbackCompletionWithAutoplayEmitsAdvancedFromQueue() throws {
+        // Drive the real completion handler through the debug-only synchronous
+        // entry point. The handler should:
         //   1. Emit `.completed` for the finishing episode
         //   2. Call `skipToNextInQueue` → prepareItem on nextUp
         //   3. Emit `.advancedFromQueue` for nextUp (the new episode)
@@ -5501,6 +5631,7 @@ struct PlaybackEventEmissionTests {
         UserDefaults.standard.set(true, forKey: "offscript.autoPlayNext")
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
         controller.debugPrimePlayback(
@@ -5508,19 +5639,11 @@ struct PlaybackEventEmissionTests {
             duration: 1800,
             currentTime: 1800,
             isPlaying: true,
-            presentPlayer: true
+            presentPlayer: true,
+            suppressExternalSideEffects: true
         )
 
-        // Post the end-time notification — picked up by
-        // `observePlaybackCompletion` which routes the completion through
-        // a `Task { @MainActor }` (not synchronous), so we have to spin
-        // the run loop a beat to let it land.
-        NotificationCenter.default.post(name: .AVPlayerItemDidPlayToEndTime, object: nil)
-        for _ in 0..<10 {
-            await Task.yield()
-            try? await Task.sleep(nanoseconds: 20_000_000) // 20ms
-            if controller.currentEpisode?.id == nextUp.id { break }
-        }
+        controller.debugCompleteCurrentEpisodeForTesting()
 
         let events = try context.fetch(FetchDescriptor<PlaybackEvent>())
         let advanced = events.filter { $0.kind == .advancedFromQueue }
@@ -5556,6 +5679,7 @@ struct PlaybackEventEmissionTests {
         context.insert(nextUp)
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
         controller.debugPrimePlayback(
@@ -5563,7 +5687,8 @@ struct PlaybackEventEmissionTests {
             duration: 1800,
             currentTime: 1800,
             isPlaying: true,
-            presentPlayer: true
+            presentPlayer: true,
+            suppressExternalSideEffects: true
         )
         // Mirror the completion observer: episode is now played.
         finishing.isPlayed = true
@@ -5597,6 +5722,7 @@ struct PlaybackEventEmissionTests {
         let ep = makeEpisode(in: context)
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
         controller.debugPrimePlayback(
@@ -5604,7 +5730,8 @@ struct PlaybackEventEmissionTests {
             duration: 1800,
             currentTime: 600,
             isPlaying: true,
-            presentPlayer: true
+            presentPlayer: true,
+            suppressExternalSideEffects: true
         )
 
         controller.togglePlayPause() // pause
@@ -6328,6 +6455,7 @@ struct DebugInspectorTests {
 
         // Reset the singleton so test isolation holds.
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         DownloadService.shared.configure(context: context)
 
         let failed = makeEpisode(title: "F", state: .failed, in: context)
@@ -6344,7 +6472,6 @@ struct DebugInspectorTests {
         #expect(failed.downloadState != .failed)
         #expect(failed.downloadErrorMessage == nil)
 
-        DebugTeardown.resetAllSingletons()
     }
 
     // MARK: SyncHistoryService
@@ -6794,6 +6921,7 @@ struct LiveActivityLifecycleTests {
         let episodeB = makeEpisode(title: "Episode B", in: context)
 
         DebugTeardown.resetAllSingletons()
+        defer { DebugTeardown.resetAllSingletons() }
         let controller = PlaybackController.shared
         controller.configure(context: context)
 

--- a/OffScriptWidgets/NowPlayingLiveActivity.swift
+++ b/OffScriptWidgets/NowPlayingLiveActivity.swift
@@ -52,53 +52,55 @@ struct NowPlayingLiveActivity: Widget {
             Link(destination: Self.openPlayerURL) {
                 LockScreenView(attributes: context.attributes, state: context.state)
             }
-            .activityBackgroundTint(Color.black.opacity(0.92))
-            .activitySystemActionForegroundColor(Color.orange)
+            .activityBackgroundTint(OffScriptWidgetTunerStyle.background)
+            .activitySystemActionForegroundColor(OffScriptWidgetTunerStyle.signalYellow)
         } dynamicIsland: { context in
             DynamicIsland {
                 // Expanded
                 DynamicIslandExpandedRegion(.leading) {
-                    if let url = context.attributes.artworkURL {
-                        AsyncImage(url: url) { image in
-                            image.resizable().scaledToFill()
-                        } placeholder: {
-                            Color.secondary.opacity(0.2)
-                        }
-                        .frame(width: 44, height: 44)
-                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-                    }
+                    TunerWidgetArtwork(url: context.attributes.artworkURL, size: 44)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     Image(systemName: context.state.isPlaying ? "waveform" : "play.fill")
                         .font(.title3)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(OffScriptWidgetTunerStyle.transportColor(isPlaying: context.state.isPlaying))
                         .accessibilityLabel(context.state.isPlaying ? "Playing" : "Paused")
                 }
                 DynamicIslandExpandedRegion(.center) {
-                    VStack(alignment: .leading, spacing: 2) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        TunerWidgetMetadata(
+                            text: context.state.isPlaying ? "LIVE SIGNAL" : "PAUSED",
+                            color: context.state.isPlaying
+                                ? OffScriptWidgetTunerStyle.fnMode
+                                : OffScriptWidgetTunerStyle.fnMute,
+                            size: 8
+                        )
+                        .accessibilityHidden(true)
                         Text(context.state.episodeTitle)
                             .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(OffScriptWidgetTunerStyle.paperWhite)
                             .lineLimit(1)
                         Text(context.state.podcastTitle)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .font(OffScriptWidgetTunerStyle.metadataFont(size: 10, weight: .medium))
+                            .foregroundStyle(OffScriptWidgetTunerStyle.fnInfo)
                             .lineLimit(1)
                     }
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    ProgressView(value: context.state.progress).tint(.orange)
+                    TunerWidgetProgressRail(progress: context.state.progress)
                 }
             } compactLeading: {
                 Image(systemName: context.state.isPlaying ? "waveform" : "play.fill")
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(OffScriptWidgetTunerStyle.transportColor(isPlaying: context.state.isPlaying))
                     .accessibilityLabel(context.state.isPlaying ? "Playing" : "Paused")
             } compactTrailing: {
                 Text(timeRemaining(state: context.state))
-                    .font(.caption2.monospacedDigit())
+                    .font(OffScriptWidgetTunerStyle.metadataFont(size: 11))
+                    .foregroundStyle(OffScriptWidgetTunerStyle.paperWhite)
                     .accessibilityLabel("Time remaining \(timeRemaining(state: context.state))")
             } minimal: {
                 Image(systemName: context.state.isPlaying ? "waveform" : "play.fill")
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(OffScriptWidgetTunerStyle.transportColor(isPlaying: context.state.isPlaying))
                     .accessibilityLabel(context.state.isPlaying ? "OffScript playing" : "OffScript paused")
             }
         }
@@ -119,41 +121,37 @@ private struct LockScreenView: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            if let url = attributes.artworkURL {
-                AsyncImage(url: url) { image in
-                    image.resizable().scaledToFill()
-                } placeholder: {
-                    Color.secondary.opacity(0.2)
-                }
-                .frame(width: 56, height: 56)
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            }
+            TunerWidgetArtwork(url: attributes.artworkURL, size: 56)
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
                     Image(systemName: state.isPlaying ? "waveform" : "play.fill")
                         .font(.caption.weight(.bold))
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(OffScriptWidgetTunerStyle.transportColor(isPlaying: state.isPlaying))
                         .accessibilityHidden(true) // status conveyed in combined label below
-                    Text("OFFSCRIPT")
-                        .font(.system(size: 9, weight: .bold, design: .monospaced))
-                        .tracking(1.4)
-                        .foregroundStyle(.secondary)
+                    TunerWidgetMetadata(
+                        text: state.isPlaying ? "OFFSCRIPT · LIVE" : "OFFSCRIPT · HOLD",
+                        color: state.isPlaying
+                            ? OffScriptWidgetTunerStyle.signalYellow
+                            : OffScriptWidgetTunerStyle.fnMute
+                    )
                         .accessibilityHidden(true) // wordmark; surfaced via combined label
                     Spacer()
                 }
                 Text(state.episodeTitle)
                     .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(OffScriptWidgetTunerStyle.paperWhite)
                     .lineLimit(2)
                 Text(state.podcastTitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(OffScriptWidgetTunerStyle.metadataFont(size: 10, weight: .medium))
+                    .foregroundStyle(OffScriptWidgetTunerStyle.fnInfo)
                     .lineLimit(1)
-                ProgressView(value: state.progress).tint(.orange)
-                    .accessibilityValue("\(Int(state.progress * 100)) percent")
+                TunerWidgetProgressRail(progress: state.progress)
             }
         }
         .padding(12)
+        .background(OffScriptWidgetTunerStyle.background)
+        .overlay(Rectangle().stroke(OffScriptWidgetTunerStyle.hairline, lineWidth: 1))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
             "OffScript, \(state.isPlaying ? "playing" : "paused"). \(state.episodeTitle) from \(state.podcastTitle)."

--- a/OffScriptWidgets/NowPlayingWidget.swift
+++ b/OffScriptWidgets/NowPlayingWidget.swift
@@ -1,6 +1,105 @@
 import SwiftUI
 import WidgetKit
 
+enum OffScriptWidgetTunerStyle {
+    static let background = Color(red: 0, green: 0, blue: 0)
+    static let panel = Color(red: 0.039, green: 0.039, blue: 0.039)
+    static let paperWhite = Color(red: 0.953, green: 0.945, blue: 0.918)
+    static let softPaper = Color(red: 0.478, green: 0.471, blue: 0.447)
+    static let signalYellow = Color(red: 0.910, green: 0.824, blue: 0.290)
+    static let fnRecord = Color(red: 0.910, green: 0.353, blue: 0.235)
+    static let fnMode = Color(red: 0.373, green: 0.812, blue: 0.494)
+    static let fnInfo = Color(red: 0.365, green: 0.769, blue: 0.910)
+    static let fnMute = Color(red: 0.478, green: 0.471, blue: 0.447)
+    static let hairline = Color(red: 1, green: 1, blue: 1).opacity(0.08)
+
+    static func transportColor(isPlaying: Bool) -> Color {
+        isPlaying ? fnMode : signalYellow
+    }
+
+    static func metadataFont(size: CGFloat = 9, weight: Font.Weight = .semibold) -> Font {
+        .system(size: size, weight: weight, design: .monospaced)
+    }
+}
+
+struct TunerWidgetMetadata: View {
+    let text: String
+    var color: Color = OffScriptWidgetTunerStyle.signalYellow
+    var size: CGFloat = 9
+
+    var body: some View {
+        Text(text)
+            .font(OffScriptWidgetTunerStyle.metadataFont(size: size))
+            .tracking(1.2)
+            .textCase(.uppercase)
+            .foregroundStyle(color)
+            .lineLimit(1)
+    }
+}
+
+struct TunerWidgetProgressRail: View {
+    let progress: Double
+
+    private var clampedProgress: Double {
+        min(max(progress, 0), 1)
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let fillWidth = proxy.size.width * clampedProgress
+
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .fill(OffScriptWidgetTunerStyle.hairline)
+                Rectangle()
+                    .fill(OffScriptWidgetTunerStyle.signalYellow)
+                    .frame(width: max(fillWidth, clampedProgress > 0 ? 2 : 0))
+            }
+        }
+        .frame(height: 3)
+        .accessibilityValue("\(Int(clampedProgress * 100)) percent")
+    }
+}
+
+struct TunerWidgetArtwork: View {
+    let url: URL?
+    let size: CGFloat
+
+    var body: some View {
+        ZStack {
+            if let url {
+                AsyncImage(url: url) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: {
+                    placeholder
+                }
+            } else {
+                placeholder
+            }
+        }
+        .frame(width: size, height: size)
+        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .stroke(OffScriptWidgetTunerStyle.hairline, lineWidth: 1)
+        )
+    }
+
+    private var placeholder: some View {
+        ZStack {
+            OffScriptWidgetTunerStyle.panel
+            VStack(spacing: 3) {
+                ForEach(0..<5, id: \.self) { index in
+                    Rectangle()
+                        .fill(index == 2 ? OffScriptWidgetTunerStyle.signalYellow : OffScriptWidgetTunerStyle.hairline)
+                        .frame(width: size * (0.28 + CGFloat(index) * 0.08), height: 1)
+                }
+            }
+        }
+    }
+}
+
 /// Lock Screen + Home Screen widget showing the currently-playing episode.
 ///
 /// Tapping the widget deep-links into the OffScript player via the
@@ -11,7 +110,7 @@ struct NowPlayingWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: NowPlayingProvider()) { entry in
             NowPlayingWidgetView(entry: entry)
-                .containerBackground(.fill.tertiary, for: .widget)
+                .containerBackground(OffScriptWidgetTunerStyle.background, for: .widget)
                 // Tap → deep-link into the player. Handled by
                 // DeepLinkRouter.handle in the main app's onOpenURL.
                 .widgetURL(URL(string: "offscript://player"))
@@ -83,14 +182,18 @@ struct NowPlayingWidgetView: View {
                 Text("OffScript — nothing playing")
             }
         }
+        .font(OffScriptWidgetTunerStyle.metadataFont(size: 11))
+        .foregroundStyle(OffScriptWidgetTunerStyle.paperWhite)
     }
 
     private var circularView: some View {
         ZStack {
             ProgressView(value: entry.snapshot.progress)
                 .progressViewStyle(.circular)
+                .tint(OffScriptWidgetTunerStyle.signalYellow)
             Image(systemName: entry.snapshot.isPlaying ? "waveform" : "play.fill")
                 .font(.headline)
+                .foregroundStyle(OffScriptWidgetTunerStyle.transportColor(isPlaying: entry.snapshot.isPlaying))
                 .accessibilityHidden(true)
         }
         .accessibilityElement(children: .combine)
@@ -102,19 +205,28 @@ struct NowPlayingWidgetView: View {
     }
 
     private var rectangularView: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 4) {
+            TunerWidgetMetadata(
+                text: entry.snapshot.isPlaying ? "NOW PLAYING" : "STANDBY",
+                color: entry.snapshot.isActive
+                    ? OffScriptWidgetTunerStyle.transportColor(isPlaying: entry.snapshot.isPlaying)
+                    : OffScriptWidgetTunerStyle.fnMute,
+                size: 8
+            )
             Text(entry.snapshot.isActive ? entry.snapshot.episodeTitle : "OffScript")
-                .font(.headline)
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(OffScriptWidgetTunerStyle.paperWhite)
                 .lineLimit(2)
             if entry.snapshot.isActive {
                 Text(entry.snapshot.podcastTitle)
-                    .font(.caption)
+                    .font(OffScriptWidgetTunerStyle.metadataFont(size: 10, weight: .medium))
+                    .foregroundStyle(OffScriptWidgetTunerStyle.fnInfo)
                     .lineLimit(1)
-                ProgressView(value: entry.snapshot.progress)
-                    .tint(.orange)
+                TunerWidgetProgressRail(progress: entry.snapshot.progress)
             } else {
                 Text("Nothing playing")
-                    .font(.caption)
+                    .font(OffScriptWidgetTunerStyle.metadataFont(size: 10, weight: .medium))
+                    .foregroundStyle(OffScriptWidgetTunerStyle.softPaper)
             }
         }
     }
@@ -122,17 +234,14 @@ struct NowPlayingWidgetView: View {
     // MARK: - Home Screen widgets
 
     private var smallView: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 9) {
             HStack {
                 Image(systemName: entry.snapshot.isPlaying ? "waveform" : "play.fill")
                     .font(.caption.weight(.bold))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(OffScriptWidgetTunerStyle.transportColor(isPlaying: entry.snapshot.isPlaying))
                     .accessibilityHidden(true)
                 Spacer()
-                Text("OFFSCRIPT")
-                    .font(.system(size: 9, weight: .bold, design: .monospaced))
-                    .tracking(1.4)
-                    .foregroundStyle(.secondary)
+                TunerWidgetMetadata(text: "OFFSCRIPT", color: OffScriptWidgetTunerStyle.softPaper)
                     .accessibilityHidden(true)
             }
 
@@ -141,24 +250,24 @@ struct NowPlayingWidgetView: View {
             if entry.snapshot.isActive {
                 Text(entry.snapshot.episodeTitle)
                     .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(OffScriptWidgetTunerStyle.paperWhite)
                     .lineLimit(3)
                 Text(entry.snapshot.podcastTitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(OffScriptWidgetTunerStyle.metadataFont(size: 10, weight: .medium))
+                    .foregroundStyle(OffScriptWidgetTunerStyle.fnInfo)
                     .lineLimit(1)
             } else {
                 Text("Nothing playing")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .font(OffScriptWidgetTunerStyle.metadataFont(size: 11, weight: .medium))
+                    .foregroundStyle(OffScriptWidgetTunerStyle.softPaper)
             }
 
             if entry.snapshot.isActive {
-                ProgressView(value: entry.snapshot.progress)
-                    .tint(.orange)
-                    .accessibilityValue("\(Int(entry.snapshot.progress * 100)) percent")
+                TunerWidgetProgressRail(progress: entry.snapshot.progress)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .overlay(Rectangle().stroke(OffScriptWidgetTunerStyle.hairline, lineWidth: 1))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
             entry.snapshot.isActive
@@ -169,27 +278,18 @@ struct NowPlayingWidgetView: View {
 
     private var mediumView: some View {
         HStack(alignment: .top, spacing: 12) {
-            // Artwork (loaded async; will be empty placeholder on first paint)
-            if let url = entry.snapshot.artworkURL {
-                AsyncImage(url: url) { image in
-                    image.resizable().scaledToFill()
-                } placeholder: {
-                    Color.secondary.opacity(0.2)
-                }
-                .frame(width: 64, height: 64)
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            }
+            TunerWidgetArtwork(url: entry.snapshot.artworkURL, size: 64)
 
             VStack(alignment: .leading, spacing: 6) {
                 HStack {
                     Image(systemName: entry.snapshot.isPlaying ? "waveform" : "play.fill")
                         .font(.caption.weight(.bold))
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(OffScriptWidgetTunerStyle.transportColor(isPlaying: entry.snapshot.isPlaying))
                         .accessibilityHidden(true)
-                    Text("NOW PLAYING")
-                        .font(.system(size: 9, weight: .bold, design: .monospaced))
-                        .tracking(1.4)
-                        .foregroundStyle(.secondary)
+                    TunerWidgetMetadata(
+                        text: entry.snapshot.isActive ? "NOW PLAYING" : "STANDBY",
+                        color: entry.snapshot.isActive ? OffScriptWidgetTunerStyle.signalYellow : OffScriptWidgetTunerStyle.fnMute
+                    )
                         .accessibilityHidden(true)
                     Spacer()
                 }
@@ -197,24 +297,24 @@ struct NowPlayingWidgetView: View {
                 if entry.snapshot.isActive {
                     Text(entry.snapshot.episodeTitle)
                         .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(OffScriptWidgetTunerStyle.paperWhite)
                         .lineLimit(2)
                     Text(entry.snapshot.podcastTitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(OffScriptWidgetTunerStyle.metadataFont(size: 10, weight: .medium))
+                        .foregroundStyle(OffScriptWidgetTunerStyle.fnInfo)
                         .lineLimit(1)
-                    ProgressView(value: entry.snapshot.progress)
-                        .tint(.orange)
-                        .accessibilityValue("\(Int(entry.snapshot.progress * 100)) percent")
+                    TunerWidgetProgressRail(progress: entry.snapshot.progress)
                 } else {
                     Text("Tap to open OffScript")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(OffScriptWidgetTunerStyle.metadataFont(size: 10, weight: .medium))
+                        .foregroundStyle(OffScriptWidgetTunerStyle.softPaper)
                 }
             }
 
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .overlay(Rectangle().stroke(OffScriptWidgetTunerStyle.hairline, lineWidth: 1))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
             entry.snapshot.isActive


### PR DESCRIPTION
## Summary
- Keep local recommendations taste-driven while making remote Apple Podcasts catalog search coarse by default unless the user explicitly opts into taste-profile catalog queries.
- Scrub Sentry and MetricKit export payloads so URLs, query strings, headers, breadcrumbs, tags/extras/contexts, and raw crash diagnostics do not leak listening/search context.
- Tighten import completion UX, player local/offline/transcript surfacing, tap targets, cancellation/background transcription behavior, playback test isolation, SwiftData relationships, and widget/Live Activity tuner styling.

## Notes
- This intentionally does **not** change the Xcode Cloud `Default` workflow distribution default; `INTERNAL_ONLY` remains treated as correct for this branch.
- Untracked local audit artifacts and `AGENTS.md` are not included in this PR.

## Test Plan
- [x] `gh project view 7 --owner zachyzissou --format json --jq '{number,title,closed,public,items:{totalCount:.items.totalCount}}'`
- [x] `git diff --check`
- [x] `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=26.5,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO`

## Local Results
- GitHub Project: `OffScript` #7 open, 176 items.
- Xcode result bundle: `/Users/zachgonser/Library/Developer/Xcode/DerivedData/OffScript-fidhgidqtqilfegwixuxzmrmxjmx/Logs/Test/Test-OffScript-2026.05.23_16-56-22--0500.xcresult`
- Local full scheme: 249 unit tests + 23 UI tests passed.
- Captured log warning scan: `grep -n "warning:" /tmp/offscript-final-xcodebuild.log` returned no warnings.
