### PR TITLE
docs: refresh roadmap current truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ The app is currently shipping the **Tuner OLED** design direction — pure black
 
 ---
 
+## Current Truth
+
+- Last refreshed: 2026-05-31T06:43Z.
+- Canonical GitHub Project: [#7 OffScript](https://github.com/users/zachyzissou/projects/7).
+- Current release/live state: TestFlight beta, marketing version `2.3.11`; Xcode Cloud remains the release path.
+- Current roadmap: [docs/NEXT_IMPLEMENTATION_BACKLOG.md](docs/NEXT_IMPLEMENTATION_BACKLOG.md).
+- Open issues: #196, #125, #124, #121, #120, #119, #117, #114, #113, #112, #111, #110, #108, #107, #106, #105, #104.
+- Open PRs: #271 tap-to-copy About build version, #38 CloudKit signing preflight.
+- Active gate: release/build visibility and Xcode Cloud/App Store Connect state are senior/owner-led; do not hand those to constrained agents without current ASC proof.
+- Next action: land narrow UX/testability PRs first, then resolve the release visibility lane before treating a build as shipped.
+
+---
+
 ## What's different
 
 **No algorithm, no paid placements.** Recommendations are computed on-device from your listening history, podcasts you've liked, and topics you've spent the most hours on. Nothing about your taste leaves your phone.

--- a/docs/NEXT_IMPLEMENTATION_BACKLOG.md
+++ b/docs/NEXT_IMPLEMENTATION_BACKLOG.md
@@ -3,7 +3,16 @@
 This roadmap mirrors the open GitHub issue backlog so the repo has a durable
 source of truth even when the GitHub Project roadmap view is not accessible
 from automation. Priorities reflect the current release state as of
-2026-04-30.
+2026-05-31.
+
+## Current Truth
+
+- Last refreshed: 2026-05-31T06:43Z.
+- Canonical GitHub Project: [#7 OffScript](https://github.com/users/zachyzissou/projects/7).
+- Open issues: #196, #125, #124, #121, #120, #119, #117, #114, #113, #112, #111, #110, #108, #107, #106, #105, #104.
+- Open PRs: #271, #38.
+- Active gate: Xcode Cloud/App Store Connect release visibility remains separate from local repo health.
+- Next action: review #271 as a narrow shipped-surface polish PR, keep #38 release-signing preflight separate, and refresh any issue routing labels before assigning constrained implementation agents.
 
 ## Agent Readiness
 


### PR DESCRIPTION
## Summary
- add README current-truth block tied to Project #7
- refresh NEXT_IMPLEMENTATION_BACKLOG date and open issue/PR inventory
- preserve Xcode Cloud/App Store Connect as the release truth gate

## Verification
- git diff --check