### PR TITLE
Cut 2.5.3 TestFlight candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to OffScript. Format: [Keep a Changelog](https://keepachange
 
 ## [Unreleased]
 
+## [2.5.3] — 2026-05-24
+
+### Added
+- Remote Apple Podcasts catalog discovery now defaults to coarse genre queries while preserving the app's local taste-driven recommendation engine. Users can explicitly opt into taste-profile catalog search from Settings when they want remote discovery to use top tags, show affinity, or "podcasts like this" signals.
+- Player now exposes a `LOCAL · DEVICE` section for offline/download state and on-device transcript access, making the no-cloud playback/transcript story visible in the primary listening surface.
+
+### Changed
+- Onboarding import completion now keeps users on the import progress screen until they deliberately enter the app, with copy that distinguishes staged subscriptions from background episode hydration.
+- Now Playing widgets and Live Activity surfaces use the Tuner OLED visual system more consistently: black field, signal-yellow rails, sharp artwork, mono labels, and function-coded state.
+
+### Fixed
+- Sentry and MetricKit export paths now scrub URLs, query strings, headers, breadcrumbs, tags/extras/contexts, listening/search identifiers, and raw crash diagnostic payloads before data leaves the device.
+- Search, speech transcription, background transcription, and playback completion paths now handle cancellation/test isolation more deterministically.
+- SwiftData relationship annotations now explicitly document the preference-signal delete behavior used by the V3 schema.
+
 ## [2.5.2] — 2026-05-20
 
 ### Fixed

--- a/OffScript.xcodeproj/project.pbxproj
+++ b/OffScript.xcodeproj/project.pbxproj
@@ -472,7 +472,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OffScript/OffScript.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2026052005;
+				CURRENT_PROJECT_VERSION = 2026052401;
 				DEVELOPMENT_TEAM = 363TRR79UG;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.offscript.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -520,7 +520,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OffScript/OffScript.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2026052005;
+				CURRENT_PROJECT_VERSION = 2026052401;
 				DEVELOPMENT_TEAM = 363TRR79UG;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -544,7 +544,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.offscript.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -565,10 +565,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2026052005;
+				CURRENT_PROJECT_VERSION = 2026052401;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.offscript.app.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -588,10 +588,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2026052005;
+				CURRENT_PROJECT_VERSION = 2026052401;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.offscript.app.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -610,10 +610,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2026052005;
+				CURRENT_PROJECT_VERSION = 2026052401;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.offscript.app.uitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -632,10 +632,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2026052005;
+				CURRENT_PROJECT_VERSION = 2026052401;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.offscript.app.uitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -657,7 +657,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = OffScriptWidgets/OffScriptWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2026052005;
+				CURRENT_PROJECT_VERSION = 2026052401;
 				DEVELOPMENT_TEAM = 363TRR79UG;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OffScriptWidgets/Info.plist;
@@ -668,7 +668,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.offscript.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -687,7 +687,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = OffScriptWidgets/OffScriptWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2026052005;
+				CURRENT_PROJECT_VERSION = 2026052401;
 				DEVELOPMENT_TEAM = 363TRR79UG;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OffScriptWidgets/Info.plist;
@@ -698,7 +698,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.offscript.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/OffScript/CrashReporter.swift
+++ b/OffScript/CrashReporter.swift
@@ -199,9 +199,9 @@ enum CrashReporter {
 }
 
 private enum SentryPrivacyScrubber {
-    private static let redacted = "[redacted]"
+    nonisolated private static let redacted = "[redacted]"
 
-    private static let urlRegex: NSRegularExpression = {
+    nonisolated private static let urlRegex: NSRegularExpression = {
         do {
             return try NSRegularExpression(pattern: #"(?:https?|feed|offscript)://[^\s<>"'`]+(?<![.,;:!?)\]\}])"#)
         } catch {
@@ -209,7 +209,7 @@ private enum SentryPrivacyScrubber {
         }
     }()
 
-    private static let uuidRegex: NSRegularExpression = {
+    nonisolated private static let uuidRegex: NSRegularExpression = {
         do {
             return try NSRegularExpression(
                 pattern: #"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"#
@@ -219,23 +219,23 @@ private enum SentryPrivacyScrubber {
         }
     }()
 
-    static func scrubStringDictionary(_ dictionary: [String: String]) -> [String: String] {
+    nonisolated static func scrubStringDictionary(_ dictionary: [String: String]) -> [String: String] {
         Dictionary(uniqueKeysWithValues: dictionary.map { key, value in
             (key, scrubURLOrString(value, key: key))
         })
     }
 
-    static func scrubDictionary(_ dictionary: [String: Any]) -> [String: Any] {
+    nonisolated static func scrubDictionary(_ dictionary: [String: Any]) -> [String: Any] {
         Dictionary(uniqueKeysWithValues: dictionary.map { key, value in
             (key, scrubValue(value, key: key))
         })
     }
 
-    static func scrubRoute(_ value: String) -> String {
+    nonisolated static func scrubRoute(_ value: String) -> String {
         scrubURLOrString(value, key: "route")
     }
 
-    static func scrubURLOrString(_ value: String, key: String) -> String {
+    nonisolated static func scrubURLOrString(_ value: String, key: String) -> String {
         var scrubbed = replaceURLs(in: value)
         scrubbed = replaceMatches(in: scrubbed, regex: uuidRegex, with: redacted)
 
@@ -253,7 +253,7 @@ private enum SentryPrivacyScrubber {
         return scrubbed
     }
 
-    private static func scrubValue(_ value: Any, key: String) -> Any {
+    nonisolated private static func scrubValue(_ value: Any, key: String) -> Any {
         switch value {
         case let string as String:
             return scrubURLOrString(string, key: key)
@@ -278,13 +278,13 @@ private enum SentryPrivacyScrubber {
         }
     }
 
-    private static func replaceURLs(in value: String) -> String {
+    nonisolated private static func replaceURLs(in value: String) -> String {
         replaceMatches(in: value, regex: urlRegex) { match in
             scrubURL(match)
         }
     }
 
-    private static func scrubURL(_ value: String) -> String {
+    nonisolated private static func scrubURL(_ value: String) -> String {
         guard var components = URLComponents(string: value), let scheme = components.scheme else {
             return redacted
         }
@@ -307,7 +307,7 @@ private enum SentryPrivacyScrubber {
             .replacingOccurrences(of: "%5Bredacted%5D", with: redacted)
     }
 
-    private static func redactRouteSegments(_ value: String) -> String {
+    nonisolated private static func redactRouteSegments(_ value: String) -> String {
         let separators = CharacterSet(charactersIn: "/?#&")
         return value
             .components(separatedBy: separators)
@@ -317,14 +317,14 @@ private enum SentryPrivacyScrubber {
             .joined(separator: "/")
     }
 
-    private static func shouldRedactRouteSegment(_ segment: String) -> Bool {
+    nonisolated private static func shouldRedactRouteSegment(_ segment: String) -> Bool {
         guard !segment.isEmpty else { return false }
         if segment == redacted { return false }
         if segment.range(of: uuidRegex.pattern, options: .regularExpression) != nil { return true }
         return segment.count >= 16 && segment.rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) == nil
     }
 
-    private static func isSensitiveKey(_ key: String) -> Bool {
+    nonisolated private static func isSensitiveKey(_ key: String) -> Bool {
         let lowercased = key.lowercased()
         return [
             "url",
@@ -344,12 +344,12 @@ private enum SentryPrivacyScrubber {
         ].contains { lowercased.contains($0) }
     }
 
-    private static func isRouteKey(_ key: String) -> Bool {
+    nonisolated private static func isRouteKey(_ key: String) -> Bool {
         let lowercased = key.lowercased()
         return lowercased.contains("route") || lowercased.contains("context") || lowercased.contains("transaction")
     }
 
-    private static func replaceMatches(
+    nonisolated private static func replaceMatches(
         in value: String,
         regex: NSRegularExpression,
         with replacement: String
@@ -357,7 +357,7 @@ private enum SentryPrivacyScrubber {
         replaceMatches(in: value, regex: regex) { _ in replacement }
     }
 
-    private static func replaceMatches(
+    nonisolated private static func replaceMatches(
         in value: String,
         regex: NSRegularExpression,
         transform: (String) -> String

--- a/build/TestFlight/notes/testflight-notes.txt
+++ b/build/TestFlight/notes/testflight-notes.txt
@@ -1,11 +1,14 @@
-OffScript beta 2.5.2 (2026052005)
+OffScript beta 2.5.3 (2026052401)
 
 What changed:
-- Search and onboarding subscription staging now treat http/https/feed, case, and trailing-slash RSS variants as the same feed, so subscribing from Search should not create duplicate Library rows.
-- Lock screen / Control Center now receive Tuner fallback artwork immediately when an episode has no feed artwork or remote artwork is still loading.
-- Shared artwork fallback, empty states, and Tuner button press feedback are aligned across the main app surfaces.
+- Harden discovery privacy and tuner UX
 
 What to test:
-- Search for a show already in your Library using a different feed URL spelling, then subscribe. The existing show should flip to IN LIBRARY immediately and no duplicate Library row should appear.
-- Play an episode with missing feed artwork and check the Lock Screen / Control Center artwork.
-- Smoke Home, Library, Queue, Search, mini-player, and full Player for sharp Tuner styling, readable copy, and usable controls.
+- Queue several episodes, use Play Next/Add to End, and confirm playback advances in the expected order.
+- Complete onboarding/import, then confirm Home recommendations explain why each episode is surfaced.
+- Open Settings diagnostics and confirm sync/feed-build events are visible after import or playback activity.
+- Check the main tabs on a small iPhone simulator for clipping, overlap, readable text, and usable tap targets.
+- Run a smoke pass through Home, Library, Queue, Search, mini-player, and full player.
+
+Release-specific focus:
+Focus on remote discovery privacy and the visible local-device story: confirm Settings shows remote catalog taste-profile opt-in off by default, Home still recommends locally from listening signals, onboarding import completion requires the explicit ENTER APP action, Player shows LOCAL · DEVICE with download/transcript status, and widgets/Live Activity preserve the Tuner OLED visual language.


### PR DESCRIPTION
## Summary
- Bumps OffScript to 2.5.3 with build 2026052401 across app, test, UI test, and widget targets.
- Adds the 2.5.3 changelog and tracked TestFlight notes focused on discovery privacy and Tuner UX hardening.
- Marks Sentry privacy scrubber helpers nonisolated so Sentry callback paths remain warning-clean under the app's default MainActor isolation.

## Test Plan
- `xcodebuild test -project OffScript.xcodeproj -scheme OffScript -destination 'platform=iOS Simulator,OS=26.5,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO`
- `grep -n "warning:" /tmp/offscript-2.5.3-xcodebuild-final2.log` returned no matches
- `git diff --check`
- Version/build settings verified as `MARKETING_VERSION=2.5.3` and `CURRENT_PROJECT_VERSION=2026052401`

## Release Notes
- This PR does not change the Xcode Cloud Default workflow audience; INTERNAL_ONLY remains intentionally untouched.